### PR TITLE
feat(platform): Phase 2 + 3 — memory, semantic index, orchestration engine, lifecycle wrapper

### DIFF
--- a/.claude/agents/lead-orchestrator.md
+++ b/.claude/agents/lead-orchestrator.md
@@ -10,6 +10,48 @@ You are the **Lead Orchestrator**, responsible for coordinating the entire model
 
 You do NOT write code, train models, or compute metrics. You plan, coordinate, gate, and recover.
 
+## Agent Roster
+
+You have 16 pre-defined agents available in `.claude/agents/`. You MUST use Claude Code agent teams (TeamCreate + Agent with team_name) for all coordination — never isolated subagents.
+
+**Project Delivery Team (spawn for project work):**
+
+| Agent | Model | Expertise | When to spawn |
+|-------|-------|-----------|---------------|
+| data-engineer | Sonnet | Data pipeline, cleaning, EDA, DataLoaders | Phase 1-2: data review and feature engineering |
+| model-builder | Opus | Architecture selection, training, iteration | Phase 3-4: model design and training |
+| oracle-qa | Sonnet | Hard metric evaluation, gating, drift detection | Phase 3-5: after every training iteration |
+| code-reviewer | Sonnet | Code quality, PEP8, security, conventions | Every phase: review all code artifacts |
+| test-engineer | Sonnet | Unit, integration, regression tests | Every phase: test all code artifacts |
+| xai-agent | Sonnet | SHAP, attention, feature importance | Phase 5: explainability analysis |
+| domain-evaluator | Opus | Domain validation, plausibility, regulatory | Phase 5: domain-specific verification |
+| ml-engineer | Sonnet | Inference optimization, GPU, experiment tracking | Phase 4-6: optimization and reproducibility |
+| infra-engineer | Haiku | Environment setup, dependencies, deployment | Phase 1 and 6: setup and packaging |
+
+**Platform Build Team (spawn for building ZO itself):**
+
+| Agent | Model | Expertise |
+|-------|-------|-----------|
+| software-architect | Opus | Module decomposition, contracts, architecture |
+| backend-engineer | Opus | Python implementation, core infrastructure |
+| frontend-engineer | Sonnet | Dashboard UI (v2, phase-in) |
+| platform-test-engineer | Sonnet | Platform test suite |
+| platform-code-reviewer | Sonnet | Platform code quality |
+| documentation-agent | Haiku | Docs, README, API reference |
+
+## Dynamic Agent Creation
+
+If a project requires expertise not covered by the 16 pre-defined agents, you MUST create a new agent definition before spawning:
+
+1. **Identify the gap** — what expertise is missing? (e.g., "NLP specialist", "time-series expert", "security auditor")
+2. **Write the agent .md file** to `.claude/agents/{new-agent-name}.md` following the same format:
+   - YAML frontmatter: name, model (pick appropriate tier), role, tier: phase-in, team: project
+   - Markdown body: role description, ownership, off-limits, contract produced/consumed, coordination rules, validation checklist
+3. **Log the decision** — append to DECISION_LOG.md why this agent was created
+4. **Spawn the agent** — include it in the team via Agent(name="{new-agent-name}", team_name=...)
+
+The agent roster is a starting point, not a ceiling. Adapt the team to the project.
+
 ## Your Ownership
 
 Own and manage these files exclusively:
@@ -123,7 +165,9 @@ See `specs/agents.md` for full contract template and edge cases.
 
 ## Coordination Rules
 
+- **ALWAYS use agent teams**: Use TeamCreate to create a named team, then Agent(team_name=...) to spawn teammates. NEVER use isolated subagents. Agents MUST be able to message each other via SendMessage.
 - **Session start**: Read `STATE.md` and `plan.md`. Determine operating mode (build/continue/maintain). Log mode selection to `DECISION_LOG.md`.
+- **Team creation**: Create one team per project phase (or per project if phases are tightly coupled). Spawn only the agents needed for the current phase from the Agent Roster above.
 - **Before parallel spawn**: Define ALL integration contracts between agents. Log contracts to `DECISION_LOG.md`. Broadcast contracts to all agents involved.
 - **Phase transitions**: Verify all gate criteria are met. Write gate decision to `DECISION_LOG.md`. Update `plan.md` phase status. Update `STATE.md`.
 - **Conflict resolution**: If two agents disagree (e.g., Model Builder vs. Oracle), moderate an adversarial debate. Log resolution to `DECISION_LOG.md`.

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,11 @@
+__pycache__/
+*.pyc
+*.pyo
+.coverage
+.pytest_cache/
+*.egg-info/
+dist/
+build/
+.venv/
+*.db
+*.sqlite

--- a/README.md
+++ b/README.md
@@ -14,7 +14,8 @@
 
 <br/>
 
-[![Status](https://img.shields.io/badge/phase-2_complete-F0C040?style=flat-square&labelColor=080808)](#status)
+[![Status](https://img.shields.io/badge/phase-3_complete-F0C040?style=flat-square&labelColor=080808)](#status)
+[![Tests](https://img.shields.io/badge/tests-224_passing-F0C040?style=flat-square&labelColor=080808)](#status)
 [![Agents](https://img.shields.io/badge/agents-16_written-F0C040?style=flat-square&labelColor=080808)](#agent-teams)
 [![Specs](https://img.shields.io/badge/specs-8_documents-F0C040?style=flat-square&labelColor=080808)](#repository-structure)
 [![Build Plan](https://img.shields.io/badge/build_plan-v2.0-F0C040?style=flat-square&labelColor=080808)](#status)
@@ -32,14 +33,33 @@ Three operating modes: **Build** from scratch, **Continue** from where you left 
 ## How it works
 
 ```
-plan.md  ──►  Orchestrator  ──►  Agent Team  ──►  Delivery Repo
-                  │                    │
-                  ▼                    ▼
-             STATE.md            DECISION_LOG
-             PRIORS.md           JSONL comms
+zo build plans/project.md
+│
+├─ Python CLI ────────────────────────────────────────────────────
+│  orchestrator.py        wrapper.py
+│  Parses plan             Launches ONE Claude Code session
+│  Decomposes phases       Monitors team via ~/.claude/tasks/
+│  Builds lead prompt      Captures tmux pane output
+│  Manages gates           Pipes events to JSONL logger
+│
+├─ Claude Code Session ───────────────────────────────────────────
+│  Lead Orchestrator (native agent team)
+│  ├── TeamCreate("project-alpha")
+│  ├── Agent(name="data-engineer", team_name=...)
+│  ├── Agent(name="model-builder", team_name=...)
+│  ├── Agent(name="oracle-qa", team_name=...)
+│  └── Agents communicate peer-to-peer via SendMessage
+│
+├─ Delivery Repo ─────────────────────────────────────────────────
+│  Clean project artifacts only (code, models, reports)
+│  Zero ZO infrastructure leaks
+│
+└─ Memory ────────────────────────────────────────────────────────
+   STATE.md → DECISION_LOG → PRIORS.md → Semantic Index
+   Pick up exactly where you left off, every session
 ```
 
-The orchestrator reads the plan, decomposes it into phases, issues contracts to agents, and gates each phase with oracle validation. Agents work autonomously between human checkpoints. Every decision is logged. Every session is recoverable.
+The orchestrator reads the plan, decomposes it into phases, and builds a context-rich prompt for the Lead Orchestrator agent. The wrapper launches one Claude Code session with `--teammate-mode tmux`. Inside that session, the Lead Orchestrator creates an agent team with native peer-to-peer messaging. Agents coordinate autonomously between human checkpoints. Every decision is logged. Every session is recoverable.
 
 ## Core principles
 
@@ -91,7 +111,15 @@ zero-operators/
 │   │   ├── platform-code-reviewer.md  # Sonnet — platform review
 │   │   └── documentation-agent.md     # Haiku — docs maintenance
 │   └── settings.json                  # Project-level config ✅
-├── src/zo/                            # Platform code (Phase 1+)
+├── src/zo/                            # Platform code ✅
+│   ├── plan.py                        # Plan parser and validator
+│   ├── target.py                      # Target file parser, isolation enforcer
+│   ├── comms.py                       # JSONL event logger (5 event types)
+│   ├── memory.py                      # STATE.md, DECISION_LOG, PRIORS, sessions
+│   ├── semantic.py                    # fastembed + SQLite semantic search
+│   ├── orchestrator.py                # Phase decomposition, gate management
+│   ├── wrapper.py                     # Claude CLI launcher + team observer
+│   └── cli.py                         # CLI entry point (Phase 4)
 ├── memory/                            # Project-scoped state
 ├── logs/                              # Audit trails
 ├── targets/                           # Delivery repo pointers
@@ -139,17 +167,17 @@ All ZO outputs follow the brand system in [`design/`](design/).
 
 ## Status
 
-**Phase 2 complete. 151 tests, 96% coverage.**
+**Phase 3 complete. 224 tests, 93% coverage.**
 
 | Milestone | Status |
 |-----------|--------|
 | Specifications (8 docs) | Done |
 | Build plan v2.0 | Done |
 | Agent definitions (16 files) | Done |
-| Phase 1: Plan parser, target parser, comms logger, setup | Done (76 tests) |
-| Phase 2: Memory layer, semantic index | Done (151 tests, 96% cov) |
-| Phase 3: Orchestration engine (hybrid) | Next |
-| Phase 4: Evolution engine, CLI, integration tests | Pending |
+| Phase 1: Plan parser, target parser, comms logger, setup | Done |
+| Phase 2: Memory layer, semantic index | Done |
+| Phase 3: Orchestration engine + lifecycle wrapper | Done (224 tests) |
+| Phase 4: Evolution engine, CLI, integration tests | Next |
 | Phase 5: End-to-end validation | Pending |
 
 ## Getting started
@@ -171,13 +199,20 @@ zo maintain my-project          # apply updated instructions
 zo draft sources/               # generate plan.md from docs
 ```
 
-## Key decisions (v2.0)
+## Architecture
 
-- **Orchestration**: Hybrid — native Claude Code agent teams for peer-to-peer comms + Python lifecycle wrapper for observability
-- **Semantic index**: Full decision entries with summary prefix embedding for context-window density
+**Three-layer design:**
+
+1. **Python CLI** (`zo build`) — parses plan, decomposes phases, builds lead prompt with full context
+2. **Lifecycle Wrapper** (`wrapper.py`) — launches one `claude --teammate-mode tmux` session, monitors team via file system, pipes events to JSONL
+3. **Claude Code Agent Team** (native) — Lead Orchestrator uses `TeamCreate` + `Agent(team_name=...)` for real peer-to-peer messaging between agents
+
+**Key decisions:**
+- **Agent teams, not subagents** — agents communicate peer-to-peer via `SendMessage`, not through a parent bottleneck
+- **Dynamic agent creation** — Lead Orchestrator can write new `.claude/agents/*.md` files on the fly if project needs expertise beyond the 16 pre-defined agents
+- **Semantic index** — full decision entries with summary prefix embedding for context-window density
 - **Setup**: `setup.sh` for environment bootstrap + `zo init` for project scaffolding
 - **Docker**: Deferred to v2 — uv lockfile + setup.sh for now
-- **Agent contracts**: Inline examples + shared reference to `specs/agents.md`
 
 ---
 
@@ -189,7 +224,7 @@ zo draft sources/               # generate plan.md from docs
 <br/>
 <br/>
 
-`ZERO OPERATORS` · `v0.2` · `phase 2 complete — 151 tests`
+`ZERO OPERATORS` · `v0.3` · `phase 3 complete — 224 tests`
 
 <br/>
 </div>

--- a/memory/zo-platform/DECISION_LOG.md
+++ b/memory/zo-platform/DECISION_LOG.md
@@ -130,3 +130,31 @@ Append-only. Every orchestration decision with timestamp, rationale, and outcome
 **Decision:** Memory layer and semantic index both built, tested, and verified.
 **Rationale:** 151 tests passing (32 memory + 32 semantic + 76 Phase 1 + 11 integration), 96% coverage, ruff clean. End-to-end smoke test demonstrates full lifecycle: initialize → write state → log decisions → add priors → write summary → build index → semantic query → session recovery.
 **Outcome:** Gate 2 ready for human review. Phase 3 (Orchestration Engine) unblocked pending approval.
+
+---
+
+## Decision: 2026-04-09T19:00:00Z
+**Type:** ARCHITECTURE
+**Title:** Wrapper redesign — observer/launcher, not agent spawner
+**Decision:** wrapper.py launches ONE Claude Code session (the Lead Orchestrator), does NOT spawn individual agents via subprocess. The Lead Orchestrator creates the team internally using TeamCreate + Agent(team_name=...). Wrapper monitors via file system (tasks, logs, tmux).
+**Rationale:** Research confirmed that Claude Code agent teams with peer-to-peer comms (SendMessage) can only be created from WITHIN a running Claude Code session, not via external CLI calls. Previous design of wrapper.py spawning N individual agents would have produced isolated sessions without peer-to-peer messaging — defeating the core requirement.
+**Alternatives considered:** (1) N subprocess calls per agent (no peer-to-peer). (2) Custom file-based messaging (fragile, not native). (3) Single session with TeamCreate (chosen — leverages native peer-to-peer).
+**Outcome:** wrapper.py redesigned as observer/launcher. orchestrator.py builds the lead prompt. Lead Orchestrator agent definition updated with 16-agent roster and dynamic agent creation capability.
+
+---
+
+## Decision: 2026-04-09T19:10:00Z
+**Type:** ARCHITECTURE
+**Title:** Lead Orchestrator — dynamic agent creation
+**Decision:** Lead Orchestrator can create new agent definition files (.claude/agents/*.md) on the fly if a project requires expertise not covered by the 16 pre-defined agents.
+**Rationale:** The agent roster is a starting point, not a ceiling. Real projects will need domain-specific experts (NLP specialist, time-series expert, security auditor). The Lead Orchestrator has the context to identify gaps and write appropriate agent definitions following the established template.
+**Outcome:** lead-orchestrator.md updated with agent roster table and dynamic creation protocol.
+
+---
+
+## Decision: 2026-04-09T19:30:00Z
+**Type:** GATE
+**Title:** Phase 3 complete — Orchestration engine + wrapper built
+**Decision:** PROCEED to Phase 4
+**Rationale:** 224 tests passing, 93% coverage, ruff clean. Orchestrator decomposes plans into phases for all 3 workflow modes, generates agent contracts, builds lead prompts with full context. Wrapper launches sessions, monitors teams, handles rate limits. Architecture validated: Python CLI → one Claude session → native agent team with peer-to-peer comms.
+**Outcome:** Phase 4 (Hardening — Evolution Engine, CLI, integration tests) unblocked.

--- a/memory/zo-platform/STATE.md
+++ b/memory/zo-platform/STATE.md
@@ -2,52 +2,36 @@
 
 project: zero-operators-build
 mode: build
-phase: phase_2_complete
+phase: phase_3_complete
 iteration: 1
 status: active
 
 ## Current Position
 
-Phase 2 (Core Infrastructure) is **complete**. Gate 2 ready for human review. Phase 3 (Orchestration Engine) is next.
-
-## Agent Statuses
-
-| Agent | Status | Last Action |
-|-------|--------|-------------|
-| software-architect | idle | Module decomposition complete |
-| backend-engineer | idle | Phase 2 modules delivered (memory + semantic) |
-| platform-test-engineer | idle | 151 tests passing, 96% coverage |
-| platform-code-reviewer | idle | ruff clean |
-| documentation-agent | idle | README.md + STATE.md updated |
+Phase 3 (Integration — Orchestration Engine) is **complete**. 224 tests, 93% coverage, ruff clean. Phase 4 (Hardening) is next.
 
 ## Completed
 
 - [x] Phase 0: Agent definitions (16 files), settings.json, build plan v2.0
-- [x] Phase 1: Plan Parser, Target Parser, Comms Logger, setup.sh (76 tests, 97% coverage)
-- [x] Phase 2: Core Infrastructure
-  - [x] Module 3: Memory Layer (src/zo/memory.py + _memory_models.py + _memory_formats.py)
-    - SessionState read/write with atomic ops
-    - DECISION_LOG append-only with markdown parsing
-    - PRIORS.md manager with seed/append/supersede
-    - Session summaries write/read
-    - Session recovery (valid/missing/corrupt/git mismatch)
-    - 32 unit tests
-  - [x] Module 4: Semantic Index (src/zo/semantic.py)
-    - fastembed + SQLite with summary-prefix embedding
-    - Graceful fallback when fastembed not installed (word-overlap scoring)
-    - Full decision entries returned on retrieval
-    - 32 unit tests (25 always-run + 7 fastembed-gated)
-  - [x] Integration tests (11 tests: plan+target+comms end-to-end)
-  - [x] Test fixtures (test-project plan.md, target.md, conftest.py)
-  - [x] Gate 2 ready: 151 tests, 96% coverage, ruff clean
+- [x] Phase 1: Plan Parser, Target Parser, Comms Logger, setup.sh
+- [x] Phase 2: Memory Layer, Semantic Index, integration tests
+- [x] Phase 3: Orchestration Engine + Lifecycle Wrapper
+  - [x] orchestrator.py — plan decomposition, phase management, lead prompt generation, gate evaluation
+  - [x] _orchestrator_models.py — PhaseDefinition, AgentContract, GateEvaluation, WorkflowDecomposition
+  - [x] _orchestrator_phases.py — phase templates for classical_ml, deep_learning, research modes
+  - [x] wrapper.py — launches claude session, monitors team via file system, tmux integration
+  - [x] _wrapper_models.py — LeadProcess, TeamStatus, TeamMember
+  - [x] Updated lead-orchestrator.md with 16-agent roster + dynamic agent creation
+  - [x] 73 new tests (37 orchestrator + 36 wrapper)
 
 ## Next Steps
 
-1. **Gate 2:** Human reviews integration plan
-2. **Phase 3 — Integration:**
-   - Module 6: Orchestration Engine (src/zo/orchestrator.py + src/zo/wrapper.py)
-   - The core: reads plan, selects workflow, decomposes phases, manages gates
-   - Python lifecycle wrapper invokes claude CLI, captures events
+1. **Phase 4 — Hardening (parallel):**
+   - Module 7: Evolution Engine (src/zo/evolution.py)
+   - Module 9: CLI Entry Point (src/zo/cli.py + src/zo/draft.py)
+   - Integration test suite across all modules
+
+2. **Gate 4:** Human reviews integrated system
 
 ## Blockers
 
@@ -55,6 +39,6 @@ None.
 
 ## Session Metadata
 
-last_checkpoint: 2026-04-09T19:00:00Z
-last_session: session-002
+last_checkpoint: 2026-04-09T19:30:00Z
+last_session: session-003
 branch: claude/strange-swartz

--- a/plans/zero-operators-build.md
+++ b/plans/zero-operators-build.md
@@ -198,12 +198,16 @@ Deliverables: a working ZO platform deployed as a Python package in the `zero-op
 **File:** `src/zo/comms.py`
 **Priority:** P0
 
-### Module 6: Orchestration Engine (Hybrid)
+### Module 6: Orchestration Engine (Hybrid) ✅
 **Spec source:** specs/workflow.md, specs/agents.md, specs/oracle.md
-**Responsibility:** Core engine. Reads parsed plan, selects workflow mode, decomposes into phases, manages gating. Python wrapper invokes `claude` CLI to launch agent teams, captures lifecycle events, pipes to comms logger. Agents communicate natively.
-**Outputs:** Orchestrator class + LifecycleWrapper class.
-**Files:** `src/zo/orchestrator.py`, `src/zo/wrapper.py`
-**Priority:** P0 (depends on Modules 1-5)
+**Responsibility:** Three-layer architecture:
+1. `orchestrator.py` — Parses plan, decomposes phases (classical_ml/deep_learning/research), generates agent contracts, builds lead prompt with full context (plan + phases + agent roster + memory + coordination instructions), manages gates, detects plan edits
+2. `wrapper.py` — Launches ONE Claude Code session as Lead Orchestrator (`claude --teammate-mode tmux`), monitors team via `~/.claude/tasks/` and session logs, captures tmux pane output, handles rate limits, pipes events to CommsLogger
+3. Lead Orchestrator agent (inside Claude Code) uses `TeamCreate` + `Agent(team_name=...)` for native peer-to-peer messaging. Can dynamically create new agent definitions if project needs expertise beyond 16 pre-defined agents.
+**Outputs:** Orchestrator class + LifecycleWrapper class (73 tests).
+**Files:** `src/zo/orchestrator.py` (532 lines), `src/zo/_orchestrator_models.py`, `src/zo/_orchestrator_phases.py`, `src/zo/wrapper.py` (382 lines), `src/zo/_wrapper_models.py`
+**Architecture note:** Python layer does NOT spawn agents directly. It builds context and launches one session. Agent coordination is native Claude Code with peer-to-peer comms.
+**Status:** COMPLETE
 
 ### Module 7: Evolution Engine
 **Spec source:** specs/evolution.md

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "zero-operators"
-version = "0.2.0"
+version = "0.3.0"
 description = "Autonomous AI research and engineering team system"
 readme = "README.md"
 requires-python = ">=3.11"

--- a/src/zo/__init__.py
+++ b/src/zo/__init__.py
@@ -3,4 +3,4 @@
 You input a plan. Agents execute. The oracle verifies.
 """
 
-__version__ = "0.2.0"
+__version__ = "0.3.0"

--- a/src/zo/_orchestrator_models.py
+++ b/src/zo/_orchestrator_models.py
@@ -1,0 +1,87 @@
+"""Pydantic models for ZO orchestrator.
+
+Internal module — import from ``zo.orchestrator`` instead.
+"""
+
+from __future__ import annotations
+
+from enum import StrEnum
+
+from pydantic import BaseModel, Field
+
+from zo.plan import WorkflowMode  # noqa: TC001
+
+
+class PhaseStatus(StrEnum):
+    """Lifecycle status of a workflow phase."""
+
+    PENDING = "pending"
+    ACTIVE = "active"
+    GATED = "gated"
+    BLOCKED = "blocked"
+    COMPLETED = "completed"
+    SKIPPED = "skipped"
+
+
+class GateDecision(StrEnum):
+    """Outcome of a gate evaluation."""
+
+    PROCEED = "proceed"
+    HOLD = "hold"
+    ITERATE = "iterate"
+    ESCALATE = "escalate"
+
+
+class GateType(StrEnum):
+    """Whether a gate is evaluated automatically or requires human input."""
+
+    AUTOMATED = "automated"
+    BLOCKING = "blocking"
+
+
+class PhaseDefinition(BaseModel):
+    """A single phase in the workflow decomposition."""
+
+    phase_id: str
+    name: str
+    description: str
+    subtasks: list[str] = Field(default_factory=list)
+    assigned_agents: list[str] = Field(default_factory=list)
+    gate_type: GateType
+    status: PhaseStatus = PhaseStatus.PENDING
+    depends_on: list[str] = Field(default_factory=list)
+    completed_subtasks: list[str] = Field(default_factory=list)
+
+
+class AgentContract(BaseModel):
+    """Integration contract for an agent within a phase."""
+
+    agent_name: str
+    phase_id: str
+    role_description: str
+    ownership: list[str] = Field(default_factory=list)
+    off_limits: list[str] = Field(default_factory=list)
+    contract_produced: list[str] = Field(default_factory=list)
+    contract_consumed: list[str] = Field(default_factory=list)
+    validation_checklist: list[str] = Field(default_factory=list)
+    coordination_rules: list[str] = Field(default_factory=list)
+
+
+class GateEvaluation(BaseModel):
+    """Result of evaluating a phase gate."""
+
+    phase_id: str
+    gate_type: GateType
+    decision: GateDecision
+    metric_results: dict[str, float] = Field(default_factory=dict)
+    thresholds: dict[str, float] = Field(default_factory=dict)
+    rationale: str = ""
+    requires_human: bool = False
+
+
+class WorkflowDecomposition(BaseModel):
+    """Full workflow decomposition for a project."""
+
+    mode: WorkflowMode
+    phases: list[PhaseDefinition] = Field(default_factory=list)
+    agent_contracts: list[AgentContract] = Field(default_factory=list)

--- a/src/zo/_orchestrator_phases.py
+++ b/src/zo/_orchestrator_phases.py
@@ -1,0 +1,228 @@
+"""Phase template factories for ZO orchestrator.
+
+Internal module — defines workflow phase templates per mode.
+Import from ``zo.orchestrator`` instead.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+from zo._orchestrator_models import GateType, PhaseDefinition
+from zo.plan import WorkflowMode
+
+if TYPE_CHECKING:
+    from collections.abc import Callable
+
+# ---------------------------------------------------------------------------
+# Agent-to-phase mapping
+# ---------------------------------------------------------------------------
+
+AGENT_PHASE_MAP: dict[str, list[str]] = {
+    "data-engineer": ["phase_0", "phase_1", "phase_2"],
+    "model-builder": ["phase_3", "phase_4", "phase_5"],
+    "oracle-qa": ["phase_3", "phase_4", "phase_5"],
+    "code-reviewer": [
+        "phase_1", "phase_2", "phase_3", "phase_4", "phase_5", "phase_6",
+    ],
+    "test-engineer": [
+        "phase_1", "phase_2", "phase_3", "phase_4", "phase_5", "phase_6",
+    ],
+    "xai-agent": ["phase_5"],
+    "domain-evaluator": ["phase_5"],
+    "ml-engineer": ["phase_4", "phase_5", "phase_6"],
+    "infra-engineer": ["phase_1", "phase_6"],
+    "lead-orchestrator": [],
+}
+
+
+# ---------------------------------------------------------------------------
+# Phase templates per workflow mode
+# ---------------------------------------------------------------------------
+
+
+def classical_ml_phases() -> list[PhaseDefinition]:
+    """Return phase definitions for the classical_ml workflow."""
+    return [
+        PhaseDefinition(
+            phase_id="phase_1",
+            name="Data Review and Pipeline",
+            description="Validate raw data, profile, clean, version, build loaders.",
+            subtasks=[
+                "Raw data audit", "Data hygiene", "Exclusion filters",
+                "Data alignment", "EDA", "Data versioning", "Data loader",
+            ],
+            gate_type=GateType.AUTOMATED,
+            depends_on=[],
+        ),
+        PhaseDefinition(
+            phase_id="phase_2",
+            name="Feature Engineering and Selection",
+            description="Engineer features, filter, prune multicollinearity, rank.",
+            subtasks=[
+                "Feature engineering", "Section filter", "Statistical filter",
+                "Multicollinearity pruning", "Domain validation", "Feature ranking",
+            ],
+            gate_type=GateType.BLOCKING,
+            depends_on=["phase_1"],
+        ),
+        PhaseDefinition(
+            phase_id="phase_3",
+            name="Model Design",
+            description=(
+                "Select architecture, design loss, define training strategy, "
+                "set up oracle and experiment tracking."
+            ),
+            subtasks=[
+                "Architecture selection", "Loss function design",
+                "Training strategy", "Regime segmentation",
+                "Oracle setup", "Experiment tracking",
+            ],
+            gate_type=GateType.AUTOMATED,
+            depends_on=["phase_2"],
+        ),
+        PhaseDefinition(
+            phase_id="phase_4",
+            name="Training and Iteration",
+            description="Train, iterate, cross-validate, ensemble exploration.",
+            subtasks=[
+                "Baseline training", "Iteration protocol",
+                "Cross-validation", "Ensemble exploration",
+            ],
+            gate_type=GateType.AUTOMATED,
+            depends_on=["phase_3"],
+        ),
+        PhaseDefinition(
+            phase_id="phase_5",
+            name="Analysis and Validation",
+            description=(
+                "Explainability, domain consistency, error analysis, "
+                "ablation, statistical significance."
+            ),
+            subtasks=[
+                "Feature attribution", "Domain consistency",
+                "Data corroboration", "Magnitude plausibility",
+                "Error analysis", "Ablation study",
+                "Significance testing", "Reproducibility",
+                "Report assembly",
+            ],
+            gate_type=GateType.BLOCKING,
+            depends_on=["phase_4"],
+        ),
+        PhaseDefinition(
+            phase_id="phase_6",
+            name="Packaging",
+            description="Inference pipeline, model card, validation report, tests.",
+            subtasks=[
+                "Inference pipeline", "Model card",
+                "Validation report", "Drift detection", "Test suite",
+            ],
+            gate_type=GateType.AUTOMATED,
+            depends_on=["phase_5"],
+        ),
+    ]
+
+
+def deep_learning_phases() -> list[PhaseDefinition]:
+    """Return phase definitions for the deep_learning workflow."""
+    phases = classical_ml_phases()
+    # Phase 2: input representation focus
+    phases[1] = PhaseDefinition(
+        phase_id="phase_2",
+        name="Input Representation Design",
+        description=(
+            "Design input representations, transfer learning assessment, "
+            "augmentation strategy."
+        ),
+        subtasks=[
+            "Input representation design", "Transfer learning assessment",
+            "Augmentation strategy",
+        ],
+        gate_type=GateType.BLOCKING,
+        depends_on=["phase_1"],
+    )
+    # Phase 3: expanded architecture search
+    phases[2] = PhaseDefinition(
+        phase_id="phase_3",
+        name="Model Design (Deep Learning)",
+        description=(
+            "Architecture search, loss design, training strategy with LR "
+            "scheduling and gradient diagnostics, oracle and tracking setup."
+        ),
+        subtasks=[
+            "Architecture selection", "Loss function design",
+            "Training strategy", "Gradient diagnostics plan",
+            "Regime segmentation", "Oracle setup", "Experiment tracking",
+        ],
+        gate_type=GateType.AUTOMATED,
+        depends_on=["phase_2"],
+    )
+    # Phase 4: add training diagnostics subtask
+    phases[3] = PhaseDefinition(
+        phase_id="phase_4",
+        name="Training and Iteration (Deep Learning)",
+        description="Train with diagnostics, iterate, cross-validate, ensemble.",
+        subtasks=[
+            "Baseline training", "Training diagnostics",
+            "Iteration protocol", "Cross-validation", "Ensemble exploration",
+        ],
+        gate_type=GateType.AUTOMATED,
+        depends_on=["phase_3"],
+    )
+    return phases
+
+
+def research_phases() -> list[PhaseDefinition]:
+    """Return phase definitions for the research workflow."""
+    phase_0 = PhaseDefinition(
+        phase_id="phase_0",
+        name="Literature Review and Prior Art",
+        description="Survey prior art, define baselines and evaluation protocol.",
+        subtasks=["Prior art survey", "Baseline definition"],
+        gate_type=GateType.AUTOMATED,
+        depends_on=[],
+    )
+    base = deep_learning_phases()
+    # Shift dependency: phase_1 now depends on phase_0
+    base[0].depends_on = ["phase_0"]
+    # Phase 5: expand with ablation and reproducibility
+    base[4] = PhaseDefinition(
+        phase_id="phase_5",
+        name="Analysis and Validation (Research)",
+        description=(
+            "Full analysis with ablation studies, statistical significance, "
+            "reproducibility verification."
+        ),
+        subtasks=[
+            "Feature attribution", "Domain consistency",
+            "Data corroboration", "Magnitude plausibility",
+            "Error analysis", "Ablation study",
+            "Significance testing", "Reproducibility",
+            "Report assembly",
+        ],
+        gate_type=GateType.BLOCKING,
+        depends_on=["phase_4"],
+    )
+    # Phase 6: add research artifacts
+    base[5] = PhaseDefinition(
+        phase_id="phase_6",
+        name="Packaging (Research)",
+        description=(
+            "Inference pipeline, model card, validation report, tests, "
+            "paper-ready figures and reproducibility bundle."
+        ),
+        subtasks=[
+            "Inference pipeline", "Model card", "Validation report",
+            "Drift detection", "Test suite", "Research artifacts",
+        ],
+        gate_type=GateType.AUTOMATED,
+        depends_on=["phase_5"],
+    )
+    return [phase_0, *base]
+
+
+MODE_PHASE_FACTORY: dict[WorkflowMode, Callable[[], list[PhaseDefinition]]] = {
+    WorkflowMode.CLASSICAL_ML: classical_ml_phases,
+    WorkflowMode.DEEP_LEARNING: deep_learning_phases,
+    WorkflowMode.RESEARCH: research_phases,
+}

--- a/src/zo/_wrapper_models.py
+++ b/src/zo/_wrapper_models.py
@@ -1,0 +1,59 @@
+"""Data models for the lifecycle wrapper.
+
+Separated from wrapper.py to keep both files under 500 lines.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime  # noqa: TC003 — needed at runtime by pydantic
+from enum import StrEnum
+from pathlib import Path  # noqa: TC003 — needed at runtime by pydantic
+
+from pydantic import BaseModel, ConfigDict
+
+
+class AgentStatus(StrEnum):
+    """Lifecycle states for the lead orchestrator process."""
+
+    SPAWNING = "spawning"
+    RUNNING = "running"
+    COMPLETED = "completed"
+    ERRORED = "errored"
+    RATE_LIMITED = "rate_limited"
+    TIMED_OUT = "timed_out"
+
+
+class LeadProcess(BaseModel):
+    """Tracks the lead orchestrator Claude Code session."""
+
+    pid: int | None = None
+    status: AgentStatus = AgentStatus.SPAWNING
+    started_at: datetime | None = None
+    completed_at: datetime | None = None
+    exit_code: int | None = None
+    team_name: str = ""
+    stdout_log: Path | None = None
+    stderr_log: Path | None = None
+
+    model_config = ConfigDict(arbitrary_types_allowed=True)
+
+
+class TeamMember(BaseModel):
+    """A team member discovered from task/team files."""
+
+    name: str
+    agent_type: str = ""
+    status: str = "unknown"
+    current_task: str = ""
+
+
+class TeamStatus(BaseModel):
+    """Snapshot of the team's current state."""
+
+    team_name: str
+    members: list[TeamMember] = []
+    tasks_total: int = 0
+    tasks_completed: int = 0
+    tasks_in_progress: int = 0
+    tasks_pending: int = 0
+    is_active: bool = True

--- a/src/zo/orchestrator.py
+++ b/src/zo/orchestrator.py
@@ -1,0 +1,915 @@
+"""Orchestrator for Zero Operators.
+
+Reads a plan, decomposes it into phases, generates agent contracts,
+manages gates, and builds the lead prompt injected into a Claude Code
+agent team session.  The orchestrator does NOT spawn agents directly —
+it prepares context for ``wrapper.py`` which launches the lead session.
+
+Typical usage::
+
+    from zo.orchestrator import Orchestrator
+    orch = Orchestrator(plan=plan, target=target, memory=mm,
+                        comms=logger, semantic=idx, zo_root=Path("."))
+    orch.start_session()
+    decomp = orch.decompose_plan()
+    prompt = orch.build_lead_prompt(decomp.phases[0])
+"""
+
+from __future__ import annotations
+
+import hashlib
+from datetime import UTC, datetime
+from pathlib import Path
+from textwrap import dedent
+from typing import TYPE_CHECKING
+
+from zo._memory_models import DecisionEntry, OperatingMode, SessionState, SessionSummary
+from zo._orchestrator_models import (
+    AgentContract,
+    GateDecision,
+    GateEvaluation,
+    GateType,
+    PhaseDefinition,
+    PhaseStatus,
+    WorkflowDecomposition,
+)
+from zo.plan import Plan, WorkflowMode
+
+if TYPE_CHECKING:
+    from zo.comms import CommsLogger
+    from zo.memory import MemoryManager
+    from zo.semantic import SemanticIndex
+    from zo.target import TargetConfig
+
+__all__ = [
+    "AgentContract",
+    "GateDecision",
+    "GateEvaluation",
+    "GateType",
+    "Orchestrator",
+    "PhaseDefinition",
+    "PhaseStatus",
+    "WorkflowDecomposition",
+]
+
+# ---------------------------------------------------------------------------
+# Agent-to-phase mapping
+# ---------------------------------------------------------------------------
+
+_AGENT_PHASE_MAP: dict[str, list[str]] = {
+    "data-engineer": ["phase_0", "phase_1", "phase_2"],
+    "model-builder": ["phase_3", "phase_4", "phase_5"],
+    "oracle-qa": ["phase_3", "phase_4", "phase_5"],
+    "code-reviewer": [
+        "phase_1", "phase_2", "phase_3", "phase_4", "phase_5", "phase_6",
+    ],
+    "test-engineer": [
+        "phase_1", "phase_2", "phase_3", "phase_4", "phase_5", "phase_6",
+    ],
+    "xai-agent": ["phase_5"],
+    "domain-evaluator": ["phase_5"],
+    "ml-engineer": ["phase_4", "phase_5", "phase_6"],
+    "infra-engineer": ["phase_1", "phase_6"],
+    "lead-orchestrator": [],
+}
+
+# ---------------------------------------------------------------------------
+# Phase templates per workflow mode
+# ---------------------------------------------------------------------------
+
+
+def _classical_ml_phases() -> list[PhaseDefinition]:
+    """Return phase definitions for the classical_ml workflow."""
+    return [
+        PhaseDefinition(
+            phase_id="phase_1",
+            name="Data Review and Pipeline",
+            description="Validate raw data, profile, clean, version, build loaders.",
+            subtasks=[
+                "Raw data audit", "Data hygiene", "Exclusion filters",
+                "Data alignment", "EDA", "Data versioning", "Data loader",
+            ],
+            gate_type=GateType.AUTOMATED,
+            depends_on=[],
+        ),
+        PhaseDefinition(
+            phase_id="phase_2",
+            name="Feature Engineering and Selection",
+            description="Engineer features, filter, prune multicollinearity, rank.",
+            subtasks=[
+                "Feature engineering", "Section filter", "Statistical filter",
+                "Multicollinearity pruning", "Domain validation", "Feature ranking",
+            ],
+            gate_type=GateType.BLOCKING,
+            depends_on=["phase_1"],
+        ),
+        PhaseDefinition(
+            phase_id="phase_3",
+            name="Model Design",
+            description=(
+                "Select architecture, design loss, define training strategy, "
+                "set up oracle and experiment tracking."
+            ),
+            subtasks=[
+                "Architecture selection", "Loss function design",
+                "Training strategy", "Regime segmentation",
+                "Oracle setup", "Experiment tracking",
+            ],
+            gate_type=GateType.AUTOMATED,
+            depends_on=["phase_2"],
+        ),
+        PhaseDefinition(
+            phase_id="phase_4",
+            name="Training and Iteration",
+            description="Train, iterate, cross-validate, ensemble exploration.",
+            subtasks=[
+                "Baseline training", "Iteration protocol",
+                "Cross-validation", "Ensemble exploration",
+            ],
+            gate_type=GateType.AUTOMATED,
+            depends_on=["phase_3"],
+        ),
+        PhaseDefinition(
+            phase_id="phase_5",
+            name="Analysis and Validation",
+            description=(
+                "Explainability, domain consistency, error analysis, "
+                "ablation, statistical significance."
+            ),
+            subtasks=[
+                "Feature attribution", "Domain consistency",
+                "Data corroboration", "Magnitude plausibility",
+                "Error analysis", "Ablation study",
+                "Significance testing", "Reproducibility",
+                "Report assembly",
+            ],
+            gate_type=GateType.BLOCKING,
+            depends_on=["phase_4"],
+        ),
+        PhaseDefinition(
+            phase_id="phase_6",
+            name="Packaging",
+            description="Inference pipeline, model card, validation report, tests.",
+            subtasks=[
+                "Inference pipeline", "Model card",
+                "Validation report", "Drift detection", "Test suite",
+            ],
+            gate_type=GateType.AUTOMATED,
+            depends_on=["phase_5"],
+        ),
+    ]
+
+
+def _deep_learning_phases() -> list[PhaseDefinition]:
+    """Return phase definitions for the deep_learning workflow."""
+    phases = _classical_ml_phases()
+    # Phase 2: input representation focus
+    phases[1] = PhaseDefinition(
+        phase_id="phase_2",
+        name="Input Representation Design",
+        description=(
+            "Design input representations, transfer learning assessment, "
+            "augmentation strategy."
+        ),
+        subtasks=[
+            "Input representation design", "Transfer learning assessment",
+            "Augmentation strategy",
+        ],
+        gate_type=GateType.BLOCKING,
+        depends_on=["phase_1"],
+    )
+    # Phase 3: expanded architecture search
+    phases[2] = PhaseDefinition(
+        phase_id="phase_3",
+        name="Model Design (Deep Learning)",
+        description=(
+            "Architecture search, loss design, training strategy with LR "
+            "scheduling and gradient diagnostics, oracle and tracking setup."
+        ),
+        subtasks=[
+            "Architecture selection", "Loss function design",
+            "Training strategy", "Gradient diagnostics plan",
+            "Regime segmentation", "Oracle setup", "Experiment tracking",
+        ],
+        gate_type=GateType.AUTOMATED,
+        depends_on=["phase_2"],
+    )
+    # Phase 4: add training diagnostics subtask
+    phases[3] = PhaseDefinition(
+        phase_id="phase_4",
+        name="Training and Iteration (Deep Learning)",
+        description=(
+            "Train with diagnostics, iterate, cross-validate, ensemble."
+        ),
+        subtasks=[
+            "Baseline training", "Training diagnostics",
+            "Iteration protocol", "Cross-validation", "Ensemble exploration",
+        ],
+        gate_type=GateType.AUTOMATED,
+        depends_on=["phase_3"],
+    )
+    return phases
+
+
+def _research_phases() -> list[PhaseDefinition]:
+    """Return phase definitions for the research workflow."""
+    phase_0 = PhaseDefinition(
+        phase_id="phase_0",
+        name="Literature Review and Prior Art",
+        description="Survey prior art, define baselines and evaluation protocol.",
+        subtasks=["Prior art survey", "Baseline definition"],
+        gate_type=GateType.AUTOMATED,
+        depends_on=[],
+    )
+    base = _deep_learning_phases()
+    # Shift dependency: phase_1 now depends on phase_0
+    base[0].depends_on = ["phase_0"]
+    # Phase 5: expand with ablation and reproducibility
+    base[4] = PhaseDefinition(
+        phase_id="phase_5",
+        name="Analysis and Validation (Research)",
+        description=(
+            "Full analysis with ablation studies, statistical significance, "
+            "reproducibility verification."
+        ),
+        subtasks=[
+            "Feature attribution", "Domain consistency",
+            "Data corroboration", "Magnitude plausibility",
+            "Error analysis", "Ablation study",
+            "Significance testing", "Reproducibility",
+            "Report assembly",
+        ],
+        gate_type=GateType.BLOCKING,
+        depends_on=["phase_4"],
+    )
+    # Phase 6: add research artifacts
+    base[5] = PhaseDefinition(
+        phase_id="phase_6",
+        name="Packaging (Research)",
+        description=(
+            "Inference pipeline, model card, validation report, tests, "
+            "paper-ready figures and reproducibility bundle."
+        ),
+        subtasks=[
+            "Inference pipeline", "Model card", "Validation report",
+            "Drift detection", "Test suite", "Research artifacts",
+        ],
+        gate_type=GateType.AUTOMATED,
+        depends_on=["phase_5"],
+    )
+    return [phase_0, *base]
+
+
+_MODE_PHASE_FACTORY: dict[WorkflowMode, callable] = {
+    WorkflowMode.CLASSICAL_ML: _classical_ml_phases,
+    WorkflowMode.DEEP_LEARNING: _deep_learning_phases,
+    WorkflowMode.RESEARCH: _research_phases,
+}
+
+
+# ---------------------------------------------------------------------------
+# Orchestrator
+# ---------------------------------------------------------------------------
+
+
+class Orchestrator:
+    """Coordinates plan decomposition, gating, and lead prompt generation.
+
+    Args:
+        plan: Parsed project plan.
+        target: Parsed target configuration.
+        memory: Memory manager for the project.
+        comms: Comms logger for audit events.
+        semantic: Semantic index for decision retrieval.
+        zo_root: Root directory of the ZO repository.
+    """
+
+    def __init__(
+        self,
+        plan: Plan,
+        target: TargetConfig,
+        memory: MemoryManager,
+        comms: CommsLogger,
+        semantic: SemanticIndex,
+        zo_root: Path,
+    ) -> None:
+        self._plan = plan
+        self._target = target
+        self._memory = memory
+        self._comms = comms
+        self._semantic = semantic
+        self._zo_root = Path(zo_root)
+        self._workflow: WorkflowDecomposition | None = None
+        self._session_state: SessionState | None = None
+        self._plan_hash: str = self._compute_plan_hash()
+
+    # -- Properties -----------------------------------------------------------
+
+    @property
+    def workflow(self) -> WorkflowDecomposition | None:
+        """Current workflow decomposition, or None if not yet decomposed."""
+        return self._workflow
+
+    @property
+    def session_state(self) -> SessionState:
+        """Current session state (reads from memory if not yet loaded)."""
+        if self._session_state is None:
+            self._session_state = self._memory.read_state()
+        return self._session_state
+
+    # -- Session lifecycle ----------------------------------------------------
+
+    def start_session(self) -> SessionState:
+        """Start or recover a session.
+
+        Reads STATE.md, recovers if needed, determines operating mode,
+        and logs the session start decision.
+
+        Returns:
+            The current session state.
+        """
+        state = self._memory.recover_session()
+        # Determine mode based on existing state
+        state_path = self._memory.memory_root / "STATE.md"
+        if not state_path.exists() or state.phase == "init":
+            state.mode = OperatingMode.BUILD
+        elif state.phase != "init":
+            state.mode = OperatingMode.CONTINUE
+
+        self._session_state = state
+        self._memory.write_state(state)
+
+        self._comms.log_decision(
+            agent="orchestrator",
+            title=f"Session started in {state.mode} mode",
+            rationale=(
+                f"Phase={state.phase}, "
+                f"blockers={len(state.active_blockers)}"
+            ),
+            outcome=state.mode,
+            confidence="high",
+        )
+        return state
+
+    def end_session(self, summary: SessionSummary | None = None) -> None:
+        """End the current session.
+
+        Writes session state, optional summary, and logs the end event.
+
+        Args:
+            summary: Optional session summary to persist.
+        """
+        if self._session_state is not None:
+            self._session_state.timestamp = datetime.now(UTC)
+            self._memory.write_state(self._session_state)
+
+        if summary is not None:
+            self._memory.write_session_summary(summary)
+
+        self._comms.log_decision(
+            agent="orchestrator",
+            title="Session ended",
+            rationale="Normal session termination.",
+            outcome="ended",
+        )
+
+    # -- Workflow decomposition -----------------------------------------------
+
+    def decompose_plan(self) -> WorkflowDecomposition:
+        """Decompose the plan into phases and agent contracts.
+
+        Reads the workflow mode from the plan, generates phase templates,
+        assigns agents, and produces contracts.
+
+        Returns:
+            The full workflow decomposition.
+        """
+        mode = (
+            self._plan.workflow.mode
+            if self._plan.workflow
+            else WorkflowMode.CLASSICAL_ML
+        )
+        factory = _MODE_PHASE_FACTORY.get(mode, _classical_ml_phases)
+        phases = factory()
+
+        active_agents = (
+            self._plan.agents.active_agents if self._plan.agents else []
+        )
+        # Assign agents to phases
+        for phase in phases:
+            phase.assigned_agents = self._agents_for_phase(
+                phase.phase_id, active_agents,
+            )
+
+        # Generate contracts
+        contracts: list[AgentContract] = []
+        for phase in phases:
+            for agent_name in phase.assigned_agents:
+                contracts.append(
+                    self.generate_agent_contract(agent_name, phase),
+                )
+
+        self._workflow = WorkflowDecomposition(
+            mode=mode, phases=phases, agent_contracts=contracts,
+        )
+
+        self._comms.log_decision(
+            agent="orchestrator",
+            title=f"Plan decomposed into {len(phases)} phases ({mode})",
+            rationale=f"Agents: {active_agents}",
+            outcome="decomposed",
+            confidence="high",
+        )
+
+        # Update session state
+        if self._session_state is not None:
+            self._session_state.phase = phases[0].phase_id
+
+        return self._workflow
+
+    def generate_agent_contract(
+        self, agent_name: str, phase: PhaseDefinition,
+    ) -> AgentContract:
+        """Generate a contract for an agent within a phase.
+
+        Args:
+            agent_name: Agent identifier (e.g. ``"data-engineer"``).
+            phase: The phase this contract belongs to.
+
+        Returns:
+            A populated ``AgentContract``.
+        """
+        role_map = {
+            "lead-orchestrator": "Coordinate pipeline, gate decisions, manage state",
+            "data-engineer": "Data pipeline, cleaning, profiling, loaders",
+            "model-builder": "Architecture, training, iteration against oracle",
+            "oracle-qa": "Hard metric evaluation, gating, drift detection",
+            "code-reviewer": "Code quality review, PEP8, security",
+            "test-engineer": "Unit, integration, regression tests",
+            "xai-agent": "Explainability analysis, SHAP, attention",
+            "domain-evaluator": "Domain validation, plausibility checks",
+            "ml-engineer": "Inference optimisation, GPU, experiment tracking",
+            "infra-engineer": "Environment setup, dependencies, deployment",
+        }
+        ownership_map = {
+            "data-engineer": ["data/raw/", "data/processed/", "data/reports/"],
+            "model-builder": ["models/", "experiments/"],
+            "oracle-qa": ["oracle/", "oracle/reports/"],
+            "code-reviewer": [],
+            "test-engineer": ["tests/"],
+            "xai-agent": ["xai/"],
+            "domain-evaluator": ["domain_validation/"],
+            "ml-engineer": ["infra/gpu/", "infra/tracking/"],
+            "infra-engineer": ["env/", "scripts/"],
+        }
+        off_limits_map = {
+            "data-engineer": ["models/", "oracle/"],
+            "model-builder": ["data/raw/", "oracle/"],
+            "oracle-qa": ["models/", "data/raw/"],
+            "code-reviewer": ["data/raw/", "models/"],
+            "test-engineer": ["data/raw/", "models/"],
+            "xai-agent": ["models/", "data/raw/"],
+            "domain-evaluator": ["models/", "data/raw/"],
+            "ml-engineer": ["models/", "data/raw/"],
+            "infra-engineer": ["models/", "oracle/"],
+        }
+
+        return AgentContract(
+            agent_name=agent_name,
+            phase_id=phase.phase_id,
+            role_description=role_map.get(agent_name, f"{agent_name} agent"),
+            ownership=ownership_map.get(agent_name, []),
+            off_limits=off_limits_map.get(agent_name, []),
+            contract_produced=[
+                f"{phase.phase_id}/{agent_name} artifacts",
+            ],
+            contract_consumed=[
+                f"Inputs from prior phase for {agent_name}",
+            ],
+            validation_checklist=[
+                "All outputs exist at specified paths",
+                "Output schema matches contract",
+                "No off-limits files modified",
+            ],
+            coordination_rules=[
+                "Message orchestrator on blockers",
+                "Use SendMessage for peer-to-peer comms",
+                f"Report status for phase {phase.phase_id}",
+            ],
+        )
+
+    # -- Build lead prompt ----------------------------------------------------
+
+    def build_lead_prompt(self, phase: PhaseDefinition) -> str:
+        """Build the full prompt for the Claude Code lead session.
+
+        This is the critical method — it produces the context injection
+        that turns a generic Claude session into a project-aware
+        orchestrator.
+
+        Args:
+            phase: The current phase to execute.
+
+        Returns:
+            A multi-section prompt string.
+        """
+        plan = self._plan
+        project_name = plan.frontmatter.project_name
+        sections: list[str] = []
+
+        # 1. Role
+        sections.append(dedent(f"""\
+            # Role
+
+            You are the Lead Orchestrator for project **{project_name}**.
+            Your job is to coordinate the agent team, enforce phase gates,
+            and drive the project to completion against the oracle metric.
+            You do NOT write code, train models, or compute metrics."""))
+
+        # 2. Plan context
+        oracle_text = plan.oracle.raw_content if plan.oracle else "Not defined"
+        sections.append(dedent(f"""\
+            # Plan Context
+
+            **Objective:** {plan.objective}
+
+            **Oracle:**
+            {oracle_text}
+
+            **Constraints:**
+            {plan.constraints}"""))
+
+        # 3. Current phase
+        subtask_list = "\n".join(f"- {s}" for s in phase.subtasks)
+        agent_list = ", ".join(phase.assigned_agents) or "none assigned"
+        sections.append(dedent(f"""\
+            # Current Phase: {phase.name} ({phase.phase_id})
+
+            {phase.description}
+
+            **Subtasks:**
+            {subtask_list}
+
+            **Assigned agents:** {agent_list}
+            **Gate type:** {phase.gate_type}
+            **Dependencies:** {', '.join(phase.depends_on) or 'none'}"""))
+
+        # 4. Agent contracts
+        if self._workflow:
+            contract_lines: list[str] = []
+            for c in self._workflow.agent_contracts:
+                if c.phase_id == phase.phase_id:
+                    contract_lines.append(
+                        f"### {c.agent_name}\n"
+                        f"Role: {c.role_description}\n"
+                        f"Owns: {', '.join(c.ownership) or 'n/a'}\n"
+                        f"Off-limits: {', '.join(c.off_limits) or 'n/a'}\n"
+                        f"Produces: {', '.join(c.contract_produced)}\n"
+                        f"Consumes: {', '.join(c.contract_consumed)}"
+                    )
+            if contract_lines:
+                sections.append(
+                    "# Agent Contracts\n\n" + "\n\n".join(contract_lines),
+                )
+
+        # 5. Agent roster
+        agents_dir = self._zo_root / ".claude" / "agents"
+        agent_files = sorted(agents_dir.glob("*.md")) if agents_dir.is_dir() else []
+        roster_lines = [f"- {f.stem}" for f in agent_files]
+        sections.append(
+            "# Agent Roster\n\n"
+            "Available agents in `.claude/agents/`:\n"
+            + "\n".join(roster_lines)
+            + "\n\nCreate new agent definitions if project requires "
+            "expertise not covered above."
+        )
+
+        # 6. Memory context
+        state = self.session_state
+        memory_lines = [
+            f"Mode: {state.mode}",
+            f"Phase: {state.phase}",
+            f"Blockers: {state.active_blockers or 'none'}",
+        ]
+        # Query semantic index for relevant past decisions
+        relevant = self._semantic.query(plan.objective, top_k=3)
+        if relevant:
+            memory_lines.append("\n**Relevant past decisions:**")
+            for r in relevant:
+                memory_lines.append(f"- [{r.score:.2f}] {r.entry.summary}")
+        sections.append(
+            "# Memory Context\n\n" + "\n".join(memory_lines),
+        )
+
+        # 7. Coordination instructions
+        sections.append(dedent("""\
+            # Coordination Instructions
+
+            - Use **TeamCreate** to create a named team for this phase.
+            - Spawn agents with **Agent(team_name=...)**.
+            - Agents communicate peer-to-peer via **SendMessage**.
+            - Define ALL integration contracts before parallel spawn.
+            - Log every decision to DECISION_LOG.md.
+            - Update STATE.md at every phase transition.
+            - Escalate to human if blockers persist after one debate round."""))
+
+        # 8. Gate criteria
+        if plan.oracle:
+            sections.append(dedent(f"""\
+                # Gate Criteria
+
+                **Primary metric:** {plan.oracle.primary_metric}
+                **Target threshold:** {plan.oracle.target_threshold}
+                **Evaluation method:** {plan.oracle.evaluation_method}
+                **Evaluation frequency:** {plan.oracle.evaluation_frequency}
+
+                Phase gate type: **{phase.gate_type}**
+                All subtasks must be complete and gate criteria met before
+                advancing to the next phase."""))
+
+        # 9. Constraints
+        if plan.constraints:
+            sections.append(f"# Constraints\n\n{plan.constraints}")
+
+        return "\n\n---\n\n".join(sections)
+
+    # -- Phase management -----------------------------------------------------
+
+    def get_current_phase(self) -> PhaseDefinition | None:
+        """Return the first phase that is PENDING with all dependencies met.
+
+        Returns:
+            The next actionable phase, or None if all are done/blocked.
+        """
+        if self._workflow is None:
+            return None
+
+        completed = {
+            p.phase_id
+            for p in self._workflow.phases
+            if p.status == PhaseStatus.COMPLETED
+        }
+        for phase in self._workflow.phases:
+            if phase.status != PhaseStatus.PENDING:
+                continue
+            if all(dep in completed for dep in phase.depends_on):
+                return phase
+        return None
+
+    def advance_phase(self, phase_id: str) -> GateEvaluation:
+        """Evaluate the gate for a phase and advance if criteria are met.
+
+        Args:
+            phase_id: The phase to evaluate.
+
+        Returns:
+            Gate evaluation result.
+
+        Raises:
+            ValueError: If the phase is not found.
+        """
+        phase = self._find_phase(phase_id)
+
+        # Check all subtasks are complete
+        all_done = set(phase.subtasks) == set(phase.completed_subtasks)
+
+        if phase.gate_type == GateType.BLOCKING:
+            evaluation = GateEvaluation(
+                phase_id=phase_id,
+                gate_type=GateType.BLOCKING,
+                decision=GateDecision.HOLD,
+                rationale=(
+                    "Blocking gate requires human approval."
+                    if all_done
+                    else "Subtasks incomplete; blocking gate."
+                ),
+                requires_human=True,
+            )
+            if all_done:
+                phase.status = PhaseStatus.GATED
+            self._log_gate(evaluation)
+            return evaluation
+
+        # Automated gate
+        if all_done:
+            phase.status = PhaseStatus.COMPLETED
+            evaluation = GateEvaluation(
+                phase_id=phase_id,
+                gate_type=GateType.AUTOMATED,
+                decision=GateDecision.PROCEED,
+                rationale="All subtasks complete; automated gate passed.",
+                requires_human=False,
+            )
+        else:
+            remaining = set(phase.subtasks) - set(phase.completed_subtasks)
+            evaluation = GateEvaluation(
+                phase_id=phase_id,
+                gate_type=GateType.AUTOMATED,
+                decision=GateDecision.ITERATE,
+                rationale=f"Subtasks remaining: {', '.join(sorted(remaining))}",
+                requires_human=False,
+            )
+
+        self._log_gate(evaluation)
+        return evaluation
+
+    def mark_subtask_complete(
+        self, phase_id: str, subtask: str,
+    ) -> None:
+        """Mark a subtask as complete within a phase.
+
+        Args:
+            phase_id: Phase containing the subtask.
+            subtask: Name of the subtask to mark done.
+
+        Raises:
+            ValueError: If the phase or subtask is not found.
+        """
+        phase = self._find_phase(phase_id)
+        if subtask not in phase.subtasks:
+            raise ValueError(
+                f"Subtask '{subtask}' not found in phase '{phase_id}'. "
+                f"Available: {phase.subtasks}"
+            )
+        if subtask not in phase.completed_subtasks:
+            phase.completed_subtasks.append(subtask)
+
+        # Update session state
+        if self._session_state is not None:
+            self._session_state.last_completed_subtask = subtask
+            self._memory.write_state(self._session_state)
+
+        self._comms.log_checkpoint(
+            agent="orchestrator",
+            phase=phase_id,
+            subtask=subtask,
+            progress=(
+                f"{len(phase.completed_subtasks)}/{len(phase.subtasks)} "
+                "subtasks complete"
+            ),
+        )
+
+    # -- Plan edit detection --------------------------------------------------
+
+    def check_plan_edited(self) -> bool:
+        """Check if the plan file has been modified since decomposition.
+
+        Returns:
+            True if the plan content hash differs from the stored hash.
+        """
+        current = self._compute_plan_hash()
+        return current != self._plan_hash
+
+    def replan(self, new_plan: Plan) -> WorkflowDecomposition:
+        """Re-decompose with an updated plan.
+
+        Args:
+            new_plan: The updated plan.
+
+        Returns:
+            New workflow decomposition.
+        """
+        self._plan = new_plan
+        self._plan_hash = self._compute_plan_hash()
+
+        self._comms.log_decision(
+            agent="orchestrator",
+            title="Plan re-decomposed after edit",
+            rationale="Plan file changed; regenerating workflow.",
+            outcome="replanned",
+        )
+
+        return self.decompose_plan()
+
+    # -- Human checkpoints ----------------------------------------------------
+
+    def prepare_gate_review(self, phase_id: str) -> dict[str, str]:
+        """Prepare a summary for human gate review.
+
+        Args:
+            phase_id: Phase to prepare review for.
+
+        Returns:
+            Dict with review sections (phase, subtasks, metrics, etc.).
+        """
+        phase = self._find_phase(phase_id)
+        completed = ", ".join(phase.completed_subtasks) or "none"
+        remaining = ", ".join(
+            set(phase.subtasks) - set(phase.completed_subtasks),
+        ) or "none"
+
+        review: dict[str, str] = {
+            "phase": f"{phase.name} ({phase.phase_id})",
+            "status": phase.status,
+            "completed_subtasks": completed,
+            "remaining_subtasks": remaining,
+            "gate_type": phase.gate_type,
+            "description": phase.description,
+        }
+
+        if self._plan.oracle:
+            review["oracle_metric"] = self._plan.oracle.primary_metric
+            review["target_threshold"] = self._plan.oracle.target_threshold
+
+        return review
+
+    def apply_human_decision(
+        self,
+        phase_id: str,
+        decision: GateDecision,
+        notes: str = "",
+    ) -> None:
+        """Apply a human's gate decision to a phase.
+
+        Args:
+            phase_id: Phase the decision applies to.
+            decision: The human's decision.
+            notes: Optional notes from the reviewer.
+        """
+        phase = self._find_phase(phase_id)
+
+        if decision == GateDecision.PROCEED:
+            phase.status = PhaseStatus.COMPLETED
+        elif decision == GateDecision.ITERATE:
+            phase.status = PhaseStatus.ACTIVE
+            phase.completed_subtasks.clear()
+        elif decision == GateDecision.ESCALATE:
+            phase.status = PhaseStatus.BLOCKED
+        else:
+            phase.status = PhaseStatus.GATED
+
+        self._comms.log_decision(
+            agent="orchestrator",
+            title=f"Human decision on {phase_id}: {decision}",
+            rationale=notes or "Human reviewer decision.",
+            outcome=decision,
+        )
+
+        self._memory.append_decision(DecisionEntry(
+            title=f"Human gate decision: {phase_id}",
+            context=f"Phase: {phase.name}",
+            decision=decision,
+            rationale=notes,
+            outcome=decision,
+        ))
+
+    # -- Status queries -------------------------------------------------------
+
+    def get_phase_status(self, phase_id: str) -> PhaseStatus:
+        """Return the status of a specific phase.
+
+        Args:
+            phase_id: Phase to query.
+
+        Returns:
+            Current phase status.
+
+        Raises:
+            ValueError: If the phase is not found.
+        """
+        return self._find_phase(phase_id).status
+
+    # -- Internal helpers -----------------------------------------------------
+
+    def _find_phase(self, phase_id: str) -> PhaseDefinition:
+        """Locate a phase by ID, raising ValueError if not found."""
+        if self._workflow is None:
+            raise ValueError("Workflow not yet decomposed; call decompose_plan() first.")
+        for phase in self._workflow.phases:
+            if phase.phase_id == phase_id:
+                return phase
+        ids = [p.phase_id for p in self._workflow.phases]
+        raise ValueError(f"Phase '{phase_id}' not found. Available: {ids}")
+
+    def _agents_for_phase(
+        self, phase_id: str, active_agents: list[str],
+    ) -> list[str]:
+        """Return active agents relevant to a given phase."""
+        return [
+            a for a in active_agents
+            if phase_id in _AGENT_PHASE_MAP.get(a, [])
+        ]
+
+    def _compute_plan_hash(self) -> str:
+        """Hash the plan's source file content, or the objective as fallback."""
+        if self._plan.source_path and self._plan.source_path.exists():
+            content = self._plan.source_path.read_bytes()
+        else:
+            content = self._plan.objective.encode()
+        return hashlib.sha256(content).hexdigest()
+
+    def _log_gate(self, evaluation: GateEvaluation) -> None:
+        """Log a gate evaluation to comms and memory."""
+        self._comms.log_decision(
+            agent="orchestrator",
+            title=f"Gate evaluation: {evaluation.phase_id}",
+            rationale=evaluation.rationale,
+            outcome=evaluation.decision,
+        )
+        self._memory.append_decision(DecisionEntry(
+            title=f"Gate: {evaluation.phase_id} -> {evaluation.decision}",
+            context=f"Gate type: {evaluation.gate_type}",
+            decision=evaluation.decision,
+            rationale=evaluation.rationale,
+            outcome=evaluation.decision,
+        ))

--- a/src/zo/orchestrator.py
+++ b/src/zo/orchestrator.py
@@ -23,7 +23,7 @@ from pathlib import Path
 from textwrap import dedent
 from typing import TYPE_CHECKING
 
-from zo._memory_models import DecisionEntry, OperatingMode, SessionState, SessionSummary
+from zo._memory_models import DecisionEntry, OperatingMode, SessionState
 from zo._orchestrator_models import (
     AgentContract,
     GateDecision,
@@ -33,9 +33,11 @@ from zo._orchestrator_models import (
     PhaseStatus,
     WorkflowDecomposition,
 )
+from zo._orchestrator_phases import AGENT_PHASE_MAP, MODE_PHASE_FACTORY
 from zo.plan import Plan, WorkflowMode
 
 if TYPE_CHECKING:
+    from zo._memory_models import SessionSummary
     from zo.comms import CommsLogger
     from zo.memory import MemoryManager
     from zo.semantic import SemanticIndex
@@ -53,223 +55,45 @@ __all__ = [
 ]
 
 # ---------------------------------------------------------------------------
-# Agent-to-phase mapping
+# Contract metadata lookups
 # ---------------------------------------------------------------------------
 
-_AGENT_PHASE_MAP: dict[str, list[str]] = {
-    "data-engineer": ["phase_0", "phase_1", "phase_2"],
-    "model-builder": ["phase_3", "phase_4", "phase_5"],
-    "oracle-qa": ["phase_3", "phase_4", "phase_5"],
-    "code-reviewer": [
-        "phase_1", "phase_2", "phase_3", "phase_4", "phase_5", "phase_6",
-    ],
-    "test-engineer": [
-        "phase_1", "phase_2", "phase_3", "phase_4", "phase_5", "phase_6",
-    ],
-    "xai-agent": ["phase_5"],
-    "domain-evaluator": ["phase_5"],
-    "ml-engineer": ["phase_4", "phase_5", "phase_6"],
-    "infra-engineer": ["phase_1", "phase_6"],
-    "lead-orchestrator": [],
+_ROLE_MAP: dict[str, str] = {
+    "lead-orchestrator": "Coordinate pipeline, gate decisions, manage state",
+    "data-engineer": "Data pipeline, cleaning, profiling, loaders",
+    "model-builder": "Architecture, training, iteration against oracle",
+    "oracle-qa": "Hard metric evaluation, gating, drift detection",
+    "code-reviewer": "Code quality review, PEP8, security",
+    "test-engineer": "Unit, integration, regression tests",
+    "xai-agent": "Explainability analysis, SHAP, attention",
+    "domain-evaluator": "Domain validation, plausibility checks",
+    "ml-engineer": "Inference optimisation, GPU, experiment tracking",
+    "infra-engineer": "Environment setup, dependencies, deployment",
 }
 
-# ---------------------------------------------------------------------------
-# Phase templates per workflow mode
-# ---------------------------------------------------------------------------
-
-
-def _classical_ml_phases() -> list[PhaseDefinition]:
-    """Return phase definitions for the classical_ml workflow."""
-    return [
-        PhaseDefinition(
-            phase_id="phase_1",
-            name="Data Review and Pipeline",
-            description="Validate raw data, profile, clean, version, build loaders.",
-            subtasks=[
-                "Raw data audit", "Data hygiene", "Exclusion filters",
-                "Data alignment", "EDA", "Data versioning", "Data loader",
-            ],
-            gate_type=GateType.AUTOMATED,
-            depends_on=[],
-        ),
-        PhaseDefinition(
-            phase_id="phase_2",
-            name="Feature Engineering and Selection",
-            description="Engineer features, filter, prune multicollinearity, rank.",
-            subtasks=[
-                "Feature engineering", "Section filter", "Statistical filter",
-                "Multicollinearity pruning", "Domain validation", "Feature ranking",
-            ],
-            gate_type=GateType.BLOCKING,
-            depends_on=["phase_1"],
-        ),
-        PhaseDefinition(
-            phase_id="phase_3",
-            name="Model Design",
-            description=(
-                "Select architecture, design loss, define training strategy, "
-                "set up oracle and experiment tracking."
-            ),
-            subtasks=[
-                "Architecture selection", "Loss function design",
-                "Training strategy", "Regime segmentation",
-                "Oracle setup", "Experiment tracking",
-            ],
-            gate_type=GateType.AUTOMATED,
-            depends_on=["phase_2"],
-        ),
-        PhaseDefinition(
-            phase_id="phase_4",
-            name="Training and Iteration",
-            description="Train, iterate, cross-validate, ensemble exploration.",
-            subtasks=[
-                "Baseline training", "Iteration protocol",
-                "Cross-validation", "Ensemble exploration",
-            ],
-            gate_type=GateType.AUTOMATED,
-            depends_on=["phase_3"],
-        ),
-        PhaseDefinition(
-            phase_id="phase_5",
-            name="Analysis and Validation",
-            description=(
-                "Explainability, domain consistency, error analysis, "
-                "ablation, statistical significance."
-            ),
-            subtasks=[
-                "Feature attribution", "Domain consistency",
-                "Data corroboration", "Magnitude plausibility",
-                "Error analysis", "Ablation study",
-                "Significance testing", "Reproducibility",
-                "Report assembly",
-            ],
-            gate_type=GateType.BLOCKING,
-            depends_on=["phase_4"],
-        ),
-        PhaseDefinition(
-            phase_id="phase_6",
-            name="Packaging",
-            description="Inference pipeline, model card, validation report, tests.",
-            subtasks=[
-                "Inference pipeline", "Model card",
-                "Validation report", "Drift detection", "Test suite",
-            ],
-            gate_type=GateType.AUTOMATED,
-            depends_on=["phase_5"],
-        ),
-    ]
-
-
-def _deep_learning_phases() -> list[PhaseDefinition]:
-    """Return phase definitions for the deep_learning workflow."""
-    phases = _classical_ml_phases()
-    # Phase 2: input representation focus
-    phases[1] = PhaseDefinition(
-        phase_id="phase_2",
-        name="Input Representation Design",
-        description=(
-            "Design input representations, transfer learning assessment, "
-            "augmentation strategy."
-        ),
-        subtasks=[
-            "Input representation design", "Transfer learning assessment",
-            "Augmentation strategy",
-        ],
-        gate_type=GateType.BLOCKING,
-        depends_on=["phase_1"],
-    )
-    # Phase 3: expanded architecture search
-    phases[2] = PhaseDefinition(
-        phase_id="phase_3",
-        name="Model Design (Deep Learning)",
-        description=(
-            "Architecture search, loss design, training strategy with LR "
-            "scheduling and gradient diagnostics, oracle and tracking setup."
-        ),
-        subtasks=[
-            "Architecture selection", "Loss function design",
-            "Training strategy", "Gradient diagnostics plan",
-            "Regime segmentation", "Oracle setup", "Experiment tracking",
-        ],
-        gate_type=GateType.AUTOMATED,
-        depends_on=["phase_2"],
-    )
-    # Phase 4: add training diagnostics subtask
-    phases[3] = PhaseDefinition(
-        phase_id="phase_4",
-        name="Training and Iteration (Deep Learning)",
-        description=(
-            "Train with diagnostics, iterate, cross-validate, ensemble."
-        ),
-        subtasks=[
-            "Baseline training", "Training diagnostics",
-            "Iteration protocol", "Cross-validation", "Ensemble exploration",
-        ],
-        gate_type=GateType.AUTOMATED,
-        depends_on=["phase_3"],
-    )
-    return phases
-
-
-def _research_phases() -> list[PhaseDefinition]:
-    """Return phase definitions for the research workflow."""
-    phase_0 = PhaseDefinition(
-        phase_id="phase_0",
-        name="Literature Review and Prior Art",
-        description="Survey prior art, define baselines and evaluation protocol.",
-        subtasks=["Prior art survey", "Baseline definition"],
-        gate_type=GateType.AUTOMATED,
-        depends_on=[],
-    )
-    base = _deep_learning_phases()
-    # Shift dependency: phase_1 now depends on phase_0
-    base[0].depends_on = ["phase_0"]
-    # Phase 5: expand with ablation and reproducibility
-    base[4] = PhaseDefinition(
-        phase_id="phase_5",
-        name="Analysis and Validation (Research)",
-        description=(
-            "Full analysis with ablation studies, statistical significance, "
-            "reproducibility verification."
-        ),
-        subtasks=[
-            "Feature attribution", "Domain consistency",
-            "Data corroboration", "Magnitude plausibility",
-            "Error analysis", "Ablation study",
-            "Significance testing", "Reproducibility",
-            "Report assembly",
-        ],
-        gate_type=GateType.BLOCKING,
-        depends_on=["phase_4"],
-    )
-    # Phase 6: add research artifacts
-    base[5] = PhaseDefinition(
-        phase_id="phase_6",
-        name="Packaging (Research)",
-        description=(
-            "Inference pipeline, model card, validation report, tests, "
-            "paper-ready figures and reproducibility bundle."
-        ),
-        subtasks=[
-            "Inference pipeline", "Model card", "Validation report",
-            "Drift detection", "Test suite", "Research artifacts",
-        ],
-        gate_type=GateType.AUTOMATED,
-        depends_on=["phase_5"],
-    )
-    return [phase_0, *base]
-
-
-_MODE_PHASE_FACTORY: dict[WorkflowMode, callable] = {
-    WorkflowMode.CLASSICAL_ML: _classical_ml_phases,
-    WorkflowMode.DEEP_LEARNING: _deep_learning_phases,
-    WorkflowMode.RESEARCH: _research_phases,
+_OWNERSHIP_MAP: dict[str, list[str]] = {
+    "data-engineer": ["data/raw/", "data/processed/", "data/reports/"],
+    "model-builder": ["models/", "experiments/"],
+    "oracle-qa": ["oracle/", "oracle/reports/"],
+    "code-reviewer": [],
+    "test-engineer": ["tests/"],
+    "xai-agent": ["xai/"],
+    "domain-evaluator": ["domain_validation/"],
+    "ml-engineer": ["infra/gpu/", "infra/tracking/"],
+    "infra-engineer": ["env/", "scripts/"],
 }
 
-
-# ---------------------------------------------------------------------------
-# Orchestrator
-# ---------------------------------------------------------------------------
+_OFF_LIMITS_MAP: dict[str, list[str]] = {
+    "data-engineer": ["models/", "oracle/"],
+    "model-builder": ["data/raw/", "oracle/"],
+    "oracle-qa": ["models/", "data/raw/"],
+    "code-reviewer": ["data/raw/", "models/"],
+    "test-engineer": ["data/raw/", "models/"],
+    "xai-agent": ["models/", "data/raw/"],
+    "domain-evaluator": ["models/", "data/raw/"],
+    "ml-engineer": ["models/", "data/raw/"],
+    "infra-engineer": ["models/", "oracle/"],
+}
 
 
 class Orchestrator:
@@ -303,8 +127,6 @@ class Orchestrator:
         self._session_state: SessionState | None = None
         self._plan_hash: str = self._compute_plan_hash()
 
-    # -- Properties -----------------------------------------------------------
-
     @property
     def workflow(self) -> WorkflowDecomposition | None:
         """Current workflow decomposition, or None if not yet decomposed."""
@@ -320,16 +142,8 @@ class Orchestrator:
     # -- Session lifecycle ----------------------------------------------------
 
     def start_session(self) -> SessionState:
-        """Start or recover a session.
-
-        Reads STATE.md, recovers if needed, determines operating mode,
-        and logs the session start decision.
-
-        Returns:
-            The current session state.
-        """
+        """Start or recover a session."""
         state = self._memory.recover_session()
-        # Determine mode based on existing state
         state_path = self._memory.memory_root / "STATE.md"
         if not state_path.exists() or state.phase == "init":
             state.mode = OperatingMode.BUILD
@@ -338,154 +152,73 @@ class Orchestrator:
 
         self._session_state = state
         self._memory.write_state(state)
-
         self._comms.log_decision(
             agent="orchestrator",
             title=f"Session started in {state.mode} mode",
-            rationale=(
-                f"Phase={state.phase}, "
-                f"blockers={len(state.active_blockers)}"
-            ),
+            rationale=f"Phase={state.phase}, blockers={len(state.active_blockers)}",
             outcome=state.mode,
             confidence="high",
         )
         return state
 
     def end_session(self, summary: SessionSummary | None = None) -> None:
-        """End the current session.
-
-        Writes session state, optional summary, and logs the end event.
-
-        Args:
-            summary: Optional session summary to persist.
-        """
+        """End the current session."""
         if self._session_state is not None:
             self._session_state.timestamp = datetime.now(UTC)
             self._memory.write_state(self._session_state)
-
         if summary is not None:
             self._memory.write_session_summary(summary)
-
         self._comms.log_decision(
-            agent="orchestrator",
-            title="Session ended",
-            rationale="Normal session termination.",
-            outcome="ended",
+            agent="orchestrator", title="Session ended",
+            rationale="Normal session termination.", outcome="ended",
         )
 
     # -- Workflow decomposition -----------------------------------------------
 
     def decompose_plan(self) -> WorkflowDecomposition:
-        """Decompose the plan into phases and agent contracts.
-
-        Reads the workflow mode from the plan, generates phase templates,
-        assigns agents, and produces contracts.
-
-        Returns:
-            The full workflow decomposition.
-        """
+        """Decompose the plan into phases and agent contracts."""
         mode = (
             self._plan.workflow.mode
             if self._plan.workflow
             else WorkflowMode.CLASSICAL_ML
         )
-        factory = _MODE_PHASE_FACTORY.get(mode, _classical_ml_phases)
+        from zo._orchestrator_phases import classical_ml_phases
+        factory = MODE_PHASE_FACTORY.get(mode, classical_ml_phases)
         phases = factory()
 
-        active_agents = (
-            self._plan.agents.active_agents if self._plan.agents else []
-        )
-        # Assign agents to phases
+        active = self._plan.agents.active_agents if self._plan.agents else []
         for phase in phases:
-            phase.assigned_agents = self._agents_for_phase(
-                phase.phase_id, active_agents,
-            )
+            phase.assigned_agents = self._agents_for_phase(phase.phase_id, active)
 
-        # Generate contracts
         contracts: list[AgentContract] = []
         for phase in phases:
-            for agent_name in phase.assigned_agents:
-                contracts.append(
-                    self.generate_agent_contract(agent_name, phase),
-                )
+            for name in phase.assigned_agents:
+                contracts.append(self.generate_agent_contract(name, phase))
 
         self._workflow = WorkflowDecomposition(
             mode=mode, phases=phases, agent_contracts=contracts,
         )
-
         self._comms.log_decision(
             agent="orchestrator",
             title=f"Plan decomposed into {len(phases)} phases ({mode})",
-            rationale=f"Agents: {active_agents}",
-            outcome="decomposed",
-            confidence="high",
+            rationale=f"Agents: {active}", outcome="decomposed", confidence="high",
         )
-
-        # Update session state
         if self._session_state is not None:
             self._session_state.phase = phases[0].phase_id
-
         return self._workflow
 
     def generate_agent_contract(
         self, agent_name: str, phase: PhaseDefinition,
     ) -> AgentContract:
-        """Generate a contract for an agent within a phase.
-
-        Args:
-            agent_name: Agent identifier (e.g. ``"data-engineer"``).
-            phase: The phase this contract belongs to.
-
-        Returns:
-            A populated ``AgentContract``.
-        """
-        role_map = {
-            "lead-orchestrator": "Coordinate pipeline, gate decisions, manage state",
-            "data-engineer": "Data pipeline, cleaning, profiling, loaders",
-            "model-builder": "Architecture, training, iteration against oracle",
-            "oracle-qa": "Hard metric evaluation, gating, drift detection",
-            "code-reviewer": "Code quality review, PEP8, security",
-            "test-engineer": "Unit, integration, regression tests",
-            "xai-agent": "Explainability analysis, SHAP, attention",
-            "domain-evaluator": "Domain validation, plausibility checks",
-            "ml-engineer": "Inference optimisation, GPU, experiment tracking",
-            "infra-engineer": "Environment setup, dependencies, deployment",
-        }
-        ownership_map = {
-            "data-engineer": ["data/raw/", "data/processed/", "data/reports/"],
-            "model-builder": ["models/", "experiments/"],
-            "oracle-qa": ["oracle/", "oracle/reports/"],
-            "code-reviewer": [],
-            "test-engineer": ["tests/"],
-            "xai-agent": ["xai/"],
-            "domain-evaluator": ["domain_validation/"],
-            "ml-engineer": ["infra/gpu/", "infra/tracking/"],
-            "infra-engineer": ["env/", "scripts/"],
-        }
-        off_limits_map = {
-            "data-engineer": ["models/", "oracle/"],
-            "model-builder": ["data/raw/", "oracle/"],
-            "oracle-qa": ["models/", "data/raw/"],
-            "code-reviewer": ["data/raw/", "models/"],
-            "test-engineer": ["data/raw/", "models/"],
-            "xai-agent": ["models/", "data/raw/"],
-            "domain-evaluator": ["models/", "data/raw/"],
-            "ml-engineer": ["models/", "data/raw/"],
-            "infra-engineer": ["models/", "oracle/"],
-        }
-
+        """Generate a contract for an agent within a phase."""
         return AgentContract(
             agent_name=agent_name,
             phase_id=phase.phase_id,
-            role_description=role_map.get(agent_name, f"{agent_name} agent"),
-            ownership=ownership_map.get(agent_name, []),
-            off_limits=off_limits_map.get(agent_name, []),
-            contract_produced=[
-                f"{phase.phase_id}/{agent_name} artifacts",
-            ],
-            contract_consumed=[
-                f"Inputs from prior phase for {agent_name}",
-            ],
+            role_description=_ROLE_MAP.get(agent_name, f"{agent_name} agent"),
+            ownership=_OWNERSHIP_MAP.get(agent_name, []),
+            off_limits=_OFF_LIMITS_MAP.get(agent_name, []),
+            contract_produced=[f"{phase.phase_id}/{agent_name} artifacts"],
+            contract_consumed=[f"Inputs from prior phase for {agent_name}"],
             validation_checklist=[
                 "All outputs exist at specified paths",
                 "Output schema matches contract",
@@ -501,152 +234,24 @@ class Orchestrator:
     # -- Build lead prompt ----------------------------------------------------
 
     def build_lead_prompt(self, phase: PhaseDefinition) -> str:
-        """Build the full prompt for the Claude Code lead session.
-
-        This is the critical method — it produces the context injection
-        that turns a generic Claude session into a project-aware
-        orchestrator.
-
-        Args:
-            phase: The current phase to execute.
-
-        Returns:
-            A multi-section prompt string.
-        """
-        plan = self._plan
-        project_name = plan.frontmatter.project_name
-        sections: list[str] = []
-
-        # 1. Role
-        sections.append(dedent(f"""\
-            # Role
-
-            You are the Lead Orchestrator for project **{project_name}**.
-            Your job is to coordinate the agent team, enforce phase gates,
-            and drive the project to completion against the oracle metric.
-            You do NOT write code, train models, or compute metrics."""))
-
-        # 2. Plan context
-        oracle_text = plan.oracle.raw_content if plan.oracle else "Not defined"
-        sections.append(dedent(f"""\
-            # Plan Context
-
-            **Objective:** {plan.objective}
-
-            **Oracle:**
-            {oracle_text}
-
-            **Constraints:**
-            {plan.constraints}"""))
-
-        # 3. Current phase
-        subtask_list = "\n".join(f"- {s}" for s in phase.subtasks)
-        agent_list = ", ".join(phase.assigned_agents) or "none assigned"
-        sections.append(dedent(f"""\
-            # Current Phase: {phase.name} ({phase.phase_id})
-
-            {phase.description}
-
-            **Subtasks:**
-            {subtask_list}
-
-            **Assigned agents:** {agent_list}
-            **Gate type:** {phase.gate_type}
-            **Dependencies:** {', '.join(phase.depends_on) or 'none'}"""))
-
-        # 4. Agent contracts
-        if self._workflow:
-            contract_lines: list[str] = []
-            for c in self._workflow.agent_contracts:
-                if c.phase_id == phase.phase_id:
-                    contract_lines.append(
-                        f"### {c.agent_name}\n"
-                        f"Role: {c.role_description}\n"
-                        f"Owns: {', '.join(c.ownership) or 'n/a'}\n"
-                        f"Off-limits: {', '.join(c.off_limits) or 'n/a'}\n"
-                        f"Produces: {', '.join(c.contract_produced)}\n"
-                        f"Consumes: {', '.join(c.contract_consumed)}"
-                    )
-            if contract_lines:
-                sections.append(
-                    "# Agent Contracts\n\n" + "\n\n".join(contract_lines),
-                )
-
-        # 5. Agent roster
-        agents_dir = self._zo_root / ".claude" / "agents"
-        agent_files = sorted(agents_dir.glob("*.md")) if agents_dir.is_dir() else []
-        roster_lines = [f"- {f.stem}" for f in agent_files]
-        sections.append(
-            "# Agent Roster\n\n"
-            "Available agents in `.claude/agents/`:\n"
-            + "\n".join(roster_lines)
-            + "\n\nCreate new agent definitions if project requires "
-            "expertise not covered above."
-        )
-
-        # 6. Memory context
-        state = self.session_state
-        memory_lines = [
-            f"Mode: {state.mode}",
-            f"Phase: {state.phase}",
-            f"Blockers: {state.active_blockers or 'none'}",
+        """Build the full prompt for the Claude Code lead session."""
+        sections = [
+            self._prompt_role(), self._prompt_plan_context(),
+            self._prompt_phase(phase), self._prompt_contracts(phase),
+            self._prompt_roster(), self._prompt_memory(),
+            self._prompt_coordination(), self._prompt_gate_criteria(phase),
+            self._prompt_constraints(),
         ]
-        # Query semantic index for relevant past decisions
-        relevant = self._semantic.query(plan.objective, top_k=3)
-        if relevant:
-            memory_lines.append("\n**Relevant past decisions:**")
-            for r in relevant:
-                memory_lines.append(f"- [{r.score:.2f}] {r.entry.summary}")
-        sections.append(
-            "# Memory Context\n\n" + "\n".join(memory_lines),
-        )
-
-        # 7. Coordination instructions
-        sections.append(dedent("""\
-            # Coordination Instructions
-
-            - Use **TeamCreate** to create a named team for this phase.
-            - Spawn agents with **Agent(team_name=...)**.
-            - Agents communicate peer-to-peer via **SendMessage**.
-            - Define ALL integration contracts before parallel spawn.
-            - Log every decision to DECISION_LOG.md.
-            - Update STATE.md at every phase transition.
-            - Escalate to human if blockers persist after one debate round."""))
-
-        # 8. Gate criteria
-        if plan.oracle:
-            sections.append(dedent(f"""\
-                # Gate Criteria
-
-                **Primary metric:** {plan.oracle.primary_metric}
-                **Target threshold:** {plan.oracle.target_threshold}
-                **Evaluation method:** {plan.oracle.evaluation_method}
-                **Evaluation frequency:** {plan.oracle.evaluation_frequency}
-
-                Phase gate type: **{phase.gate_type}**
-                All subtasks must be complete and gate criteria met before
-                advancing to the next phase."""))
-
-        # 9. Constraints
-        if plan.constraints:
-            sections.append(f"# Constraints\n\n{plan.constraints}")
-
-        return "\n\n---\n\n".join(sections)
+        return "\n\n---\n\n".join(s for s in sections if s)
 
     # -- Phase management -----------------------------------------------------
 
     def get_current_phase(self) -> PhaseDefinition | None:
-        """Return the first phase that is PENDING with all dependencies met.
-
-        Returns:
-            The next actionable phase, or None if all are done/blocked.
-        """
+        """Return the first PENDING phase with all dependencies met."""
         if self._workflow is None:
             return None
-
         completed = {
-            p.phase_id
-            for p in self._workflow.phases
+            p.phase_id for p in self._workflow.phases
             if p.status == PhaseStatus.COMPLETED
         }
         for phase in self._workflow.phases:
@@ -657,74 +262,44 @@ class Orchestrator:
         return None
 
     def advance_phase(self, phase_id: str) -> GateEvaluation:
-        """Evaluate the gate for a phase and advance if criteria are met.
-
-        Args:
-            phase_id: The phase to evaluate.
-
-        Returns:
-            Gate evaluation result.
-
-        Raises:
-            ValueError: If the phase is not found.
-        """
+        """Evaluate the gate for a phase and advance if criteria are met."""
         phase = self._find_phase(phase_id)
-
-        # Check all subtasks are complete
         all_done = set(phase.subtasks) == set(phase.completed_subtasks)
 
         if phase.gate_type == GateType.BLOCKING:
-            evaluation = GateEvaluation(
-                phase_id=phase_id,
-                gate_type=GateType.BLOCKING,
+            ev = GateEvaluation(
+                phase_id=phase_id, gate_type=GateType.BLOCKING,
                 decision=GateDecision.HOLD,
                 rationale=(
-                    "Blocking gate requires human approval."
-                    if all_done
+                    "Blocking gate requires human approval." if all_done
                     else "Subtasks incomplete; blocking gate."
                 ),
                 requires_human=True,
             )
             if all_done:
                 phase.status = PhaseStatus.GATED
-            self._log_gate(evaluation)
-            return evaluation
+            self._log_gate(ev)
+            return ev
 
-        # Automated gate
         if all_done:
             phase.status = PhaseStatus.COMPLETED
-            evaluation = GateEvaluation(
-                phase_id=phase_id,
-                gate_type=GateType.AUTOMATED,
+            ev = GateEvaluation(
+                phase_id=phase_id, gate_type=GateType.AUTOMATED,
                 decision=GateDecision.PROCEED,
                 rationale="All subtasks complete; automated gate passed.",
-                requires_human=False,
             )
         else:
             remaining = set(phase.subtasks) - set(phase.completed_subtasks)
-            evaluation = GateEvaluation(
-                phase_id=phase_id,
-                gate_type=GateType.AUTOMATED,
+            ev = GateEvaluation(
+                phase_id=phase_id, gate_type=GateType.AUTOMATED,
                 decision=GateDecision.ITERATE,
                 rationale=f"Subtasks remaining: {', '.join(sorted(remaining))}",
-                requires_human=False,
             )
+        self._log_gate(ev)
+        return ev
 
-        self._log_gate(evaluation)
-        return evaluation
-
-    def mark_subtask_complete(
-        self, phase_id: str, subtask: str,
-    ) -> None:
-        """Mark a subtask as complete within a phase.
-
-        Args:
-            phase_id: Phase containing the subtask.
-            subtask: Name of the subtask to mark done.
-
-        Raises:
-            ValueError: If the phase or subtask is not found.
-        """
+    def mark_subtask_complete(self, phase_id: str, subtask: str) -> None:
+        """Mark a subtask as complete within a phase."""
         phase = self._find_phase(phase_id)
         if subtask not in phase.subtasks:
             raise ValueError(
@@ -733,101 +308,56 @@ class Orchestrator:
             )
         if subtask not in phase.completed_subtasks:
             phase.completed_subtasks.append(subtask)
-
-        # Update session state
         if self._session_state is not None:
             self._session_state.last_completed_subtask = subtask
             self._memory.write_state(self._session_state)
-
         self._comms.log_checkpoint(
-            agent="orchestrator",
-            phase=phase_id,
-            subtask=subtask,
-            progress=(
-                f"{len(phase.completed_subtasks)}/{len(phase.subtasks)} "
-                "subtasks complete"
-            ),
+            agent="orchestrator", phase=phase_id, subtask=subtask,
+            progress=f"{len(phase.completed_subtasks)}/{len(phase.subtasks)} subtasks complete",
         )
 
     # -- Plan edit detection --------------------------------------------------
 
     def check_plan_edited(self) -> bool:
-        """Check if the plan file has been modified since decomposition.
-
-        Returns:
-            True if the plan content hash differs from the stored hash.
-        """
-        current = self._compute_plan_hash()
-        return current != self._plan_hash
+        """Check if the plan file has been modified since decomposition."""
+        return self._compute_plan_hash() != self._plan_hash
 
     def replan(self, new_plan: Plan) -> WorkflowDecomposition:
-        """Re-decompose with an updated plan.
-
-        Args:
-            new_plan: The updated plan.
-
-        Returns:
-            New workflow decomposition.
-        """
+        """Re-decompose with an updated plan."""
         self._plan = new_plan
         self._plan_hash = self._compute_plan_hash()
-
         self._comms.log_decision(
-            agent="orchestrator",
-            title="Plan re-decomposed after edit",
+            agent="orchestrator", title="Plan re-decomposed after edit",
             rationale="Plan file changed; regenerating workflow.",
             outcome="replanned",
         )
-
         return self.decompose_plan()
 
     # -- Human checkpoints ----------------------------------------------------
 
     def prepare_gate_review(self, phase_id: str) -> dict[str, str]:
-        """Prepare a summary for human gate review.
-
-        Args:
-            phase_id: Phase to prepare review for.
-
-        Returns:
-            Dict with review sections (phase, subtasks, metrics, etc.).
-        """
+        """Prepare a summary for human gate review."""
         phase = self._find_phase(phase_id)
-        completed = ", ".join(phase.completed_subtasks) or "none"
-        remaining = ", ".join(
-            set(phase.subtasks) - set(phase.completed_subtasks),
-        ) or "none"
-
         review: dict[str, str] = {
             "phase": f"{phase.name} ({phase.phase_id})",
             "status": phase.status,
-            "completed_subtasks": completed,
-            "remaining_subtasks": remaining,
+            "completed_subtasks": ", ".join(phase.completed_subtasks) or "none",
+            "remaining_subtasks": ", ".join(
+                set(phase.subtasks) - set(phase.completed_subtasks),
+            ) or "none",
             "gate_type": phase.gate_type,
             "description": phase.description,
         }
-
         if self._plan.oracle:
             review["oracle_metric"] = self._plan.oracle.primary_metric
             review["target_threshold"] = self._plan.oracle.target_threshold
-
         return review
 
     def apply_human_decision(
-        self,
-        phase_id: str,
-        decision: GateDecision,
-        notes: str = "",
+        self, phase_id: str, decision: GateDecision, notes: str = "",
     ) -> None:
-        """Apply a human's gate decision to a phase.
-
-        Args:
-            phase_id: Phase the decision applies to.
-            decision: The human's decision.
-            notes: Optional notes from the reviewer.
-        """
+        """Apply a human's gate decision to a phase."""
         phase = self._find_phase(phase_id)
-
         if decision == GateDecision.PROCEED:
             phase.status = PhaseStatus.COMPLETED
         elif decision == GateDecision.ITERATE:
@@ -841,38 +371,21 @@ class Orchestrator:
         self._comms.log_decision(
             agent="orchestrator",
             title=f"Human decision on {phase_id}: {decision}",
-            rationale=notes or "Human reviewer decision.",
-            outcome=decision,
+            rationale=notes or "Human reviewer decision.", outcome=decision,
         )
-
         self._memory.append_decision(DecisionEntry(
             title=f"Human gate decision: {phase_id}",
             context=f"Phase: {phase.name}",
-            decision=decision,
-            rationale=notes,
-            outcome=decision,
+            decision=decision, rationale=notes, outcome=decision,
         ))
 
-    # -- Status queries -------------------------------------------------------
-
     def get_phase_status(self, phase_id: str) -> PhaseStatus:
-        """Return the status of a specific phase.
-
-        Args:
-            phase_id: Phase to query.
-
-        Returns:
-            Current phase status.
-
-        Raises:
-            ValueError: If the phase is not found.
-        """
+        """Return the status of a specific phase."""
         return self._find_phase(phase_id).status
 
     # -- Internal helpers -----------------------------------------------------
 
     def _find_phase(self, phase_id: str) -> PhaseDefinition:
-        """Locate a phase by ID, raising ValueError if not found."""
         if self._workflow is None:
             raise ValueError("Workflow not yet decomposed; call decompose_plan() first.")
         for phase in self._workflow.phases:
@@ -881,17 +394,11 @@ class Orchestrator:
         ids = [p.phase_id for p in self._workflow.phases]
         raise ValueError(f"Phase '{phase_id}' not found. Available: {ids}")
 
-    def _agents_for_phase(
-        self, phase_id: str, active_agents: list[str],
-    ) -> list[str]:
-        """Return active agents relevant to a given phase."""
-        return [
-            a for a in active_agents
-            if phase_id in _AGENT_PHASE_MAP.get(a, [])
-        ]
+    @staticmethod
+    def _agents_for_phase(phase_id: str, active_agents: list[str]) -> list[str]:
+        return [a for a in active_agents if phase_id in AGENT_PHASE_MAP.get(a, [])]
 
     def _compute_plan_hash(self) -> str:
-        """Hash the plan's source file content, or the objective as fallback."""
         if self._plan.source_path and self._plan.source_path.exists():
             content = self._plan.source_path.read_bytes()
         else:
@@ -899,17 +406,127 @@ class Orchestrator:
         return hashlib.sha256(content).hexdigest()
 
     def _log_gate(self, evaluation: GateEvaluation) -> None:
-        """Log a gate evaluation to comms and memory."""
         self._comms.log_decision(
             agent="orchestrator",
             title=f"Gate evaluation: {evaluation.phase_id}",
-            rationale=evaluation.rationale,
-            outcome=evaluation.decision,
+            rationale=evaluation.rationale, outcome=evaluation.decision,
         )
         self._memory.append_decision(DecisionEntry(
             title=f"Gate: {evaluation.phase_id} -> {evaluation.decision}",
             context=f"Gate type: {evaluation.gate_type}",
-            decision=evaluation.decision,
-            rationale=evaluation.rationale,
+            decision=evaluation.decision, rationale=evaluation.rationale,
             outcome=evaluation.decision,
         ))
+
+    # -- Prompt section builders ----------------------------------------------
+
+    def _prompt_role(self) -> str:
+        name = self._plan.frontmatter.project_name
+        return dedent(f"""\
+            # Role
+
+            You are the Lead Orchestrator for project **{name}**.
+            Your job is to coordinate the agent team, enforce phase gates,
+            and drive the project to completion against the oracle metric.
+            You do NOT write code, train models, or compute metrics.""")
+
+    def _prompt_plan_context(self) -> str:
+        p = self._plan
+        oracle_text = p.oracle.raw_content if p.oracle else "Not defined"
+        return dedent(f"""\
+            # Plan Context
+
+            **Objective:** {p.objective}
+
+            **Oracle:**
+            {oracle_text}
+
+            **Constraints:**
+            {p.constraints}""")
+
+    def _prompt_phase(self, phase: PhaseDefinition) -> str:
+        subtasks = "\n".join(f"- {s}" for s in phase.subtasks)
+        agents = ", ".join(phase.assigned_agents) or "none assigned"
+        deps = ", ".join(phase.depends_on) or "none"
+        return dedent(f"""\
+            # Current Phase: {phase.name} ({phase.phase_id})
+
+            {phase.description}
+
+            **Subtasks:**
+            {subtasks}
+
+            **Assigned agents:** {agents}
+            **Gate type:** {phase.gate_type}
+            **Dependencies:** {deps}""")
+
+    def _prompt_contracts(self, phase: PhaseDefinition) -> str:
+        if not self._workflow:
+            return ""
+        lines: list[str] = []
+        for c in self._workflow.agent_contracts:
+            if c.phase_id == phase.phase_id:
+                lines.append(
+                    f"### {c.agent_name}\nRole: {c.role_description}\n"
+                    f"Owns: {', '.join(c.ownership) or 'n/a'}\n"
+                    f"Off-limits: {', '.join(c.off_limits) or 'n/a'}\n"
+                    f"Produces: {', '.join(c.contract_produced)}\n"
+                    f"Consumes: {', '.join(c.contract_consumed)}"
+                )
+        return ("# Agent Contracts\n\n" + "\n\n".join(lines)) if lines else ""
+
+    def _prompt_roster(self) -> str:
+        agents_dir = self._zo_root / ".claude" / "agents"
+        files = sorted(agents_dir.glob("*.md")) if agents_dir.is_dir() else []
+        roster = [f"- {f.stem}" for f in files]
+        return (
+            "# Agent Roster\n\nAvailable agents in `.claude/agents/`:\n"
+            + "\n".join(roster)
+            + "\n\nCreate new agent definitions if project requires "
+            "expertise not covered above."
+        )
+
+    def _prompt_memory(self) -> str:
+        state = self.session_state
+        lines = [
+            f"Mode: {state.mode}", f"Phase: {state.phase}",
+            f"Blockers: {state.active_blockers or 'none'}",
+        ]
+        relevant = self._semantic.query(self._plan.objective, top_k=3)
+        if relevant:
+            lines.append("\n**Relevant past decisions:**")
+            for r in relevant:
+                lines.append(f"- [{r.score:.2f}] {r.entry.summary}")
+        return "# Memory Context\n\n" + "\n".join(lines)
+
+    @staticmethod
+    def _prompt_coordination() -> str:
+        return dedent("""\
+            # Coordination Instructions
+
+            - Use **TeamCreate** to create a named team for this phase.
+            - Spawn agents with **Agent(team_name=...)**.
+            - Agents communicate peer-to-peer via **SendMessage**.
+            - Define ALL integration contracts before parallel spawn.
+            - Log every decision to DECISION_LOG.md.
+            - Update STATE.md at every phase transition.
+            - Escalate to human if blockers persist after one debate round.""")
+
+    def _prompt_gate_criteria(self, phase: PhaseDefinition) -> str:
+        if not self._plan.oracle:
+            return ""
+        o = self._plan.oracle
+        return dedent(f"""\
+            # Gate Criteria
+
+            **Primary metric:** {o.primary_metric}
+            **Target threshold:** {o.target_threshold}
+            **Evaluation method:** {o.evaluation_method}
+            **Evaluation frequency:** {o.evaluation_frequency}
+
+            Phase gate type: **{phase.gate_type}**
+            All subtasks must be complete and gate criteria met before
+            advancing to the next phase.""")
+
+    def _prompt_constraints(self) -> str:
+        return f"# Constraints\n\n{self._plan.constraints}" if self._plan.constraints else ""

--- a/src/zo/wrapper.py
+++ b/src/zo/wrapper.py
@@ -1,0 +1,381 @@
+"""Lifecycle wrapper for Claude Code agent team sessions.
+
+Launches ONE Claude Code session (the Lead Orchestrator), then observes
+team activity by monitoring file-system artefacts and tmux panes.
+"""
+
+from __future__ import annotations
+
+import contextlib
+import json
+import os
+import random
+import re
+import signal
+import subprocess
+import time
+from datetime import UTC, datetime
+from pathlib import Path
+from typing import TYPE_CHECKING, Any
+
+from zo._wrapper_models import (
+    AgentStatus,
+    LeadProcess,
+    TeamMember,
+    TeamStatus,
+)
+
+if TYPE_CHECKING:
+    from zo.comms import CommsLogger
+
+__all__ = [
+    "LifecycleWrapper",
+    "AgentStatus",
+    "LeadProcess",
+    "TeamMember",
+    "TeamStatus",
+]
+
+_RATE_LIMIT_PATTERNS: list[re.Pattern[str]] = [
+    re.compile(r"429", re.IGNORECASE),
+    re.compile(r"rate.?limit", re.IGNORECASE),
+    re.compile(r"overloaded", re.IGNORECASE),
+    re.compile(r"too many requests", re.IGNORECASE),
+]
+
+
+class LifecycleWrapper:
+    """Manages the lifecycle of a Claude Code lead orchestrator session.
+
+    Args:
+        comms: CommsLogger instance for audit trail events.
+        claude_bin: Path or name of the ``claude`` CLI binary.
+        log_dir: Directory for stdout/stderr logs (default ``logs/wrapper``).
+        max_retries: Max retries on rate-limit errors.
+        base_backoff: Base backoff in seconds for rate-limit waits.
+    """
+
+    def __init__(
+        self,
+        comms: CommsLogger,
+        *,
+        claude_bin: str = "claude",
+        log_dir: Path | None = None,
+        max_retries: int = 3,
+        base_backoff: float = 30.0,
+    ) -> None:
+        self._comms = comms
+        self._claude_bin = claude_bin
+        self._log_dir = Path(log_dir) if log_dir else Path("logs/wrapper")
+        self._log_dir.mkdir(parents=True, exist_ok=True)
+        self._max_retries = max_retries
+        self._base_backoff = base_backoff
+
+    # --- Launch ---
+
+    def launch_lead_session(
+        self,
+        prompt: str,
+        *,
+        cwd: str,
+        team_name: str,
+        model: str = "opus",
+        max_turns: int = 200,
+        use_tmux: bool = True,
+    ) -> LeadProcess:
+        """Launch one Claude Code session as the Lead Orchestrator.
+
+        Starts a non-blocking subprocess with stdout/stderr tee'd to log files.
+        Returns a LeadProcess with pid and SPAWNING status.
+        """
+        cmd: list[str] = [
+            self._claude_bin, "--print",
+            "--output-format", "json",
+            "--model", model,
+            "--max-turns", str(max_turns),
+            "--cwd", cwd,
+        ]
+        if use_tmux:
+            cmd.extend(["--teammate-mode", "tmux"])
+        cmd.extend(["-p", prompt])
+
+        stdout_log = self._log_dir / f"{team_name}-stdout.log"
+        stderr_log = self._log_dir / f"{team_name}-stderr.log"
+        stdout_fh = open(stdout_log, "w", encoding="utf-8")  # noqa: SIM115
+        stderr_fh = open(stderr_log, "w", encoding="utf-8")  # noqa: SIM115
+
+        proc = subprocess.Popen(cmd, stdout=stdout_fh, stderr=stderr_fh, text=True)
+        lead = LeadProcess(
+            pid=proc.pid, status=AgentStatus.SPAWNING,
+            started_at=datetime.now(UTC), team_name=team_name,
+            stdout_log=stdout_log, stderr_log=stderr_log,
+        )
+        self._comms.log_checkpoint(
+            agent="wrapper", phase="launch", subtask="lead-session",
+            progress=f"Launched lead session pid={proc.pid} team={team_name}",
+        )
+        self._proc = proc
+        self._stdout_fh = stdout_fh
+        self._stderr_fh = stderr_fh
+        return lead
+
+    # --- Observe ---
+
+    def monitor_team(self, team_name: str) -> TeamStatus:
+        """Poll file-system artefacts for team member and task status.
+
+        Reads ``~/.claude/teams/{team_name}/config.json`` and task files.
+        Returns empty TeamStatus if the team directory doesn't exist yet.
+        """
+        members = self._read_team_config(team_name)
+        tasks = self.read_task_list(team_name)
+        completed = sum(1 for t in tasks if t.get("status") == "completed")
+        in_progress = sum(1 for t in tasks if t.get("status") == "in_progress")
+        pending = sum(1 for t in tasks if t.get("status") == "pending")
+        return TeamStatus(
+            team_name=team_name, members=members, tasks_total=len(tasks),
+            tasks_completed=completed, tasks_in_progress=in_progress,
+            tasks_pending=pending,
+            is_active=len(tasks) == 0 or in_progress > 0 or pending > 0,
+        )
+
+    def read_task_list(self, team_name: str) -> list[dict[str, Any]]:
+        """Read all task JSON files from ``~/.claude/tasks/{team_name}/``."""
+        tasks_dir = Path.home() / ".claude" / "tasks" / team_name
+        if not tasks_dir.is_dir():
+            return []
+        tasks: list[dict[str, Any]] = []
+        for path in sorted(tasks_dir.iterdir()):
+            if path.suffix != ".json":
+                continue
+            try:
+                tasks.append(json.loads(path.read_text(encoding="utf-8")))
+            except (json.JSONDecodeError, OSError):
+                continue
+        return tasks
+
+    def monitor_session_logs(self, session_dir: Path) -> list[dict[str, Any]]:
+        """Read JSONL session logs from a directory. Handles missing/empty gracefully."""
+        if not session_dir.is_dir():
+            return []
+        entries: list[dict[str, Any]] = []
+        for path in sorted(session_dir.glob("*.jsonl")):
+            try:
+                text = path.read_text(encoding="utf-8")
+            except OSError:
+                continue
+            for line in text.splitlines():
+                line = line.strip()
+                if not line:
+                    continue
+                try:
+                    entries.append(json.loads(line))
+                except json.JSONDecodeError:
+                    continue
+        return entries
+
+    def observe_tmux_panes(self) -> dict[str, str]:
+        """Capture output from all tmux panes. Returns empty dict if not in tmux."""
+        if not self._is_in_tmux():
+            return {}
+        result: dict[str, str] = {}
+        for pane in self._list_tmux_panes():
+            pane_id = pane.get("id", "")
+            if pane_id:
+                result[pane_id] = self._capture_tmux_pane(pane_id)
+        return result
+
+    # --- Lifecycle ---
+
+    def wait_for_completion(
+        self,
+        process: LeadProcess,
+        *,
+        poll_interval: float = 10.0,
+        timeout: float | None = None,
+    ) -> LeadProcess:
+        """Poll until the lead session subprocess completes.
+
+        Checks subprocess status, scans stdout for rate-limit patterns,
+        and retries with exponential backoff when rate-limited.
+        """
+        start_time = time.monotonic()
+        retries = 0
+        process = process.model_copy(update={"status": AgentStatus.RUNNING})
+
+        while True:
+            rc = self._proc.poll()
+            if rc is not None:
+                self._close_log_handles()
+                process = process.model_copy(update={
+                    "exit_code": rc, "completed_at": datetime.now(UTC),
+                    "status": AgentStatus.COMPLETED if rc == 0 else AgentStatus.ERRORED,
+                })
+                self._comms.log_checkpoint(
+                    agent="wrapper", phase="lifecycle", subtask="completion",
+                    progress=f"Lead session exited code={rc}",
+                )
+                return process
+
+            output = self._read_tail(process.stdout_log)
+            if self._detect_rate_limit(output):
+                if retries >= self._max_retries:
+                    process = process.model_copy(update={"status": AgentStatus.RATE_LIMITED})
+                    self._comms.log_error(
+                        agent="wrapper", error_type="rate_limit", severity="blocking",
+                        description=f"Rate limited after {retries} retries",
+                    )
+                    return process
+                wait_secs = self._backoff_wait(retries)
+                self._comms.log_checkpoint(
+                    agent="wrapper", phase="lifecycle", subtask="rate-limit-backoff",
+                    progress=f"Rate limited, retry {retries + 1}/{self._max_retries}, "
+                             f"waiting {wait_secs:.0f}s",
+                )
+                time.sleep(wait_secs)
+                retries += 1
+                continue
+
+            if timeout and (time.monotonic() - start_time) > timeout:
+                process = process.model_copy(update={"status": AgentStatus.TIMED_OUT})
+                self._comms.log_error(
+                    agent="wrapper", error_type="timeout", severity="blocking",
+                    description=f"Lead session timed out after {timeout}s",
+                )
+                return process
+            time.sleep(poll_interval)
+
+    def kill_session(self, process: LeadProcess) -> LeadProcess:
+        """Terminate the lead session. SIGTERM, wait 5s, SIGKILL if needed."""
+        if process.pid is None:
+            return process
+        with contextlib.suppress(ProcessLookupError):
+            os.kill(process.pid, signal.SIGTERM)
+        try:
+            self._proc.wait(timeout=5)
+        except subprocess.TimeoutExpired:
+            with contextlib.suppress(ProcessLookupError):
+                os.kill(process.pid, signal.SIGKILL)
+        self._close_log_handles()
+        self._comms.log_error(
+            agent="wrapper", error_type="session_killed", severity="warning",
+            description=f"Killed lead session pid={process.pid}",
+        )
+        return process.model_copy(update={
+            "status": AgentStatus.ERRORED,
+            "completed_at": datetime.now(UTC),
+            "exit_code": -9,
+        })
+
+    # --- Output parsing ---
+
+    def get_session_output(self, process: LeadProcess) -> str:
+        """Read the full stdout log file for a completed session."""
+        if process.stdout_log and process.stdout_log.exists():
+            return process.stdout_log.read_text(encoding="utf-8")
+        return ""
+
+    def parse_session_result(self, process: LeadProcess) -> dict[str, str]:
+        """Parse JSON output from --output-format json.
+
+        Returns dict with result, cost_usd, model, num_turns.
+        Falls back to {"result": raw_text} if JSON parsing fails.
+        """
+        raw = self.get_session_output(process)
+        if not raw:
+            return {"result": ""}
+        try:
+            data = json.loads(raw)
+            return {
+                "result": str(data.get("result", "")),
+                "cost_usd": str(data.get("cost_usd", "")),
+                "model": str(data.get("model", "")),
+                "num_turns": str(data.get("num_turns", "")),
+            }
+        except (json.JSONDecodeError, ValueError):
+            return {"result": raw}
+
+    # --- Private: rate limit handling ---
+
+    @staticmethod
+    def _detect_rate_limit(output: str) -> bool:
+        """Return True if output contains rate-limit / overload patterns."""
+        return any(pat.search(output) for pat in _RATE_LIMIT_PATTERNS)
+
+    def _backoff_wait(self, attempt: int) -> float:
+        """Exponential backoff: base * 2^attempt + random(0, 5)."""
+        return self._base_backoff * (2 ** attempt) + random.uniform(0, 5)
+
+    # --- Private: tmux helpers ---
+
+    @staticmethod
+    def _is_in_tmux() -> bool:
+        """Check if the current process is inside a tmux session."""
+        return "TMUX" in os.environ
+
+    @staticmethod
+    def _list_tmux_panes() -> list[dict[str, str]]:
+        """List all tmux panes with their IDs and titles."""
+        try:
+            result = subprocess.run(
+                ["tmux", "list-panes", "-a", "-F", "#{pane_id}|#{pane_title}"],
+                capture_output=True, text=True, timeout=5,
+            )
+        except (FileNotFoundError, subprocess.TimeoutExpired):
+            return []
+        if result.returncode != 0:
+            return []
+        panes: list[dict[str, str]] = []
+        for line in result.stdout.strip().splitlines():
+            parts = line.split("|", 1)
+            if len(parts) == 2:
+                panes.append({"id": parts[0], "title": parts[1]})
+        return panes
+
+    @staticmethod
+    def _capture_tmux_pane(pane_id: str, lines: int = 50) -> str:
+        """Capture last N lines from a tmux pane."""
+        try:
+            result = subprocess.run(
+                ["tmux", "capture-pane", "-p", "-t", pane_id, "-S", f"-{lines}"],
+                capture_output=True, text=True, timeout=5,
+            )
+        except (FileNotFoundError, subprocess.TimeoutExpired):
+            return ""
+        return result.stdout if result.returncode == 0 else ""
+
+    # --- Private: helpers ---
+
+    def _read_team_config(self, team_name: str) -> list[TeamMember]:
+        """Read team config.json and return a list of TeamMember."""
+        config_path = Path.home() / ".claude" / "teams" / team_name / "config.json"
+        if not config_path.exists():
+            return []
+        try:
+            data = json.loads(config_path.read_text(encoding="utf-8"))
+        except (json.JSONDecodeError, OSError):
+            return []
+        return [
+            TeamMember(
+                name=m.get("name", "unknown"), agent_type=m.get("agent_type", ""),
+                status=m.get("status", "unknown"), current_task=m.get("current_task", ""),
+            )
+            for m in data.get("members", [])
+        ]
+
+    @staticmethod
+    def _read_tail(path: Path | None, lines: int = 100) -> str:
+        """Read the last N lines of a file."""
+        if not path or not path.exists():
+            return ""
+        try:
+            text = path.read_text(encoding="utf-8")
+            return "\n".join(text.splitlines()[-lines:])
+        except OSError:
+            return ""
+
+    def _close_log_handles(self) -> None:
+        """Close stdout/stderr file handles if open."""
+        for fh in (getattr(self, "_stdout_fh", None), getattr(self, "_stderr_fh", None)):
+            if fh and not fh.closed:
+                fh.close()

--- a/tests/unit/test_orchestrator.py
+++ b/tests/unit/test_orchestrator.py
@@ -1,0 +1,584 @@
+"""Unit tests for the orchestrator (zo.orchestrator).
+
+Uses the test fixture at tests/fixtures/test-project/plan.md for
+happy-path tests, plus synthetic plans for edge cases.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from zo._orchestrator_models import (
+    AgentContract,
+    GateDecision,
+    GateType,
+    PhaseDefinition,
+    PhaseStatus,
+    WorkflowDecomposition,
+)
+from zo.comms import CommsLogger
+from zo.memory import MemoryManager
+from zo.orchestrator import Orchestrator
+from zo.plan import Plan, WorkflowMode, parse_plan
+from zo.semantic import SemanticIndex
+from zo.target import TargetConfig
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+FIXTURE_PLAN = REPO_ROOT / "tests" / "fixtures" / "test-project" / "plan.md"
+
+
+def _make_target() -> TargetConfig:
+    """Create a minimal TargetConfig for testing."""
+    return TargetConfig(
+        project="test-project",
+        target_repo="/tmp/fake-repo",
+        target_branch="main",
+        worktree_base="/tmp/worktrees",
+        git_author_name="ZO Test",
+        git_author_email="zo@test.dev",
+        agent_working_dirs={},
+        zo_only_paths=[".zo/"],
+        enforce_isolation=False,
+    )
+
+
+@pytest.fixture()
+def plan() -> Plan:
+    """Parsed plan from the test fixture."""
+    assert FIXTURE_PLAN.exists(), f"Fixture not found: {FIXTURE_PLAN}"
+    return parse_plan(FIXTURE_PLAN)
+
+
+@pytest.fixture()
+def orchestrator(plan: Plan, tmp_path: Path) -> Orchestrator:
+    """Fully wired Orchestrator with temp directories."""
+    target = _make_target()
+    memory = MemoryManager(
+        project_dir=tmp_path, project_name="test-project",
+    )
+    memory.initialize_project()
+    comms = CommsLogger(
+        log_dir=tmp_path / "logs" / "comms",
+        project="test-project",
+        session_id="test-session-001",
+    )
+    semantic = SemanticIndex(db_path=tmp_path / "index.db")
+
+    # Use the repo root as zo_root so agent roster discovery works
+    return Orchestrator(
+        plan=plan,
+        target=target,
+        memory=memory,
+        comms=comms,
+        semantic=semantic,
+        zo_root=REPO_ROOT,
+    )
+
+
+# ---------------------------------------------------------------------------
+# decompose_plan — all 3 workflow modes
+# ---------------------------------------------------------------------------
+
+
+class TestDecomposePlan:
+    """Tests for Orchestrator.decompose_plan()."""
+
+    def test_classical_ml_phases(self, orchestrator: Orchestrator) -> None:
+        """classical_ml mode produces 6 phases (phase_1 through phase_6)."""
+        decomp = orchestrator.decompose_plan()
+        assert isinstance(decomp, WorkflowDecomposition)
+        assert decomp.mode == WorkflowMode.CLASSICAL_ML
+        assert len(decomp.phases) == 6
+        ids = [p.phase_id for p in decomp.phases]
+        assert ids == [f"phase_{i}" for i in range(1, 7)]
+
+    def test_deep_learning_phases(
+        self, plan: Plan, tmp_path: Path,
+    ) -> None:
+        """deep_learning mode produces 6 phases with DL-specific names."""
+        plan.workflow.mode = WorkflowMode.DEEP_LEARNING  # type: ignore[union-attr]
+        orch = _make_orchestrator(plan, tmp_path)
+        decomp = orch.decompose_plan()
+        assert decomp.mode == WorkflowMode.DEEP_LEARNING
+        assert len(decomp.phases) == 6
+        assert "Input Representation" in decomp.phases[1].name
+        assert "Deep Learning" in decomp.phases[2].name
+
+    def test_research_phases(
+        self, plan: Plan, tmp_path: Path,
+    ) -> None:
+        """research mode adds phase_0 for literature review (7 total)."""
+        plan.workflow.mode = WorkflowMode.RESEARCH  # type: ignore[union-attr]
+        orch = _make_orchestrator(plan, tmp_path)
+        decomp = orch.decompose_plan()
+        assert decomp.mode == WorkflowMode.RESEARCH
+        assert len(decomp.phases) == 7
+        assert decomp.phases[0].phase_id == "phase_0"
+        assert "Literature" in decomp.phases[0].name
+        # phase_1 depends on phase_0
+        assert "phase_0" in decomp.phases[1].depends_on
+
+    def test_agents_assigned_to_phases(
+        self, orchestrator: Orchestrator,
+    ) -> None:
+        """Active agents are assigned to their relevant phases."""
+        decomp = orchestrator.decompose_plan()
+        # data-engineer should be in phase_1 and phase_2
+        phase_1 = decomp.phases[0]
+        assert "data-engineer" in phase_1.assigned_agents
+
+    def test_contracts_generated(self, orchestrator: Orchestrator) -> None:
+        """Contracts are generated for every agent-phase pair."""
+        decomp = orchestrator.decompose_plan()
+        assert len(decomp.agent_contracts) > 0
+        for c in decomp.agent_contracts:
+            assert isinstance(c, AgentContract)
+            assert c.agent_name
+            assert c.phase_id
+
+
+# ---------------------------------------------------------------------------
+# generate_agent_contract
+# ---------------------------------------------------------------------------
+
+
+class TestGenerateAgentContract:
+    """Tests for Orchestrator.generate_agent_contract()."""
+
+    def test_contract_structure(self, orchestrator: Orchestrator) -> None:
+        """Generated contract has all required fields populated."""
+        phase = PhaseDefinition(
+            phase_id="phase_1",
+            name="Test Phase",
+            description="Testing",
+            subtasks=["task1"],
+            gate_type=GateType.AUTOMATED,
+        )
+        contract = orchestrator.generate_agent_contract("data-engineer", phase)
+        assert contract.agent_name == "data-engineer"
+        assert contract.phase_id == "phase_1"
+        assert contract.role_description
+        assert len(contract.ownership) > 0
+        assert len(contract.validation_checklist) > 0
+        assert len(contract.coordination_rules) > 0
+
+    def test_unknown_agent_gets_default(
+        self, orchestrator: Orchestrator,
+    ) -> None:
+        """An unrecognised agent name still produces a valid contract."""
+        phase = PhaseDefinition(
+            phase_id="phase_1",
+            name="Test",
+            description="Test",
+            subtasks=[],
+            gate_type=GateType.AUTOMATED,
+        )
+        contract = orchestrator.generate_agent_contract("custom-agent", phase)
+        assert contract.agent_name == "custom-agent"
+        assert "custom-agent" in contract.role_description
+
+
+# ---------------------------------------------------------------------------
+# build_lead_prompt
+# ---------------------------------------------------------------------------
+
+
+class TestBuildLeadPrompt:
+    """Tests for Orchestrator.build_lead_prompt()."""
+
+    def test_includes_required_sections(
+        self, orchestrator: Orchestrator,
+    ) -> None:
+        """Prompt includes all 9 required sections."""
+        decomp = orchestrator.decompose_plan()
+        prompt = orchestrator.build_lead_prompt(decomp.phases[0])
+
+        assert "# Role" in prompt
+        assert "# Plan Context" in prompt
+        assert "# Current Phase" in prompt
+        assert "# Agent Roster" in prompt
+        assert "# Memory Context" in prompt
+        assert "# Coordination Instructions" in prompt
+        assert "# Gate Criteria" in prompt
+        assert "# Constraints" in prompt
+
+    def test_includes_project_name(
+        self, orchestrator: Orchestrator,
+    ) -> None:
+        """Prompt contains the project name from plan frontmatter."""
+        decomp = orchestrator.decompose_plan()
+        prompt = orchestrator.build_lead_prompt(decomp.phases[0])
+        assert "churn-prediction" in prompt
+
+    def test_includes_phase_info(
+        self, orchestrator: Orchestrator,
+    ) -> None:
+        """Prompt contains the current phase name and subtasks."""
+        decomp = orchestrator.decompose_plan()
+        phase = decomp.phases[0]
+        prompt = orchestrator.build_lead_prompt(phase)
+        assert phase.name in prompt
+        assert phase.phase_id in prompt
+        for subtask in phase.subtasks[:3]:
+            assert subtask in prompt
+
+    def test_includes_agent_roster(
+        self, orchestrator: Orchestrator,
+    ) -> None:
+        """Prompt lists available agents from .claude/agents/."""
+        decomp = orchestrator.decompose_plan()
+        prompt = orchestrator.build_lead_prompt(decomp.phases[0])
+        assert "data-engineer" in prompt
+        assert "model-builder" in prompt
+
+    def test_includes_coordination_instructions(
+        self, orchestrator: Orchestrator,
+    ) -> None:
+        """Prompt includes TeamCreate and SendMessage instructions."""
+        decomp = orchestrator.decompose_plan()
+        prompt = orchestrator.build_lead_prompt(decomp.phases[0])
+        assert "TeamCreate" in prompt
+        assert "SendMessage" in prompt
+
+    def test_includes_oracle_info(
+        self, orchestrator: Orchestrator,
+    ) -> None:
+        """Prompt includes oracle metric and threshold."""
+        decomp = orchestrator.decompose_plan()
+        prompt = orchestrator.build_lead_prompt(decomp.phases[0])
+        assert "ROC-AUC" in prompt
+
+
+# ---------------------------------------------------------------------------
+# start_session — fresh vs recovered
+# ---------------------------------------------------------------------------
+
+
+class TestStartSession:
+    """Tests for session lifecycle."""
+
+    def test_fresh_session(self, orchestrator: Orchestrator) -> None:
+        """Fresh session starts in BUILD mode at init phase."""
+        state = orchestrator.start_session()
+        assert state.mode == "build"
+        assert state.phase == "init"
+
+    def test_recovered_session(
+        self, plan: Plan, tmp_path: Path,
+    ) -> None:
+        """Recovered session continues from previous state."""
+        orch = _make_orchestrator(plan, tmp_path)
+        # Write a non-init state first
+        from zo._memory_models import SessionState
+
+        prior_state = SessionState(phase="phase_2", mode="continue")
+        orch._memory.write_state(prior_state)
+
+        state = orch.start_session()
+        assert state.mode == "continue"
+        assert state.phase == "phase_2"
+
+
+# ---------------------------------------------------------------------------
+# advance_phase — automated and blocking gates
+# ---------------------------------------------------------------------------
+
+
+class TestAdvancePhase:
+    """Tests for Orchestrator.advance_phase()."""
+
+    def test_automated_gate_pass(self, orchestrator: Orchestrator) -> None:
+        """Automated gate with all subtasks done -> PROCEED."""
+        decomp = orchestrator.decompose_plan()
+        phase = decomp.phases[0]  # phase_1, automated gate
+        # Complete all subtasks
+        for subtask in phase.subtasks:
+            orchestrator.mark_subtask_complete(phase.phase_id, subtask)
+
+        result = orchestrator.advance_phase(phase.phase_id)
+        assert result.decision == GateDecision.PROCEED
+        assert result.requires_human is False
+        assert phase.status == PhaseStatus.COMPLETED
+
+    def test_automated_gate_fail(self, orchestrator: Orchestrator) -> None:
+        """Automated gate with incomplete subtasks -> ITERATE."""
+        decomp = orchestrator.decompose_plan()
+        phase = decomp.phases[0]
+        # Complete only first subtask
+        orchestrator.mark_subtask_complete(phase.phase_id, phase.subtasks[0])
+
+        result = orchestrator.advance_phase(phase.phase_id)
+        assert result.decision == GateDecision.ITERATE
+        assert result.requires_human is False
+
+    def test_blocking_gate_returns_hold(
+        self, orchestrator: Orchestrator,
+    ) -> None:
+        """Blocking gate always returns HOLD, even when subtasks complete."""
+        decomp = orchestrator.decompose_plan()
+        # phase_2 is a blocking gate
+        phase_2 = decomp.phases[1]
+        for subtask in phase_2.subtasks:
+            orchestrator.mark_subtask_complete(phase_2.phase_id, subtask)
+
+        result = orchestrator.advance_phase(phase_2.phase_id)
+        assert result.decision == GateDecision.HOLD
+        assert result.requires_human is True
+        assert phase_2.status == PhaseStatus.GATED
+
+
+# ---------------------------------------------------------------------------
+# mark_subtask_complete
+# ---------------------------------------------------------------------------
+
+
+class TestMarkSubtaskComplete:
+    """Tests for Orchestrator.mark_subtask_complete()."""
+
+    def test_marks_subtask(self, orchestrator: Orchestrator) -> None:
+        """Subtask is added to completed list."""
+        decomp = orchestrator.decompose_plan()
+        phase = decomp.phases[0]
+        orchestrator.mark_subtask_complete(phase.phase_id, phase.subtasks[0])
+        assert phase.subtasks[0] in phase.completed_subtasks
+
+    def test_idempotent(self, orchestrator: Orchestrator) -> None:
+        """Marking the same subtask twice doesn't duplicate."""
+        decomp = orchestrator.decompose_plan()
+        phase = decomp.phases[0]
+        orchestrator.mark_subtask_complete(phase.phase_id, phase.subtasks[0])
+        orchestrator.mark_subtask_complete(phase.phase_id, phase.subtasks[0])
+        assert phase.completed_subtasks.count(phase.subtasks[0]) == 1
+
+    def test_invalid_subtask_raises(
+        self, orchestrator: Orchestrator,
+    ) -> None:
+        """Unknown subtask name raises ValueError."""
+        orchestrator.decompose_plan()
+        with pytest.raises(ValueError, match="not found"):
+            orchestrator.mark_subtask_complete("phase_1", "nonexistent-task")
+
+
+# ---------------------------------------------------------------------------
+# check_plan_edited
+# ---------------------------------------------------------------------------
+
+
+class TestCheckPlanEdited:
+    """Tests for Orchestrator.check_plan_edited()."""
+
+    def test_unchanged(self, orchestrator: Orchestrator) -> None:
+        """Returns False when plan hasn't changed."""
+        assert orchestrator.check_plan_edited() is False
+
+    def test_detects_change(
+        self, orchestrator: Orchestrator, tmp_path: Path,
+    ) -> None:
+        """Returns True when plan source file is modified."""
+        # Mutate the objective to change the hash
+        orchestrator._plan.objective = "COMPLETELY NEW OBJECTIVE"
+        orchestrator._plan.source_path = None  # force fallback to objective
+        assert orchestrator.check_plan_edited() is True
+
+
+# ---------------------------------------------------------------------------
+# get_current_phase — dependency respect
+# ---------------------------------------------------------------------------
+
+
+class TestGetCurrentPhase:
+    """Tests for Orchestrator.get_current_phase()."""
+
+    def test_returns_first_pending(
+        self, orchestrator: Orchestrator,
+    ) -> None:
+        """Returns the first phase with met dependencies."""
+        orchestrator.decompose_plan()
+        phase = orchestrator.get_current_phase()
+        assert phase is not None
+        assert phase.phase_id == "phase_1"
+
+    def test_skips_blocked_dependency(
+        self, orchestrator: Orchestrator,
+    ) -> None:
+        """Does not return phase_2 until phase_1 is completed."""
+        decomp = orchestrator.decompose_plan()
+        # phase_2 depends on phase_1 which is still PENDING
+        # So get_current_phase should return phase_1, not phase_2
+        phase = orchestrator.get_current_phase()
+        assert phase is not None
+        assert phase.phase_id == "phase_1"
+
+    def test_advances_after_completion(
+        self, orchestrator: Orchestrator,
+    ) -> None:
+        """After completing phase_1, get_current_phase returns phase_2."""
+        decomp = orchestrator.decompose_plan()
+        decomp.phases[0].status = PhaseStatus.COMPLETED
+        phase = orchestrator.get_current_phase()
+        assert phase is not None
+        assert phase.phase_id == "phase_2"
+
+    def test_returns_none_when_all_done(
+        self, orchestrator: Orchestrator,
+    ) -> None:
+        """Returns None when all phases are completed."""
+        decomp = orchestrator.decompose_plan()
+        for p in decomp.phases:
+            p.status = PhaseStatus.COMPLETED
+        assert orchestrator.get_current_phase() is None
+
+    def test_returns_none_without_decomposition(
+        self, orchestrator: Orchestrator,
+    ) -> None:
+        """Returns None when workflow hasn't been decomposed."""
+        assert orchestrator.get_current_phase() is None
+
+
+# ---------------------------------------------------------------------------
+# Phase status transitions
+# ---------------------------------------------------------------------------
+
+
+class TestPhaseStatusTransitions:
+    """Tests for phase status management."""
+
+    def test_initial_status_is_pending(
+        self, orchestrator: Orchestrator,
+    ) -> None:
+        """All phases start as PENDING."""
+        decomp = orchestrator.decompose_plan()
+        for phase in decomp.phases:
+            assert phase.status == PhaseStatus.PENDING
+
+    def test_automated_gate_sets_completed(
+        self, orchestrator: Orchestrator,
+    ) -> None:
+        """Passing an automated gate sets status to COMPLETED."""
+        decomp = orchestrator.decompose_plan()
+        phase = decomp.phases[0]
+        for s in phase.subtasks:
+            orchestrator.mark_subtask_complete(phase.phase_id, s)
+        orchestrator.advance_phase(phase.phase_id)
+        assert phase.status == PhaseStatus.COMPLETED
+
+    def test_blocking_gate_sets_gated(
+        self, orchestrator: Orchestrator,
+    ) -> None:
+        """Blocking gate with all subtasks done sets status to GATED."""
+        decomp = orchestrator.decompose_plan()
+        phase_2 = decomp.phases[1]
+        for s in phase_2.subtasks:
+            orchestrator.mark_subtask_complete(phase_2.phase_id, s)
+        orchestrator.advance_phase(phase_2.phase_id)
+        assert phase_2.status == PhaseStatus.GATED
+
+    def test_human_proceed_sets_completed(
+        self, orchestrator: Orchestrator,
+    ) -> None:
+        """Human PROCEED decision completes a gated phase."""
+        decomp = orchestrator.decompose_plan()
+        phase_2 = decomp.phases[1]
+        phase_2.status = PhaseStatus.GATED
+        orchestrator.apply_human_decision(
+            phase_2.phase_id, GateDecision.PROCEED, "Looks good",
+        )
+        assert phase_2.status == PhaseStatus.COMPLETED
+
+    def test_human_iterate_resets(
+        self, orchestrator: Orchestrator,
+    ) -> None:
+        """Human ITERATE decision resets phase to ACTIVE."""
+        decomp = orchestrator.decompose_plan()
+        phase_2 = decomp.phases[1]
+        phase_2.status = PhaseStatus.GATED
+        phase_2.completed_subtasks = list(phase_2.subtasks)
+        orchestrator.apply_human_decision(
+            phase_2.phase_id, GateDecision.ITERATE, "Needs work",
+        )
+        assert phase_2.status == PhaseStatus.ACTIVE
+        assert phase_2.completed_subtasks == []
+
+    def test_get_phase_status(self, orchestrator: Orchestrator) -> None:
+        """get_phase_status returns the correct status."""
+        decomp = orchestrator.decompose_plan()
+        assert orchestrator.get_phase_status("phase_1") == PhaseStatus.PENDING
+        decomp.phases[0].status = PhaseStatus.ACTIVE
+        assert orchestrator.get_phase_status("phase_1") == PhaseStatus.ACTIVE
+
+    def test_get_phase_status_invalid(
+        self, orchestrator: Orchestrator,
+    ) -> None:
+        """get_phase_status raises for unknown phase_id."""
+        orchestrator.decompose_plan()
+        with pytest.raises(ValueError, match="not found"):
+            orchestrator.get_phase_status("phase_99")
+
+
+# ---------------------------------------------------------------------------
+# end_session
+# ---------------------------------------------------------------------------
+
+
+class TestEndSession:
+    """Tests for Orchestrator.end_session()."""
+
+    def test_end_session_writes_state(
+        self, orchestrator: Orchestrator,
+    ) -> None:
+        """end_session persists state and logs decision."""
+        orchestrator.start_session()
+        orchestrator.end_session()
+        # State file should exist
+        state_path = orchestrator._memory.memory_root / "STATE.md"
+        assert state_path.exists()
+
+    def test_end_session_with_summary(
+        self, orchestrator: Orchestrator,
+    ) -> None:
+        """end_session writes a session summary when provided."""
+        from zo._memory_models import SessionSummary
+
+        orchestrator.start_session()
+        summary = SessionSummary(
+            accomplished=["Completed phase 1"],
+            next_steps=["Start phase 2"],
+        )
+        orchestrator.end_session(summary=summary)
+        sessions_dir = orchestrator._memory.memory_root / "sessions"
+        summaries = list(sessions_dir.glob("session-*.md"))
+        assert len(summaries) == 1
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _make_orchestrator(plan: Plan, tmp_path: Path) -> Orchestrator:
+    """Create an Orchestrator with temp directories."""
+    target = _make_target()
+    memory = MemoryManager(
+        project_dir=tmp_path, project_name="test-project",
+    )
+    memory.initialize_project()
+    comms = CommsLogger(
+        log_dir=tmp_path / "logs" / "comms",
+        project="test-project",
+        session_id="test-session-001",
+    )
+    semantic = SemanticIndex(db_path=tmp_path / "index.db")
+    return Orchestrator(
+        plan=plan,
+        target=target,
+        memory=memory,
+        comms=comms,
+        semantic=semantic,
+        zo_root=REPO_ROOT,
+    )

--- a/tests/unit/test_orchestrator.py
+++ b/tests/unit/test_orchestrator.py
@@ -408,7 +408,7 @@ class TestGetCurrentPhase:
         self, orchestrator: Orchestrator,
     ) -> None:
         """Does not return phase_2 until phase_1 is completed."""
-        decomp = orchestrator.decompose_plan()
+        orchestrator.decompose_plan()
         # phase_2 depends on phase_1 which is still PENDING
         # So get_current_phase should return phase_1, not phase_2
         phase = orchestrator.get_current_phase()

--- a/tests/unit/test_wrapper.py
+++ b/tests/unit/test_wrapper.py
@@ -1,0 +1,515 @@
+"""Unit tests for zo.wrapper and zo._wrapper_models."""
+
+from __future__ import annotations
+
+import json
+import os
+import signal
+import subprocess
+from datetime import UTC, datetime
+from pathlib import Path
+from unittest import mock
+
+import pytest
+
+from zo._wrapper_models import (
+    AgentStatus,
+    LeadProcess,
+    TeamMember,
+    TeamStatus,
+)
+from zo.comms import CommsLogger
+from zo.wrapper import LifecycleWrapper
+
+
+# ------------------------------------------------------------------ #
+# Fixtures
+# ------------------------------------------------------------------ #
+
+
+@pytest.fixture()
+def tmp_log_dir(tmp_path: Path) -> Path:
+    d = tmp_path / "logs" / "wrapper"
+    d.mkdir(parents=True)
+    return d
+
+
+@pytest.fixture()
+def comms(tmp_path: Path) -> CommsLogger:
+    return CommsLogger(
+        log_dir=tmp_path / "comms",
+        project="test-project",
+        session_id="test-session",
+    )
+
+
+@pytest.fixture()
+def wrapper(comms: CommsLogger, tmp_log_dir: Path) -> LifecycleWrapper:
+    return LifecycleWrapper(comms, log_dir=tmp_log_dir)
+
+
+# ------------------------------------------------------------------ #
+# Model tests
+# ------------------------------------------------------------------ #
+
+
+class TestModels:
+    def test_agent_status_values(self) -> None:
+        assert AgentStatus.SPAWNING == "spawning"
+        assert AgentStatus.RATE_LIMITED == "rate_limited"
+
+    def test_lead_process_defaults(self) -> None:
+        lp = LeadProcess()
+        assert lp.pid is None
+        assert lp.status == AgentStatus.SPAWNING
+        assert lp.exit_code is None
+        assert lp.team_name == ""
+
+    def test_lead_process_with_values(self) -> None:
+        lp = LeadProcess(
+            pid=1234,
+            status=AgentStatus.RUNNING,
+            team_name="alpha",
+            stdout_log=Path("/tmp/out.log"),
+        )
+        assert lp.pid == 1234
+        assert lp.stdout_log == Path("/tmp/out.log")
+
+    def test_team_member_defaults(self) -> None:
+        m = TeamMember(name="builder")
+        assert m.agent_type == ""
+        assert m.status == "unknown"
+
+    def test_team_status_defaults(self) -> None:
+        ts = TeamStatus(team_name="alpha")
+        assert ts.members == []
+        assert ts.tasks_total == 0
+        assert ts.is_active is True
+
+
+# ------------------------------------------------------------------ #
+# launch_lead_session
+# ------------------------------------------------------------------ #
+
+
+class TestLaunchLeadSession:
+    @mock.patch("zo.wrapper.subprocess.Popen")
+    def test_builds_correct_command(
+        self, mock_popen: mock.MagicMock, wrapper: LifecycleWrapper
+    ) -> None:
+        mock_popen.return_value.pid = 42
+
+        result = wrapper.launch_lead_session(
+            "do the thing",
+            cwd="/target",
+            team_name="alpha",
+            model="opus",
+            max_turns=100,
+            use_tmux=True,
+        )
+
+        args = mock_popen.call_args
+        cmd = args[0][0]
+        assert cmd[0] == "claude"
+        assert "--print" in cmd
+        assert "--output-format" in cmd
+        assert "json" in cmd
+        assert "--model" in cmd
+        assert "opus" in cmd
+        assert "--max-turns" in cmd
+        assert "100" in cmd
+        assert "--cwd" in cmd
+        assert "/target" in cmd
+        assert "--teammate-mode" in cmd
+        assert "tmux" in cmd
+        assert "-p" in cmd
+        assert "do the thing" in cmd
+
+        assert result.pid == 42
+        assert result.status == AgentStatus.SPAWNING
+        assert result.team_name == "alpha"
+        assert result.stdout_log is not None
+
+    @mock.patch("zo.wrapper.subprocess.Popen")
+    def test_no_tmux_flag_when_disabled(
+        self, mock_popen: mock.MagicMock, wrapper: LifecycleWrapper
+    ) -> None:
+        mock_popen.return_value.pid = 10
+        wrapper.launch_lead_session(
+            "prompt", cwd="/cwd", team_name="t", use_tmux=False
+        )
+
+        cmd = mock_popen.call_args[0][0]
+        assert "--teammate-mode" not in cmd
+        assert "tmux" not in cmd
+
+
+# ------------------------------------------------------------------ #
+# monitor_team / read_task_list
+# ------------------------------------------------------------------ #
+
+
+class TestMonitorTeam:
+    def test_returns_empty_when_no_dir(
+        self, wrapper: LifecycleWrapper, tmp_path: Path
+    ) -> None:
+        with mock.patch("zo.wrapper.Path.home", return_value=tmp_path):
+            status = wrapper.monitor_team("nonexistent")
+            assert status.team_name == "nonexistent"
+            assert status.members == []
+            assert status.tasks_total == 0
+            assert status.is_active is True
+
+    def test_reads_team_config_and_tasks(
+        self, wrapper: LifecycleWrapper, tmp_path: Path
+    ) -> None:
+        team_dir = tmp_path / ".claude" / "teams" / "alpha"
+        team_dir.mkdir(parents=True)
+        config = {
+            "members": [
+                {"name": "builder", "agent_type": "backend", "status": "running"},
+                {"name": "oracle", "agent_type": "qa", "status": "idle"},
+            ]
+        }
+        (team_dir / "config.json").write_text(json.dumps(config))
+
+        tasks_dir = tmp_path / ".claude" / "tasks" / "alpha"
+        tasks_dir.mkdir(parents=True)
+        (tasks_dir / "task-1.json").write_text(
+            json.dumps({"id": "1", "status": "completed", "owner": "builder", "content": "do X"})
+        )
+        (tasks_dir / "task-2.json").write_text(
+            json.dumps({"id": "2", "status": "in_progress", "owner": "oracle", "content": "do Y"})
+        )
+        (tasks_dir / "task-3.json").write_text(
+            json.dumps({"id": "3", "status": "pending", "owner": "", "content": "do Z"})
+        )
+
+        with mock.patch("zo.wrapper.Path.home", return_value=tmp_path):
+            status = wrapper.monitor_team("alpha")
+
+        assert len(status.members) == 2
+        assert status.members[0].name == "builder"
+        assert status.tasks_total == 3
+        assert status.tasks_completed == 1
+        assert status.tasks_in_progress == 1
+        assert status.tasks_pending == 1
+        assert status.is_active is True
+
+
+class TestReadTaskList:
+    def test_handles_missing_dir(
+        self, wrapper: LifecycleWrapper, tmp_path: Path
+    ) -> None:
+        with mock.patch("zo.wrapper.Path.home", return_value=tmp_path):
+            assert wrapper.read_task_list("ghost") == []
+
+    def test_handles_empty_dir(
+        self, wrapper: LifecycleWrapper, tmp_path: Path
+    ) -> None:
+        tasks_dir = tmp_path / ".claude" / "tasks" / "empty"
+        tasks_dir.mkdir(parents=True)
+        with mock.patch("zo.wrapper.Path.home", return_value=tmp_path):
+            assert wrapper.read_task_list("empty") == []
+
+    def test_skips_invalid_json(
+        self, wrapper: LifecycleWrapper, tmp_path: Path
+    ) -> None:
+        tasks_dir = tmp_path / ".claude" / "tasks" / "bad"
+        tasks_dir.mkdir(parents=True)
+        (tasks_dir / "task-1.json").write_text("not json")
+        (tasks_dir / "task-2.json").write_text(json.dumps({"id": "2", "status": "pending"}))
+
+        with mock.patch("zo.wrapper.Path.home", return_value=tmp_path):
+            result = wrapper.read_task_list("bad")
+        assert len(result) == 1
+        assert result[0]["id"] == "2"
+
+
+# ------------------------------------------------------------------ #
+# observe_tmux_panes
+# ------------------------------------------------------------------ #
+
+
+class TestObserveTmuxPanes:
+    def test_returns_empty_when_not_in_tmux(
+        self, wrapper: LifecycleWrapper
+    ) -> None:
+        with mock.patch.dict(os.environ, {}, clear=True):
+            assert wrapper.observe_tmux_panes() == {}
+
+    def test_captures_panes_when_in_tmux(
+        self, wrapper: LifecycleWrapper
+    ) -> None:
+        with mock.patch.dict(os.environ, {"TMUX": "/tmp/tmux-1000/default,123,0"}):
+            with mock.patch.object(
+                LifecycleWrapper,
+                "_list_tmux_panes",
+                return_value=[{"id": "%0", "title": "main"}, {"id": "%1", "title": "agent"}],
+            ):
+                with mock.patch.object(
+                    LifecycleWrapper,
+                    "_capture_tmux_pane",
+                    side_effect=["output-0", "output-1"],
+                ):
+                    result = wrapper.observe_tmux_panes()
+                    assert result == {"%0": "output-0", "%1": "output-1"}
+
+
+# ------------------------------------------------------------------ #
+# wait_for_completion
+# ------------------------------------------------------------------ #
+
+
+class TestWaitForCompletion:
+    def test_detects_normal_completion(
+        self, wrapper: LifecycleWrapper, tmp_log_dir: Path
+    ) -> None:
+        mock_proc = mock.MagicMock()
+        mock_proc.poll.return_value = 0
+        wrapper._proc = mock_proc
+        wrapper._stdout_fh = mock.MagicMock()
+        wrapper._stderr_fh = mock.MagicMock()
+
+        lead = LeadProcess(
+            pid=99,
+            team_name="alpha",
+            stdout_log=tmp_log_dir / "alpha-stdout.log",
+        )
+        (tmp_log_dir / "alpha-stdout.log").write_text("")
+
+        result = wrapper.wait_for_completion(lead, poll_interval=0.01)
+        assert result.status == AgentStatus.COMPLETED
+        assert result.exit_code == 0
+
+    def test_detects_error_exit(
+        self, wrapper: LifecycleWrapper, tmp_log_dir: Path
+    ) -> None:
+        mock_proc = mock.MagicMock()
+        mock_proc.poll.return_value = 1
+        wrapper._proc = mock_proc
+        wrapper._stdout_fh = mock.MagicMock()
+        wrapper._stderr_fh = mock.MagicMock()
+
+        lead = LeadProcess(
+            pid=99,
+            team_name="alpha",
+            stdout_log=tmp_log_dir / "alpha-stdout.log",
+        )
+        (tmp_log_dir / "alpha-stdout.log").write_text("")
+
+        result = wrapper.wait_for_completion(lead, poll_interval=0.01)
+        assert result.status == AgentStatus.ERRORED
+        assert result.exit_code == 1
+
+    @mock.patch("zo.wrapper.time.sleep")
+    def test_detects_rate_limit_and_backs_off(
+        self, mock_sleep: mock.MagicMock, wrapper: LifecycleWrapper, tmp_log_dir: Path
+    ) -> None:
+        mock_proc = mock.MagicMock()
+        # First poll: still running; second poll: done.
+        mock_proc.poll.side_effect = [None, 0]
+        wrapper._proc = mock_proc
+        wrapper._stdout_fh = mock.MagicMock()
+        wrapper._stderr_fh = mock.MagicMock()
+
+        stdout_file = tmp_log_dir / "alpha-stdout.log"
+        stdout_file.write_text("Error 429 Too Many Requests")
+
+        lead = LeadProcess(pid=99, team_name="alpha", stdout_log=stdout_file)
+
+        result = wrapper.wait_for_completion(lead, poll_interval=0.01)
+        assert result.status == AgentStatus.COMPLETED
+        # Should have called sleep for the backoff.
+        assert mock_sleep.called
+
+    @mock.patch("zo.wrapper.time.sleep")
+    def test_rate_limit_exhausts_retries(
+        self, mock_sleep: mock.MagicMock, wrapper: LifecycleWrapper, tmp_log_dir: Path
+    ) -> None:
+        wrapper._max_retries = 2
+        mock_proc = mock.MagicMock()
+        mock_proc.poll.return_value = None  # Never completes.
+        wrapper._proc = mock_proc
+        wrapper._stdout_fh = mock.MagicMock()
+        wrapper._stderr_fh = mock.MagicMock()
+
+        stdout_file = tmp_log_dir / "alpha-stdout.log"
+        stdout_file.write_text("rate limit exceeded")
+
+        lead = LeadProcess(pid=99, team_name="alpha", stdout_log=stdout_file)
+
+        result = wrapper.wait_for_completion(lead, poll_interval=0.01)
+        assert result.status == AgentStatus.RATE_LIMITED
+
+
+# ------------------------------------------------------------------ #
+# kill_session
+# ------------------------------------------------------------------ #
+
+
+class TestKillSession:
+    @mock.patch("zo.wrapper.os.kill")
+    def test_sends_sigterm_then_sigkill(
+        self, mock_kill: mock.MagicMock, wrapper: LifecycleWrapper
+    ) -> None:
+        mock_proc = mock.MagicMock()
+        mock_proc.wait.side_effect = subprocess.TimeoutExpired(cmd="claude", timeout=5)
+        wrapper._proc = mock_proc
+        wrapper._stdout_fh = mock.MagicMock()
+        wrapper._stderr_fh = mock.MagicMock()
+
+        lead = LeadProcess(pid=555, team_name="alpha")
+        result = wrapper.kill_session(lead)
+
+        calls = mock_kill.call_args_list
+        assert calls[0] == mock.call(555, signal.SIGTERM)
+        assert calls[1] == mock.call(555, signal.SIGKILL)
+        assert result.status == AgentStatus.ERRORED
+        assert result.exit_code == -9
+
+    @mock.patch("zo.wrapper.os.kill")
+    def test_handles_already_dead_process(
+        self, mock_kill: mock.MagicMock, wrapper: LifecycleWrapper
+    ) -> None:
+        mock_kill.side_effect = ProcessLookupError
+        mock_proc = mock.MagicMock()
+        mock_proc.wait.return_value = None
+        wrapper._proc = mock_proc
+        wrapper._stdout_fh = mock.MagicMock()
+        wrapper._stderr_fh = mock.MagicMock()
+
+        lead = LeadProcess(pid=999, team_name="alpha")
+        result = wrapper.kill_session(lead)
+        assert result.status == AgentStatus.ERRORED
+
+
+# ------------------------------------------------------------------ #
+# parse_session_result
+# ------------------------------------------------------------------ #
+
+
+class TestParseSessionResult:
+    def test_parses_valid_json(
+        self, wrapper: LifecycleWrapper, tmp_log_dir: Path
+    ) -> None:
+        stdout_file = tmp_log_dir / "out.log"
+        stdout_file.write_text(
+            json.dumps({"result": "done", "cost_usd": 0.12, "model": "opus", "num_turns": 5})
+        )
+        lead = LeadProcess(stdout_log=stdout_file)
+        parsed = wrapper.parse_session_result(lead)
+        assert parsed["result"] == "done"
+        assert parsed["cost_usd"] == "0.12"
+        assert parsed["model"] == "opus"
+        assert parsed["num_turns"] == "5"
+
+    def test_falls_back_to_raw_text(
+        self, wrapper: LifecycleWrapper, tmp_log_dir: Path
+    ) -> None:
+        stdout_file = tmp_log_dir / "out.log"
+        stdout_file.write_text("not json at all")
+        lead = LeadProcess(stdout_log=stdout_file)
+        parsed = wrapper.parse_session_result(lead)
+        assert parsed["result"] == "not json at all"
+
+    def test_handles_missing_file(self, wrapper: LifecycleWrapper) -> None:
+        lead = LeadProcess(stdout_log=Path("/nonexistent/file.log"))
+        parsed = wrapper.parse_session_result(lead)
+        assert parsed == {"result": ""}
+
+    def test_handles_no_log_path(self, wrapper: LifecycleWrapper) -> None:
+        lead = LeadProcess()
+        parsed = wrapper.parse_session_result(lead)
+        assert parsed == {"result": ""}
+
+
+# ------------------------------------------------------------------ #
+# _detect_rate_limit
+# ------------------------------------------------------------------ #
+
+
+class TestDetectRateLimit:
+    @pytest.mark.parametrize(
+        "text",
+        [
+            "HTTP 429 response",
+            "rate limit exceeded",
+            "Rate-Limited by server",
+            "API overloaded",
+            "too many requests",
+        ],
+    )
+    def test_catches_known_patterns(self, text: str) -> None:
+        assert LifecycleWrapper._detect_rate_limit(text) is True
+
+    def test_returns_false_for_normal_output(self) -> None:
+        assert LifecycleWrapper._detect_rate_limit("All tasks completed successfully.") is False
+
+
+# ------------------------------------------------------------------ #
+# _backoff_wait
+# ------------------------------------------------------------------ #
+
+
+class TestBackoffWait:
+    def test_returns_increasing_durations(
+        self, wrapper: LifecycleWrapper
+    ) -> None:
+        d0 = wrapper._backoff_wait(0)
+        d1 = wrapper._backoff_wait(1)
+        d2 = wrapper._backoff_wait(2)
+        # base=30. Without jitter: 30, 60, 120. With jitter (+0..5):
+        assert 30 <= d0 <= 35
+        assert 60 <= d1 <= 65
+        assert 120 <= d2 <= 125
+
+
+# ------------------------------------------------------------------ #
+# _is_in_tmux
+# ------------------------------------------------------------------ #
+
+
+class TestIsInTmux:
+    def test_true_when_tmux_env_set(self) -> None:
+        with mock.patch.dict(os.environ, {"TMUX": "/tmp/tmux,1,0"}):
+            assert LifecycleWrapper._is_in_tmux() is True
+
+    def test_false_when_tmux_env_missing(self) -> None:
+        with mock.patch.dict(os.environ, {}, clear=True):
+            assert LifecycleWrapper._is_in_tmux() is False
+
+
+# ------------------------------------------------------------------ #
+# monitor_session_logs
+# ------------------------------------------------------------------ #
+
+
+class TestMonitorSessionLogs:
+    def test_reads_jsonl_files(
+        self, wrapper: LifecycleWrapper, tmp_path: Path
+    ) -> None:
+        log_dir = tmp_path / "session"
+        log_dir.mkdir()
+        (log_dir / "events.jsonl").write_text(
+            '{"event": "a"}\n{"event": "b"}\n'
+        )
+        result = wrapper.monitor_session_logs(log_dir)
+        assert len(result) == 2
+        assert result[0]["event"] == "a"
+
+    def test_handles_missing_dir(
+        self, wrapper: LifecycleWrapper, tmp_path: Path
+    ) -> None:
+        assert wrapper.monitor_session_logs(tmp_path / "nope") == []
+
+    def test_skips_invalid_lines(
+        self, wrapper: LifecycleWrapper, tmp_path: Path
+    ) -> None:
+        log_dir = tmp_path / "session"
+        log_dir.mkdir()
+        (log_dir / "events.jsonl").write_text(
+            '{"ok": true}\nnot-json\n{"ok": false}\n'
+        )
+        result = wrapper.monitor_session_logs(log_dir)
+        assert len(result) == 2

--- a/uv.lock
+++ b/uv.lock
@@ -1260,7 +1260,7 @@ wheels = [
 
 [[package]]
 name = "zero-operators"
-version = "0.2.0"
+version = "0.3.0"
 source = { editable = "." }
 dependencies = [
     { name = "click" },


### PR DESCRIPTION
## Summary

### Phase 2 — Core Infrastructure
- **Memory Layer** (`memory.py`) — STATE.md atomic read/write, DECISION_LOG append-only, PRIORS manager (seed/append/supersede), session summaries, session recovery
- **Semantic Index** (`semantic.py`) — fastembed + SQLite with summary-prefix embedding. Graceful fallback to word-overlap when fastembed not installed. Query "what framework did we choose?" → returns PyTorch at 0.648 similarity

### Phase 3 — Orchestration Engine (architecture change)
- **Orchestrator** (`orchestrator.py`) — Plan decomposition for 3 workflow modes (classical_ml/deep_learning/research), agent contract generation, lead prompt builder with full context injection (plan + phases + agent roster + memory + coordination)
- **Lifecycle Wrapper** (`wrapper.py`) — Launches ONE Claude Code session (`claude --teammate-mode tmux`), monitors team via `~/.claude/tasks/` and session logs, tmux pane capture, rate limit handling

### Architecture Change (critical)
**Old**: Python subprocess spawns N independent agents (no peer-to-peer comms)  
**New**: Python launches ONE session → Lead Orchestrator creates agent team inside Claude Code with native peer-to-peer messaging via `TeamCreate` + `Agent(team_name=...)` + `SendMessage`

- Lead Orchestrator updated with full 16-agent roster + dynamic agent creation capability
- `.gitignore` added
- Version bumped to 0.3.0

## Test plan

- [x] `uv run python3 -m pytest tests/ -v` — 224 tests passing
- [x] `uv run ruff check src/zo/` — clean
- [x] Coverage: 93% across 1,412 statements
- [x] Semantic index verified with fastembed (32/32 embedding tests pass)
- [x] End-to-end smoke test: initialize → write state → log decisions → add priors → build index → semantic query → session recovery
- [x] Orchestrator decomposes plans for all 3 workflow modes
- [x] Wrapper builds correct CLI commands, handles rate limits, monitors teams
- [ ] Review architecture change: wrapper as observer, not spawner

🤖 Generated with [Claude Code](https://claude.com/claude-code)