### PR TITLE
feat(platform): Phases 0-3 — full ZO platform engine

### DIFF
--- a/src/zo/_orchestrator_models.py
+++ b/src/zo/_orchestrator_models.py
@@ -12,6 +12,19 @@ from pydantic import BaseModel, Field
 from zo.plan import WorkflowMode  # noqa: TC001
 
 
+class GateMode(StrEnum):
+    """Controls how phase gates are evaluated.
+
+    SUPERVISED: every phase transition requires human approval.
+    AUTO: only gates marked BLOCKING in the plan require human approval.
+    FULL_AUTO: no human gates — ZO runs to completion autonomously.
+    """
+
+    SUPERVISED = "supervised"
+    AUTO = "auto"
+    FULL_AUTO = "full_auto"
+
+
 class PhaseStatus(StrEnum):
     """Lifecycle status of a workflow phase."""
 

--- a/src/zo/orchestrator.py
+++ b/src/zo/orchestrator.py
@@ -119,7 +119,7 @@ class Orchestrator:
         semantic: SemanticIndex,
         zo_root: Path,
         *,
-        gate_mode: GateMode = GateMode.AUTO,
+        gate_mode: GateMode = GateMode.SUPERVISED,
     ) -> None:
         self._plan = plan
         self._target = target

--- a/src/zo/orchestrator.py
+++ b/src/zo/orchestrator.py
@@ -28,6 +28,7 @@ from zo._orchestrator_models import (
     AgentContract,
     GateDecision,
     GateEvaluation,
+    GateMode,
     GateType,
     PhaseDefinition,
     PhaseStatus,
@@ -47,6 +48,7 @@ __all__ = [
     "AgentContract",
     "GateDecision",
     "GateEvaluation",
+    "GateMode",
     "GateType",
     "Orchestrator",
     "PhaseDefinition",
@@ -116,6 +118,8 @@ class Orchestrator:
         comms: CommsLogger,
         semantic: SemanticIndex,
         zo_root: Path,
+        *,
+        gate_mode: GateMode = GateMode.AUTO,
     ) -> None:
         self._plan = plan
         self._target = target
@@ -123,6 +127,7 @@ class Orchestrator:
         self._comms = comms
         self._semantic = semantic
         self._zo_root = Path(zo_root)
+        self._gate_mode = gate_mode
         self._workflow: WorkflowDecomposition | None = None
         self._session_state: SessionState | None = None
         self._plan_hash: str = self._compute_plan_hash()
@@ -131,6 +136,16 @@ class Orchestrator:
     def workflow(self) -> WorkflowDecomposition | None:
         """Current workflow decomposition, or None if not yet decomposed."""
         return self._workflow
+
+    @property
+    def gate_mode(self) -> GateMode:
+        """Current gate mode (supervised / auto / full_auto)."""
+        return self._gate_mode
+
+    @gate_mode.setter
+    def gate_mode(self, value: GateMode) -> None:
+        """Change gate mode at runtime."""
+        self._gate_mode = value
 
     @property
     def session_state(self) -> SessionState:
@@ -262,11 +277,29 @@ class Orchestrator:
         return None
 
     def advance_phase(self, phase_id: str) -> GateEvaluation:
-        """Evaluate the gate for a phase and advance if criteria are met."""
+        """Evaluate the gate for a phase and advance if criteria are met.
+
+        Behaviour depends on ``gate_mode``:
+
+        * **supervised** — every phase transition requires human approval,
+          regardless of the gate_type defined in the plan.
+        * **auto** (default) — only gates marked BLOCKING in the plan
+          require human approval; automated gates proceed if subtasks done.
+        * **full_auto** — no human gates at all; all gates are treated as
+          automated and ZO runs to completion autonomously.
+        """
         phase = self._find_phase(phase_id)
         all_done = set(phase.subtasks) == set(phase.completed_subtasks)
 
-        if phase.gate_type == GateType.BLOCKING:
+        # Determine effective gate type based on gate_mode
+        if self._gate_mode == GateMode.SUPERVISED:
+            effective_gate = GateType.BLOCKING
+        elif self._gate_mode == GateMode.FULL_AUTO:
+            effective_gate = GateType.AUTOMATED
+        else:  # GateMode.AUTO — use plan-defined gate type
+            effective_gate = phase.gate_type
+
+        if effective_gate == GateType.BLOCKING:
             ev = GateEvaluation(
                 phase_id=phase_id, gate_type=GateType.BLOCKING,
                 decision=GateDecision.HOLD,

--- a/tests/unit/test_orchestrator.py
+++ b/tests/unit/test_orchestrator.py
@@ -13,6 +13,7 @@ import pytest
 from zo._orchestrator_models import (
     AgentContract,
     GateDecision,
+    GateMode,
     GateType,
     PhaseDefinition,
     PhaseStatus,
@@ -331,6 +332,65 @@ class TestAdvancePhase:
         assert result.decision == GateDecision.HOLD
         assert result.requires_human is True
         assert phase_2.status == PhaseStatus.GATED
+
+    def test_supervised_mode_all_gates_block(
+        self, orchestrator: Orchestrator,
+    ) -> None:
+        """In supervised mode, even automated gates require human approval."""
+        orchestrator.gate_mode = GateMode.SUPERVISED
+        decomp = orchestrator.decompose_plan()
+        phase = decomp.phases[0]  # phase_1 is normally automated
+        for subtask in phase.subtasks:
+            orchestrator.mark_subtask_complete(phase.phase_id, subtask)
+
+        result = orchestrator.advance_phase(phase.phase_id)
+        assert result.decision == GateDecision.HOLD
+        assert result.requires_human is True
+
+    def test_full_auto_mode_no_gates_block(
+        self, orchestrator: Orchestrator,
+    ) -> None:
+        """In full_auto mode, even blocking gates proceed automatically."""
+        orchestrator.gate_mode = GateMode.FULL_AUTO
+        decomp = orchestrator.decompose_plan()
+        phase_2 = decomp.phases[1]  # phase_2 is normally blocking
+        for subtask in phase_2.subtasks:
+            orchestrator.mark_subtask_complete(phase_2.phase_id, subtask)
+
+        result = orchestrator.advance_phase(phase_2.phase_id)
+        assert result.decision == GateDecision.PROCEED
+        assert result.requires_human is False
+        assert phase_2.status == PhaseStatus.COMPLETED
+
+    def test_auto_mode_respects_plan_gates(
+        self, orchestrator: Orchestrator,
+    ) -> None:
+        """Auto mode (default) uses the gate type defined in the plan."""
+        assert orchestrator.gate_mode == GateMode.AUTO
+        decomp = orchestrator.decompose_plan()
+        # phase_1 automated -> PROCEED
+        phase_1 = decomp.phases[0]
+        for subtask in phase_1.subtasks:
+            orchestrator.mark_subtask_complete(phase_1.phase_id, subtask)
+        r1 = orchestrator.advance_phase(phase_1.phase_id)
+        assert r1.decision == GateDecision.PROCEED
+
+        # phase_2 blocking -> HOLD
+        phase_2 = decomp.phases[1]
+        for subtask in phase_2.subtasks:
+            orchestrator.mark_subtask_complete(phase_2.phase_id, subtask)
+        r2 = orchestrator.advance_phase(phase_2.phase_id)
+        assert r2.decision == GateDecision.HOLD
+
+    def test_gate_mode_changeable_at_runtime(
+        self, orchestrator: Orchestrator,
+    ) -> None:
+        """Gate mode can be changed between phases."""
+        assert orchestrator.gate_mode == GateMode.AUTO
+        orchestrator.gate_mode = GateMode.SUPERVISED
+        assert orchestrator.gate_mode == GateMode.SUPERVISED
+        orchestrator.gate_mode = GateMode.FULL_AUTO
+        assert orchestrator.gate_mode == GateMode.FULL_AUTO
 
 
 # ---------------------------------------------------------------------------

--- a/tests/unit/test_orchestrator.py
+++ b/tests/unit/test_orchestrator.py
@@ -71,7 +71,9 @@ def orchestrator(plan: Plan, tmp_path: Path) -> Orchestrator:
     )
     semantic = SemanticIndex(db_path=tmp_path / "index.db")
 
-    # Use the repo root as zo_root so agent roster discovery works
+    # Use the repo root as zo_root so agent roster discovery works.
+    # Fixture uses AUTO mode so existing gate tests work as expected.
+    # Gate mode tests explicitly switch modes.
     return Orchestrator(
         plan=plan,
         target=target,
@@ -79,6 +81,7 @@ def orchestrator(plan: Plan, tmp_path: Path) -> Orchestrator:
         comms=comms,
         semantic=semantic,
         zo_root=REPO_ROOT,
+        gate_mode=GateMode.AUTO,
     )
 
 
@@ -365,8 +368,8 @@ class TestAdvancePhase:
     def test_auto_mode_respects_plan_gates(
         self, orchestrator: Orchestrator,
     ) -> None:
-        """Auto mode (default) uses the gate type defined in the plan."""
-        assert orchestrator.gate_mode == GateMode.AUTO
+        """Auto mode uses the gate type defined in the plan."""
+        orchestrator.gate_mode = GateMode.AUTO
         decomp = orchestrator.decompose_plan()
         # phase_1 automated -> PROCEED
         phase_1 = decomp.phases[0]
@@ -386,9 +389,10 @@ class TestAdvancePhase:
         self, orchestrator: Orchestrator,
     ) -> None:
         """Gate mode can be changed between phases."""
-        assert orchestrator.gate_mode == GateMode.AUTO
         orchestrator.gate_mode = GateMode.SUPERVISED
         assert orchestrator.gate_mode == GateMode.SUPERVISED
+        orchestrator.gate_mode = GateMode.AUTO
+        assert orchestrator.gate_mode == GateMode.AUTO
         orchestrator.gate_mode = GateMode.FULL_AUTO
         assert orchestrator.gate_mode == GateMode.FULL_AUTO
 


### PR DESCRIPTION
## Summary

Complete ZO platform engine: Phases 0 through 3, from agent definitions to orchestration.

### Phase 0 — Agent Definitions + Setup
- 16 agent definition files in `.claude/agents/` (10 project delivery + 6 platform build)
- `.claude/settings.json` with agent teams enabled
- Build plan v2.0 with all 8 design decisions resolved

### Phase 1 — Core Parsers + Setup
- **Plan parser** (`plan.py`) — parses and validates plan.md against 8-section schema
- **Target parser** (`target.py`) — enforces repo isolation via zo_only_paths blocklist
- **Comms logger** (`comms.py`) — JSONL structured logging, 5 event types, daily rotation
- **setup.sh** — validates 11 environment prerequisites

### Phase 2 — Memory + Search
- **Memory layer** (`memory.py`) — STATE.md atomic read/write, DECISION_LOG append-only, PRIORS manager, session summaries, crash recovery
- **Semantic index** (`semantic.py`) — fastembed + SQLite, summary-prefix embedding, graceful fallback without fastembed

### Phase 3 — Orchestration Engine
- **Orchestrator** (`orchestrator.py`) — plan decomposition for 3 workflow modes (classical_ml / deep_learning / research), agent contract generation, lead prompt builder with full context injection
- **Lifecycle wrapper** (`wrapper.py`) — launches ONE Claude Code session (`claude --teammate-mode tmux`), monitors team via `~/.claude/tasks/`, tmux pane capture, rate limit handling
- **Architecture**: Python CLI prepares context → wrapper launches one session → Lead Orchestrator creates agent team inside Claude Code with native peer-to-peer messaging (TeamCreate + SendMessage)
- **Gate mode toggle**: supervised (default, human required) / auto / full_auto
- **Dynamic agent creation**: Lead Orchestrator can write new `.claude/agents/*.md` files on the fly

### Key Architecture Decisions
- Agent teams with peer-to-peer comms, NOT isolated subagents
- Default gate mode is **supervised** (human approval at every phase)
- Wrapper is observer/launcher, not agent spawner
- Lead Orchestrator knows all 16 agents and creates new ones as needed

## Stats

- **49 files changed**, 12,270 lines added
- **228 tests passing**
- **93% code coverage** (1,412 statements)
- **ruff clean**

## Test plan

- [x] `uv run python3 -m pytest tests/ -v` — 228 tests passing
- [x] `uv run ruff check src/zo/` — clean
- [x] `./setup.sh` — 11/11 checks pass
- [x] Gate mode: supervised blocks all gates, auto respects plan, full_auto skips all
- [x] Semantic index: query "what framework?" returns PyTorch at 0.648 similarity
- [x] Memory: crash recovery handles valid/missing/corrupt/git-mismatch states
- [x] Orchestrator: decomposes plans for all 3 workflow modes
- [x] Wrapper: builds correct CLI commands, monitors teams, handles rate limits

🤖 Generated with [Claude Code](https://claude.com/claude-code)