### PR TITLE
feat(commands): 23 ZO slash commands for Claude Code

### DIFF
--- a/.claude/commands/agents/agents.md
+++ b/.claude/commands/agents/agents.md
@@ -1,0 +1,59 @@
+---
+description: List all defined agents with their roles, tiers, and teams
+---
+
+# /agents — Agent Roster
+
+You are listing all agent definitions in the Zero Operators system.
+
+## Steps
+
+1. **Find all agent definition files** in `.claude/agents/`. List all `.md` files:
+   ```bash
+   ls .claude/agents/*.md
+   ```
+
+2. **Parse each agent file**. Read the YAML frontmatter from each file and extract:
+   - `name` — agent display name
+   - `model` or model tier (opus, sonnet, haiku)
+   - `description` — one-line role description
+   - Team membership (project delivery vs platform build)
+   - Any other frontmatter fields (tools, tier, etc.)
+
+3. **Read the role section** from each agent's markdown body. Extract a one-line summary of their role.
+
+4. **Display as a grouped table**:
+
+   ```
+   ZO Agent Roster
+   ═══════════════
+
+   Project Delivery Team — Launch Agents
+   ┌──────────────────┬────────┬─────────────────────────────────────────┬────────┐
+   │ Name             │ Model  │ Role                                    │ Status │
+   ├──────────────────┼────────┼─────────────────────────────────────────┼────────┤
+   │ lead-orchestrator│ opus   │ Coordinates pipeline, gates, checkpoints│ launch │
+   │ data-engineer    │ sonnet │ Data pipeline, cleaning, profiling      │ launch │
+   │ model-builder    │ sonnet │ Architecture, training, iteration       │ launch │
+   │ oracle-qa        │ sonnet │ Hard oracle, metric evaluation, gating  │ launch │
+   │ code-reviewer    │ sonnet │ Code quality gate                       │ launch │
+   │ test-engineer    │ sonnet │ Test coverage and correctness            │ launch │
+   └──────────────────┴────────┴─────────────────────────────────────────┴────────┘
+
+   Project Delivery Team — Phase-In Agents
+   ┌──────────────────┬────────┬─────────────────────────────────────────┬──────────┐
+   │ Name             │ Model  │ Role                                    │ Status   │
+   │ xai-agent        │ sonnet │ Explainability analysis                 │ phase-in │
+   │ ...              │ ...    │ ...                                     │ ...      │
+   └──────────────────┴────────┴─────────────────────────────────────────┴──────────┘
+
+   Platform Build Team
+   ┌──────────────────┬────────┬─────────────────────────────────────────┐
+   │ ...              │ ...    │ ...                                     │
+   └──────────────────┴────────┴─────────────────────────────────────────┘
+   ```
+
+5. **Show summary** at the bottom:
+   - Total agents defined
+   - Breakdown by team and status (launch vs phase-in)
+   - Any agents referenced in specs but not yet defined as files

--- a/.claude/commands/agents/create-agent.md
+++ b/.claude/commands/agents/create-agent.md
@@ -1,0 +1,89 @@
+---
+description: Create a new agent definition file interactively
+argument-hint: <agent-name>
+---
+
+# /create-agent — Agent Definition Creator
+
+You are creating a new Zero Operators agent definition file.
+
+## Steps
+
+1. **Get agent name** from `$ARGUMENTS`. Validate it is a valid kebab-case identifier (e.g., `domain-evaluator`, `report-writer`).
+
+2. **Ask the user** for the following (if not already provided):
+   - **Role description**: What does this agent do? (one paragraph)
+   - **Model tier**: opus (complex reasoning, orchestration), sonnet (most tasks), or haiku (simple formatting, infrastructure)
+   - **Team**: project (project delivery team) or platform (platform build team)
+
+3. **Generate the agent definition file** at `.claude/agents/$ARGUMENTS.md` following this template:
+
+   ```markdown
+   ---
+   name: {agent-name}
+   model: {opus|sonnet|haiku}
+   description: {one-line description}
+   team: {project|platform}
+   status: {launch|phase-in}
+   ---
+
+   # {Agent Display Name}
+
+   **Model tier**: {tier}
+   **Team**: {project delivery | platform build}
+   **Role**: {role description}
+
+   ## Ownership
+   {Directories and files this agent owns and can write to}
+   - `{path}/`: {purpose}
+
+   ## Off-Limits
+   {Directories and files this agent must NOT modify}
+   - `{path}/`: Managed by {other-agent}
+
+   ## Contract Produced
+   {What outputs this agent creates}
+   - File: `{path}`
+     Format: {description}
+
+   ## Contract Consumed
+   {What inputs this agent requires from other agents}
+   - File: `{path}`
+     From: {source-agent}
+     Validation: {how to verify input is valid}
+
+   ## Coordination Rules
+   - Message Orchestrator if {blocker condition}
+   - Request from {agent} if {dependency condition}
+   - Escalate to Orchestrator if {conflict condition}
+
+   ## Validation Checklist
+   Before reporting done, verify:
+   - [ ] All outputs exist at specified paths
+   - [ ] Output schema matches contract
+   - [ ] All inputs consumed and validated
+   - [ ] No off-limits files were modified
+   - [ ] Logs document any errors or assumptions
+
+   ## What This Agent Must NOT Do
+   - {Explicit prohibition 1}
+   - {Explicit prohibition 2}
+   ```
+
+4. **Fill in reasonable defaults** based on the role description. Leave placeholders marked with `{TODO}` for anything that requires project-specific knowledge.
+
+5. **Log the creation** to DECISION_LOG.md (if it exists for the current project):
+   ```markdown
+   ## Agent Created: {agent-name}
+   **Timestamp**: {ISO 8601}
+   **Decided by**: human (via /create-agent)
+   **Model tier**: {tier}
+   **Team**: {team}
+   **Role**: {one-line description}
+   ```
+
+6. **Report** to the user:
+   - Path to the created file
+   - Summary of the agent definition
+   - Remind them to review and fill in any `{TODO}` placeholders
+   - Suggest running `/agents` to see the updated roster

--- a/.claude/commands/agents/spawn.md
+++ b/.claude/commands/agents/spawn.md
@@ -1,0 +1,51 @@
+---
+description: Spawn an agent in the current session with full context
+argument-hint: <agent-name>
+---
+
+# /spawn — Agent Spawner
+
+You are spawning a Zero Operators agent into the current session context.
+
+## Steps
+
+1. **Read the agent definition** from `.claude/agents/$ARGUMENTS.md`. If the file does not exist, report available agents (list `.claude/agents/`) and stop.
+
+2. **Read current project context**:
+   - Read `STATE.md` from the active project's memory directory to understand current phase and status
+   - Read the project plan (`targets/{project}.target.md`) for objectives and constraints
+   - Read DECISION_LOG.md for recent decisions and context
+
+3. **Validate the spawn**:
+   - Is this agent appropriate for the current phase? (e.g., do not spawn XAI Agent during data profiling phase)
+   - Are the agent's input dependencies met? (e.g., Model Builder needs DataLoaders to exist)
+   - If validation fails, report why and suggest what needs to happen first
+
+4. **Construct the spawn context**. From the agent definition, assemble:
+   - Role description
+   - Ownership (directories and files this agent owns)
+   - Off-limits (what it must not touch)
+   - Contract produced (expected outputs)
+   - Contract consumed (required inputs)
+   - Coordination rules
+   - Validation checklist
+
+5. **Log the spawn** to comms JSONL (`logs/comms/{YYYY-MM-DD}.jsonl`):
+   ```json
+   {
+     "timestamp": "{ISO 8601}",
+     "session_id": "{current session}",
+     "event_type": "message",
+     "agent": "lead-orchestrator",
+     "project": "{project-name}",
+     "message_type": "broadcast",
+     "subject": "Spawning agent: $ARGUMENTS",
+     "body": "Agent $ARGUMENTS spawned for phase {current-phase}"
+   }
+   ```
+
+6. **Activate the agent**. Present the full agent instructions and context, then begin operating as that agent within the delivery repo. The agent should:
+   - Acknowledge its role and current task
+   - Verify its input dependencies are available
+   - Begin working on its assigned phase/task
+   - Follow its validation checklist before reporting done

--- a/.claude/commands/commit.md
+++ b/.claude/commands/commit.md
@@ -1,0 +1,62 @@
+---
+description: Stage and commit changes with a conventional commit message
+---
+
+# /commit — Conventional Commit
+
+You are creating a git commit for the current changes following Zero Operators conventions.
+
+## Steps
+
+1. **Run git status** to see all changed, staged, and untracked files:
+   ```bash
+   git status
+   ```
+
+2. **Run git diff** to see the actual changes (both staged and unstaged):
+   ```bash
+   git diff
+   git diff --staged
+   ```
+
+3. **Check recent commit messages** for style consistency:
+   ```bash
+   git log --oneline -10
+   ```
+
+4. **Analyze the changes** and determine:
+   - What type of change is this? Use conventional commit types:
+     - `feat` — new feature or capability
+     - `fix` — bug fix
+     - `docs` — documentation only
+     - `test` — adding or updating tests
+     - `refactor` — code change that neither fixes a bug nor adds a feature
+     - `chore` — maintenance, dependencies, configs
+     - `style` — formatting, whitespace, no logic change
+   - What scope is affected? (e.g., `orchestrator`, `memory`, `oracle`, `agents`)
+   - What is the concise subject? (imperative mood, lowercase, no period)
+
+5. **Stage relevant files**. Do NOT stage:
+   - `.env` files
+   - Credential files, API keys, tokens
+   - Large binary files (unless intentional)
+   - `__pycache__/` or `.pyc` files
+   - IDE config files (`.vscode/`, `.idea/`)
+
+   Stage everything else that is part of the logical change:
+   ```bash
+   git add {specific files}
+   ```
+
+6. **Create the commit** with the conventional format:
+   ```
+   type(scope): subject
+
+   Body explaining what changed and why (if non-obvious).
+   ```
+
+7. **Report** to the user:
+   - The commit message used
+   - Files committed
+   - The commit hash
+   - Any files that were intentionally excluded and why

--- a/.claude/commands/document/code-docs.md
+++ b/.claude/commands/document/code-docs.md
@@ -1,0 +1,58 @@
+---
+description: Generate or update documentation for the delivery repo code
+---
+
+# /code-docs — Code Documentation Generator
+
+You are generating and updating documentation for the delivery repo associated with the current Zero Operators project.
+
+## Steps
+
+1. **Detect the delivery repo**. Read STATE.md or the project plan to identify the delivery repo path. If working within a target project directory, use that. If unclear, ask the user.
+
+2. **Scan all Python files** in the delivery repo:
+   ```bash
+   find {delivery-repo} -name "*.py" -not -path "*/__pycache__/*" -not -path "*/venv/*"
+   ```
+
+3. **For each Python file**, check documentation quality:
+   - Does the module have a module-level docstring?
+   - Do all public functions and classes have Google-style docstrings?
+   - Are type hints present on public function signatures?
+   - Are parameters documented in the docstring?
+   - Are return values documented?
+
+4. **Fix missing docstrings**. For each gap found:
+   - Read the function/class to understand its purpose
+   - Write a Google-style docstring:
+     ```python
+     def function_name(param1: str, param2: int) -> bool:
+         """Brief description of what this function does.
+
+         Args:
+             param1: Description of param1.
+             param2: Description of param2.
+
+         Returns:
+             Description of return value.
+
+         Raises:
+             ValueError: When invalid input is provided.
+         """
+     ```
+   - Add module-level docstrings where missing
+
+5. **Generate API reference** if the project has a clear public interface:
+   - List all public modules with one-line descriptions
+   - List key functions and classes with signatures
+   - Write to `docs/api_reference.md` in the delivery repo (only if a `docs/` directory exists or the project warrants it)
+
+6. **Commit the changes** using conventional commit format:
+   ```
+   docs: add missing docstrings and update code documentation
+   ```
+
+7. **Report** to the user:
+   - Number of files scanned
+   - Number of docstrings added or updated
+   - Any files that need manual attention (complex logic needing human-written docs)

--- a/.claude/commands/document/model-card.md
+++ b/.claude/commands/document/model-card.md
@@ -1,0 +1,76 @@
+---
+description: Generate a standard model card for the project
+argument-hint: <project-name>
+---
+
+# /model-card — Model Card Generator
+
+You are generating a model card following standard practices for a Zero Operators project.
+
+## Steps
+
+1. **Read the project plan** (`targets/{project-name}.target.md`). Extract:
+   - Objective and problem statement
+   - Constraints and requirements
+   - Data sources
+   - Success criteria
+
+2. **Read oracle evaluation results**. Look in:
+   - `oracle/reports/` for structured results
+   - DECISION_LOG.md for gate events and metric history
+   - Comms JSONL logs for gate events
+
+3. **Read model architecture from source code**. Look in:
+   - `models/` directory for architecture definitions
+   - Training scripts for hyperparameters
+   - Experiment configs for training details
+
+4. **Generate the model card** with these sections:
+
+   ```markdown
+   # Model Card: {project-name}
+   **Generated**: {date}
+
+   ## Model Details
+   - **Architecture**: {model type, layers, key design choices}
+   - **Training procedure**: {optimizer, learning rate, epochs, batch size}
+   - **Hyperparameters**: {key hyperparameters and values}
+   - **Framework**: PyTorch
+   - **Training date**: {date of final training run}
+   - **Version**: {model version or checkpoint ID}
+
+   ## Intended Use
+   - **Primary use case**: {from plan objective}
+   - **Users**: {intended consumers of model output}
+   - **Out-of-scope uses**: {what this model should NOT be used for}
+
+   ## Training Data
+   - **Source**: {data sources from plan}
+   - **Size**: {dataset size, number of samples}
+   - **Preprocessing**: {key data transformations}
+   - **Splits**: {train/val/test split ratios and strategy}
+
+   ## Evaluation Results
+   - **Primary metric**: {metric name} = {value} (threshold: {threshold})
+   - **Tier 1 (Core)**: {result}
+   - **Tier 2 (Operational)**: {result}
+   - **Tier 3 (Robustness)**: {result}
+   - **Per-stratum breakdown**: {if applicable}
+
+   ## Limitations and Biases
+   - {Known failure modes from oracle evaluation}
+   - {Data limitations or gaps}
+   - {Distribution assumptions that may not hold}
+
+   ## Ethical Considerations
+   - {Potential misuse scenarios}
+   - {Fairness considerations}
+   - {Privacy implications if applicable}
+   ```
+
+5. **Write the model card** to `reports/model_card.md` in the delivery repo. Create `reports/` if needed.
+
+6. **Report** to the user:
+   - Summary of model card contents
+   - Any sections that need manual review or additional information
+   - Path to the generated file

--- a/.claude/commands/document/retrospective.md
+++ b/.claude/commands/document/retrospective.md
@@ -1,0 +1,72 @@
+---
+description: Run a retrospective analyzing failures, evolutions, and lessons learned
+argument-hint: <project-name>
+---
+
+# /retrospective — Project Retrospective
+
+You are running the evolution engine's retrospective protocol for a Zero Operators project, as defined in specs/evolution.md.
+
+## Steps
+
+1. **Scan DECISION_LOG.md** (`memory/{project-name}/DECISION_LOG.md`). Extract all entries tagged or categorized as:
+   - `failure` — any failure entry with root cause analysis
+   - `evolution` — any rule update entry
+   - Gate rejections and re-evaluations
+
+2. **Categorize failures by root cause**. For each failure, identify its category:
+   - `missing_rule` — no rule existed to prevent this
+   - `incomplete_rule` — rule existed but did not cover this case
+   - `ignored_rule` — rule existed but agent did not follow it
+   - `novel_case` — genuinely new situation not covered by priors
+   - `regression` — a previously fixed issue recurring
+
+3. **Identify patterns**. Look for clustering:
+   - Are failures concentrated in a specific phase?
+   - Is one agent responsible for multiple failures?
+   - Is there a domain area that keeps causing issues?
+   - Are there recurring themes (data quality, contract violations, metric drift)?
+
+4. **Propose systemic updates**. Based on patterns:
+   - If 3+ failures relate to the same area, propose a structural change
+   - Suggest new mandatory subtasks, stronger gates, or new agent skills
+   - Reference specific spec files that should be updated
+
+5. **Generate the retrospective report**:
+
+   ```markdown
+   # Project Retrospective: {project-name}
+   **Date**: {today}
+   **Sessions completed**: {count from session files}
+   **Total failures**: {count}
+   **Total rule updates**: {count}
+
+   ## Failure Distribution
+   | Category | Count | Example |
+   |----------|-------|---------|
+   | missing_rule | ... | ... |
+   | incomplete_rule | ... | ... |
+   | ignored_rule | ... | ... |
+   | novel_case | ... | ... |
+   | regression | ... | ... |
+
+   ## Patterns Identified
+   {Description of recurring failure patterns}
+
+   ## Rule Updates Made
+   {List of evolution entries — what was updated and why}
+
+   ## Recommended Systemic Updates
+   {Specific changes to specs, agents, or workflow — for human approval}
+
+   ## Lessons for Future Projects
+   {Domain-agnostic insights that apply to all ZO projects}
+   ```
+
+6. **Present findings for human review**. Do NOT automatically apply systemic updates. Present them as recommendations and wait for approval.
+
+7. **Report** to the user:
+   - Key findings summary
+   - Number of failures analyzed
+   - Most impactful recommended changes
+   - Ask if they want to approve any of the recommended systemic updates

--- a/.claude/commands/document/validation-report.md
+++ b/.claude/commands/document/validation-report.md
@@ -1,0 +1,71 @@
+---
+description: Generate a comprehensive validation report from oracle results
+argument-hint: <project-name>
+---
+
+# /validation-report — Oracle Validation Report Generator
+
+You are generating a comprehensive validation report for a Zero Operators project.
+
+## Steps
+
+1. **Read oracle evaluation results** from the delivery repo. Look for:
+   - `oracle/reports/` directory for structured evaluation reports
+   - Any metric output files (JSON, CSV) from oracle runs
+   - Latest gate events from comms JSONL logs (`logs/comms/`)
+
+2. **Read DECISION_LOG.md** (`memory/{project-name}/DECISION_LOG.md`). Extract:
+   - All gate events with metric results
+   - All oracle-related decisions
+   - Any metric threshold changes (should be rare per oracle spec)
+
+3. **Read the project plan** (`targets/{project-name}.target.md`) for:
+   - Primary metric definition and threshold
+   - Tiered success criteria (Tier 1/2/3)
+   - Ground truth source
+   - Evaluation method
+
+4. **Generate the validation report** with these sections:
+
+   ```markdown
+   # Validation Report: {project-name}
+   **Generated**: {date}
+   **Prepared by**: /validation-report command
+
+   ## Primary Metric
+   | Metric | Threshold | Result | Status |
+   |--------|-----------|--------|--------|
+   | {name} | {threshold} | {value} | PASS/FAIL |
+
+   ## Tiered Results
+   | Tier | Threshold | Result | Status |
+   |------|-----------|--------|--------|
+   | Tier 1 (Core) | ... | ... | ... |
+   | Tier 2 (Operational) | ... | ... | ... |
+   | Tier 3 (Robustness) | ... | ... | ... |
+
+   ## Per-Stratum Breakdown
+   {Table breaking down metric by data strata/regimes/categories}
+
+   ## Confusion Matrix
+   {If classification task — show the matrix}
+
+   ## Comparison to Baseline
+   {How does the model compare to the stated baseline or naive approach}
+
+   ## Confidence Intervals
+   {Statistical confidence bounds on the primary metric}
+
+   ## Known Limitations
+   {Edge cases, failure modes, data gaps identified during evaluation}
+
+   ## Gate History
+   {Chronological list of all oracle gate evaluations for this project}
+   ```
+
+5. **Write the report** to `reports/validation_report.md` in the delivery repo. Create the `reports/` directory if it does not exist.
+
+6. **Report** to the user:
+   - Summary of pass/fail status
+   - Key findings or concerns
+   - Path to the generated report

--- a/.claude/commands/gates/approve.md
+++ b/.claude/commands/gates/approve.md
@@ -1,0 +1,50 @@
+---
+description: Approve the current pending gate and advance to the next phase
+---
+
+# /approve — Gate Approval
+
+You are executing a human gate approval for the current Zero Operators project.
+
+## Steps
+
+1. **Read STATE.md** in the project's memory directory (`memory/{project}/STATE.md`). Identify:
+   - The current phase and its status
+   - Which gate is pending (look for `status: PENDING_GATE` or similar)
+   - If no gate is pending, report that and stop
+
+2. **Log the approval to DECISION_LOG.md** (`memory/{project}/DECISION_LOG.md`). Append an entry:
+   ```markdown
+   ## Gate Approved: {gate name}
+   **Timestamp**: {ISO 8601 now}
+   **Decided by**: human
+   **Phase**: {phase that was gated}
+   **Outcome**: approved
+   **Notes**: Human approved gate via /approve command
+   ```
+
+3. **Update STATE.md** to advance to the next phase:
+   - Set the current phase status to `COMPLETED`
+   - Set the next phase status to `ACTIVE`
+   - Update `last_updated` timestamp
+
+4. **Log gate event to comms JSONL** (`logs/comms/{YYYY-MM-DD}.jsonl`). Append:
+   ```json
+   {
+     "timestamp": "{ISO 8601}",
+     "session_id": "manual",
+     "event_type": "gate",
+     "agent": "human",
+     "project": "{project-name}",
+     "gate_id": "{gate-id}",
+     "gate_name": "{gate-name}",
+     "result": "pass",
+     "notes": "Human approved via /approve command"
+   }
+   ```
+
+5. **Report** to the user:
+   - What gate was approved
+   - What phase just completed
+   - What phase is now active
+   - Any relevant next steps from the plan

--- a/.claude/commands/gates/gates.md
+++ b/.claude/commands/gates/gates.md
@@ -1,0 +1,42 @@
+---
+description: Display all gates for a project with their current status
+argument-hint: <project-name>
+---
+
+# /gates — Gate Status Overview
+
+You are displaying the full gate status table for a Zero Operators project.
+
+## Steps
+
+1. **Read the project plan** (`targets/{project-name}.target.md` or the project's plan file). Extract all gate definitions:
+   - Gate number/ID
+   - Associated phase
+   - Gate type (auto = oracle-evaluated, blocking = requires human approval)
+   - Pass criteria
+
+2. **Read STATE.md** (`memory/{project-name}/STATE.md`). Extract:
+   - Current phase and status
+   - Which gates have been passed, which are pending
+
+3. **Read DECISION_LOG.md** (`memory/{project-name}/DECISION_LOG.md`). Extract:
+   - All gate-related entries (approved, rejected, oracle pass/fail)
+   - Timestamps and notes for each gate event
+
+4. **Display a table** with all gates:
+
+   ```
+   Gate Status: {project-name}
+   Current Phase: {phase} ({status})
+
+   | # | Phase | Gate Name | Type | Status | Date | Notes |
+   |---|-------|-----------|------|--------|------|-------|
+   | 1 | Phase 1 | ... | blocking | passed | 2026-04-05 | Human approved |
+   | 2 | Phase 2 | ... | auto | passed | 2026-04-07 | Oracle: 0.92 >= 0.85 |
+   | 3 | Phase 3 | ... | blocking | PENDING | - | Awaiting human review |
+   | 4 | Phase 4 | ... | auto | - | - | Not yet reached |
+   ```
+
+5. **Highlight** the current/next gate clearly (mark it as PENDING or NEXT).
+
+6. If any gates have failed previously, show the failure history beneath the table with rejection reasons and dates.

--- a/.claude/commands/gates/reject.md
+++ b/.claude/commands/gates/reject.md
@@ -1,0 +1,53 @@
+---
+description: Reject the current pending gate with a reason, triggering rework
+argument-hint: <reason>
+---
+
+# /reject — Gate Rejection
+
+You are executing a human gate rejection for the current Zero Operators project. The argument provided is the rejection reason.
+
+## Steps
+
+1. **Read STATE.md** in the project's memory directory (`memory/{project}/STATE.md`). Identify:
+   - The current phase and its status
+   - Which gate is pending
+   - If no gate is pending, report that and stop
+
+2. **Log the rejection to DECISION_LOG.md** (`memory/{project}/DECISION_LOG.md`). Append:
+   ```markdown
+   ## Gate Rejected: {gate name}
+   **Timestamp**: {ISO 8601 now}
+   **Decided by**: human
+   **Phase**: {phase that was gated}
+   **Outcome**: rejected
+   **Reason**: $ARGUMENTS
+   **Action**: Phase set back to ACTIVE for rework
+   ```
+
+3. **Update STATE.md**:
+   - Set the current phase status to `BLOCKED` with the rejection reason
+   - Then immediately set it back to `ACTIVE` to trigger rework
+   - Add a `blocker_history` entry recording the rejection
+   - Update `last_updated` timestamp
+
+4. **Log gate event to comms JSONL** (`logs/comms/{YYYY-MM-DD}.jsonl`). Append:
+   ```json
+   {
+     "timestamp": "{ISO 8601}",
+     "session_id": "manual",
+     "event_type": "gate",
+     "agent": "human",
+     "project": "{project-name}",
+     "gate_id": "{gate-id}",
+     "gate_name": "{gate-name}",
+     "result": "fail",
+     "notes": "$ARGUMENTS"
+   }
+   ```
+
+5. **Report** to the user:
+   - What gate was rejected and why
+   - The phase is now set back to ACTIVE for rework
+   - What the agents need to address based on the rejection reason
+   - Suggest next steps (re-run the phase, modify approach, etc.)

--- a/.claude/commands/memory/prime.md
+++ b/.claude/commands/memory/prime.md
@@ -1,0 +1,119 @@
+---
+description: Load full project context — the "catch me up" command for new sessions
+argument-hint: <project-name>
+---
+
+# /prime — Context briefing for a new session
+
+You are preparing a context briefing for project `$ARGUMENTS`. This is the "catch me up" command — read everything relevant and present a concise summary of where we are.
+
+If no argument is provided, detect the active project from memory or ask the user.
+
+## 1. Read STATE.md
+
+```bash
+!cat "$(git rev-parse --show-toplevel)/memory/$ARGUMENTS/STATE.md" 2>/dev/null || echo "NO STATE"
+```
+
+If STATE.md does not exist, tell the user the project is not initialized and suggest running `/project/connect` or `zo init`.
+
+Extract and note:
+- Current mode (build / continue / maintain)
+- Current phase
+- Last completed subtask
+- Active blockers
+- Next steps
+- Active agents
+- Git HEAD commit
+
+## 2. Read recent session summaries
+
+```bash
+!ls -t "$(git rev-parse --show-toplevel)/memory/$ARGUMENTS/sessions/" 2>/dev/null | head -3
+```
+
+Read the last 3 session summaries. For each, note:
+- What was accomplished
+- Decisions made (with DECISION_LOG references)
+- Blockers hit
+- Recommended next steps
+
+## 3. Query relevant decisions
+
+Read `memory/{project-name}/DECISION_LOG.md` and extract decisions related to the current phase. If the semantic index exists, use it:
+
+```bash
+!cd "$(git rev-parse --show-toplevel)" && python -c "
+from zo.semantic import SemanticIndex
+from pathlib import Path
+idx = SemanticIndex(Path('memory/$ARGUMENTS/index.db'))
+results = idx.query('current phase decisions and blockers', top_k=5)
+for r in results:
+    print(f'[{r.score:.2f}] {r.text[:200]}')
+idx.close()
+" 2>/dev/null || echo "No semantic index available"
+```
+
+Otherwise, read the last 5-10 entries from DECISION_LOG.md directly.
+
+## 4. Read domain priors
+
+Read `memory/{project-name}/PRIORS.md` in full. Note all accumulated domain knowledge, especially:
+- High-confidence priors
+- Recently added priors
+- Any superseded priors (indicates learning/correction)
+
+## 5. Check delivery repo activity
+
+Find the target repo path from the target file:
+
+```bash
+!grep "target_repo" "$(git rev-parse --show-toplevel)/targets/$ARGUMENTS.target.md" 2>/dev/null
+```
+
+Check recent git activity in the delivery repo:
+
+```bash
+!cd "$(git rev-parse --show-toplevel)/../{target-repo}" && git log --oneline -10 2>/dev/null || echo "Target repo not accessible"
+```
+
+## 6. Present context briefing
+
+Format the briefing as a concise, scannable summary:
+
+```
+## Context Briefing: {project-name}
+**Date**: {today}
+
+### Where We Are
+- **Mode**: {mode}
+- **Phase**: {phase}
+- **Last completed**: {last subtask}
+- **Blockers**: {list or "none"}
+
+### What Happened Recently
+{2-3 bullet summary from most recent session}
+{2-3 bullet summary from second most recent session}
+
+### Key Decisions
+{List the 3-5 most relevant recent decisions with one-line summaries}
+
+### What We Know (Domain Priors)
+{List key priors, grouped by category if multiple exist}
+- {prior 1}
+- {prior 2}
+
+### Delivery Repo Activity
+{Recent commits in the target repo, or "no activity"}
+
+### What's Next
+{Next steps from STATE.md, prioritized}
+1. {next step 1}
+2. {next step 2}
+3. {next step 3}
+
+### Open Blockers
+{Any unresolved blockers that need attention}
+```
+
+Keep the briefing to one screenful if possible. The goal is to get the human (or a new agent session) fully oriented in under 30 seconds of reading.

--- a/.claude/commands/memory/priors.md
+++ b/.claude/commands/memory/priors.md
@@ -1,0 +1,84 @@
+---
+description: Display all accumulated domain priors for a project
+argument-hint: <project-name>
+---
+
+# /priors — View domain priors
+
+You are displaying the accumulated domain priors for project `$ARGUMENTS`.
+
+If no argument is provided, detect the active project from memory or ask the user.
+
+## 1. Locate the priors file
+
+```bash
+!cat "$(git rev-parse --show-toplevel)/memory/$ARGUMENTS/PRIORS.md" 2>/dev/null || echo "NO PRIORS FILE"
+```
+
+If the file does not exist, tell the user the project is not initialized and suggest running `zo init {project-name}`.
+
+## 2. Parse and display priors
+
+Read the full PRIORS.md file. Parse each prior entry which follows this schema:
+
+```
+## Prior: {category}
+**Statement**: {factual claim}
+**Evidence**: {case or reference}
+**Confidence**: high | medium | low
+**Superseded By**: {reference or empty}
+```
+
+## 3. Format the display
+
+Group priors by category and display with clear formatting:
+
+```
+## Domain Priors: {project-name}
+**Domain**: {domain from file header}
+**Last Updated**: {timestamp from file header}
+**Total Priors**: {count}
+
+### {Category 1}
+
+1. **{Statement}**
+   - Evidence: {evidence}
+   - Confidence: {high/medium/low}
+
+2. **{Statement}**
+   - Evidence: {evidence}
+   - Confidence: {low}
+   - SUPERSEDED BY: {reference}
+
+### {Category 2}
+...
+```
+
+Highlight:
+- High-confidence priors (these are well-established facts)
+- Low-confidence priors (these need more evidence)
+- Superseded priors (mark clearly that these have been updated)
+
+## 4. Handle empty priors
+
+If the PRIORS.md exists but contains no prior entries (only the header), display:
+
+```
+## Domain Priors: {project-name}
+
+No priors accumulated yet. Domain priors are learned as the project progresses:
+
+- The domain evaluator adds priors when resolving QUESTIONABLE cases
+- Priors capture domain-specific knowledge that agents would not discover from data alone
+- They compound over iterations: first session has none, later sessions benefit from accumulated knowledge
+
+Priors will appear here after the first domain evaluation cycle.
+```
+
+## 5. Summary statistics
+
+At the end, show:
+- Total prior count
+- Breakdown by confidence level (high / medium / low)
+- Number of superseded priors
+- Most recent prior added (date and statement)

--- a/.claude/commands/memory/recall.md
+++ b/.claude/commands/memory/recall.md
@@ -1,0 +1,92 @@
+---
+description: Search project memory for decisions and priors matching a query
+argument-hint: <query>
+---
+
+# /recall — Search project memory
+
+You are searching the ZO memory system for information related to: `$ARGUMENTS`
+
+If no argument is provided, ask the user what they want to search for.
+
+## 1. Detect current project
+
+Find the active project by checking STATE.md files:
+
+```bash
+!find "$(git rev-parse --show-toplevel)/memory" -name "STATE.md" -type f 2>/dev/null
+```
+
+If multiple projects exist, list them and ask the user which one to search. If only one exists, use it. If none exist, tell the user no projects are initialized.
+
+## 2. Try semantic index first
+
+Check if a semantic index exists for the project:
+
+```bash
+!ls "$(git rev-parse --show-toplevel)/memory/{project-name}/index.db" 2>/dev/null || echo "NO INDEX"
+```
+
+If the index exists, query it using the Python semantic search:
+
+```bash
+!cd "$(git rev-parse --show-toplevel)" && python -c "
+from zo.semantic import SemanticIndex
+from pathlib import Path
+idx = SemanticIndex(Path('memory/{project-name}/index.db'))
+results = idx.query('$ARGUMENTS', top_k=5)
+for r in results:
+    print(f'--- Score: {r.score:.3f} ---')
+    print(f'Source: {r.source}')
+    print(r.text)
+    print()
+idx.close()
+"
+```
+
+If this succeeds, format and display the results. Skip to step 4.
+
+## 3. Fall back to text search
+
+If no semantic index or the query fails, search the memory files directly.
+
+### Search DECISION_LOG.md
+
+Read `memory/{project-name}/DECISION_LOG.md` and search for entries matching the query. Look for keyword matches in the Decision, Context, and Rationale fields.
+
+### Search PRIORS.md
+
+Read `memory/{project-name}/PRIORS.md` and search for entries matching the query. Look for keyword matches in Statement, Evidence, and Category fields.
+
+### Search session summaries
+
+```bash
+!find "$(git rev-parse --show-toplevel)/memory/{project-name}/sessions" -name "*.md" -type f 2>/dev/null | sort -r | head -10
+```
+
+Read the most recent session summaries and search for relevant content.
+
+## 4. Format results
+
+Present the top 5 results clearly:
+
+```
+## Recall Results for: "{query}"
+
+### 1. {title or first line}
+- **Source**: DECISION_LOG / PRIORS / session-{date}
+- **Timestamp**: {date if available}
+- **Relevance**: {score if semantic, "keyword match" if grep}
+
+{Full text of the decision, prior, or relevant session excerpt}
+
+---
+
+### 2. {title or first line}
+...
+```
+
+If no results are found, say so and suggest:
+- Broadening the search terms
+- Checking if the project has accumulated enough history
+- Listing what is available: number of decisions, priors, and sessions on file

--- a/.claude/commands/memory/session-summary.md
+++ b/.claude/commands/memory/session-summary.md
@@ -1,0 +1,170 @@
+---
+description: Write a session summary and update all memory files — the "wrap up cleanly" command
+---
+
+# /session-summary — End-of-session wrap-up
+
+You are writing a session summary and updating all memory artifacts for the current project. This is the clean wrap-up command.
+
+## 1. Detect current project
+
+```bash
+!find "$(git rev-parse --show-toplevel)/memory" -name "STATE.md" -type f 2>/dev/null
+```
+
+If multiple projects exist, determine which one was actively worked on this session by checking recent git changes and file modifications. If ambiguous, ask the user.
+
+## 2. Collect session information
+
+### What was accomplished
+
+Review the current conversation and session activity. Identify:
+- Tasks completed
+- Files created or modified
+- Features implemented or bugs fixed
+- Experiments run and their results
+
+### Decisions made
+
+Identify any decisions made during this session:
+- Architecture choices
+- Tool or library selections
+- Approach changes
+- Trade-offs evaluated
+
+### Files changed
+
+```bash
+!cd "$(git rev-parse --show-toplevel)" && git diff --name-only HEAD~5 2>/dev/null || git diff --name-only 2>/dev/null
+```
+
+Also check the target repo for changes:
+
+```bash
+!grep "target_repo" "$(git rev-parse --show-toplevel)/targets/{project-name}.target.md" 2>/dev/null
+```
+
+```bash
+!cd "{target-repo-path}" && git diff --name-only HEAD~5 2>/dev/null || echo "No target repo changes"
+```
+
+### Blockers hit
+
+Note any issues encountered:
+- Errors or failures
+- Missing dependencies or data
+- Unclear requirements
+- Blocked on human input
+
+## 3. Write session summary
+
+Create the session summary file:
+
+```bash
+!date +%Y-%m-%d-%H%M%S
+```
+
+Write to `memory/{project-name}/sessions/session-{timestamp}.md`:
+
+```markdown
+# Session Summary: {date}
+**Date**: {YYYY-MM-DD}
+**Duration**: {estimated duration}
+**Mode**: {build | continue | maintain}
+**Agent**: orchestrator
+
+## Accomplished
+- {task 1}
+- {task 2}
+
+## Decisions Made
+- {decision 1} (see DECISION_LOG entry: {short title})
+- {decision 2}
+
+## Blockers Hit
+- {blocker 1, status: resolved | open}
+
+## Next Steps
+- {action 1}
+- {action 2}
+
+## Files Changed
+- {filename}: {brief description of change}
+
+## Context Handoff
+- Estimated completion: {estimate or "blocked"}
+- Open questions: {list}
+- Recommended next phase: {recommendation}
+```
+
+## 4. Update STATE.md
+
+Read the current STATE.md and update it:
+
+```markdown
+# STATE
+timestamp: {now in ISO 8601}
+mode: {current mode}
+phase: {current phase, advance if phase completed}
+last_completed_subtask: {most recent completed subtask}
+active_blockers: [{list of open blockers}]
+next_steps: [{prioritized list of next actions}]
+active_agents: [{agents that were active}]
+git_head: {current commit hash}
+context_window_usage: "not tracked in v1"
+```
+
+Get the current git HEAD:
+
+```bash
+!cd "$(git rev-parse --show-toplevel)" && git rev-parse HEAD
+```
+
+## 5. Append to DECISION_LOG.md
+
+For each decision identified in step 2, append an entry to `memory/{project-name}/DECISION_LOG.md`:
+
+```markdown
+## Decision: {short title}
+**Timestamp**: {ISO 8601}
+**Context**: {brief description of the situation}
+**Decision**: {what was decided}
+**Rationale**: {why this decision was made}
+**Alternatives Considered**: {other options and why rejected}
+**Outcome**: {result or "pending"}
+**Confidence**: {high | medium | low}
+---
+```
+
+Remember: DECISION_LOG is append-only. Never edit or remove existing entries.
+
+## 6. Rebuild semantic index
+
+If the semantic index infrastructure is available:
+
+```bash
+!cd "$(git rev-parse --show-toplevel)" && python -c "
+from zo.semantic import SemanticIndex
+from zo.memory import MemoryManager
+from pathlib import Path
+mm = MemoryManager(project_dir=Path('.'), project_name='{project-name}')
+idx = SemanticIndex(mm.memory_root / 'index.db')
+decisions = mm.read_decisions()
+priors = mm.read_priors()
+if decisions:
+    idx.index_decisions(decisions)
+if priors:
+    idx.index_priors(priors)
+idx.close()
+print('Semantic index rebuilt.')
+" 2>/dev/null || echo "Semantic index rebuild skipped (not available)"
+```
+
+## 7. Confirm
+
+Report to the user:
+- Session summary file path
+- STATE.md updated (show key fields: phase, next steps)
+- Number of decisions logged
+- Whether semantic index was rebuilt
+- Reminder of next steps for the following session

--- a/.claude/commands/observe/decisions.md
+++ b/.claude/commands/observe/decisions.md
@@ -1,0 +1,44 @@
+---
+description: Display all decisions from the project decision log
+argument-hint: <project-name> [search-term]
+---
+
+# /decisions — Decision Log Viewer
+
+You are displaying the parsed decision log for a Zero Operators project.
+
+## Steps
+
+1. **Read DECISION_LOG.md** from `memory/{project-name}/DECISION_LOG.md`. If the file does not exist, report that no decisions have been logged yet and stop.
+
+2. **Parse all decision entries**. Each entry is a markdown section (## heading) with structured fields. Extract:
+   - Entry number (sequential)
+   - Timestamp
+   - Title (from heading)
+   - Category (decision, gate, failure, evolution)
+   - Outcome (approved, rejected, proceed, blocked, etc.)
+   - Confidence (if present)
+   - Decided by (agent name or human)
+
+3. **Apply search filter** if a search term is provided after the project name:
+   - Filter entries where the title, description, or any field contains the search term (case-insensitive)
+   - Report: "Filtered to entries matching: '{search-term}'"
+
+4. **Display as a numbered list**:
+
+   ```
+   Decision Log: {project-name}
+   Total: {count} entries | {date-range}
+
+   #  | TIMESTAMP            | TITLE                          | BY               | OUTCOME    | CONFIDENCE
+   ───┼──────────────────────┼────────────────────────────────┼──────────────────┼────────────┼───────────
+   1  | 2026-04-05 10:00:00  | Feature list approved          | human            | approved   | high
+   2  | 2026-04-05 14:30:00  | Use LSTM over Transformer      | lead-orchestrator| proceed    | medium
+   3  | 2026-04-06 09:15:00  | Gate 2: Oracle threshold met   | oracle-qa        | pass       | high
+   4  | 2026-04-06 11:00:00  | Data quality failure Sensor 12 | data-engineer    | escalated  | -
+   ```
+
+5. **Show summary stats** at the bottom:
+   - Total decisions
+   - By category breakdown (decisions / gates / failures / evolutions)
+   - Date range (earliest to latest)

--- a/.claude/commands/observe/history.md
+++ b/.claude/commands/observe/history.md
@@ -1,0 +1,52 @@
+---
+description: Show a combined timeline of sessions, commits, and decisions for a project
+argument-hint: <project-name>
+---
+
+# /history — Project History Timeline
+
+You are building a comprehensive chronological history of a Zero Operators project.
+
+## Steps
+
+1. **Read all session summaries** from `memory/{project-name}/sessions/`. For each session file, extract:
+   - Session date/timestamp
+   - Phase worked on
+   - Key accomplishments
+   - Blockers encountered
+   - Decisions made
+
+2. **Read git log** from the delivery repo (if identifiable from the plan or STATE.md). Run:
+   ```bash
+   git log --oneline --since="project start date" --format="%h %ad %s" --date=short
+   ```
+   Extract commit hashes, dates, and messages.
+
+3. **Read DECISION_LOG.md** (`memory/{project-name}/DECISION_LOG.md`). Extract key decisions with timestamps.
+
+4. **Combine into a unified chronological timeline**:
+
+   ```
+   Project History: {project-name}
+   Started: {earliest date} | Last activity: {latest date}
+   Sessions: {count} | Commits: {count} | Decisions: {count}
+
+   DATE         TYPE       SUMMARY
+   ───────────────────────────────────────────────────────────
+   2026-04-01   session    Session 1: Project setup, plan approved
+   2026-04-01   commit     abc1234 feat: initial data pipeline
+   2026-04-01   decision   Feature list approved by human
+   2026-04-02   session    Session 2: Data profiling, quality issues found
+   2026-04-02   commit     def5678 fix: handle NaN in sensor data
+   2026-04-02   decision   Exclude Sensor 12 Q3 data
+   2026-04-03   session    Session 3: Model training, first oracle eval
+   2026-04-03   gate       Gate 2: Oracle RMSE 0.042 PASS
+   2026-04-03   commit     ghi9012 feat: LSTM model v1
+   ```
+
+5. **Group by phase** if the timeline is long (more than 30 entries). Show phase boundaries clearly.
+
+6. **Report** at the bottom:
+   - Total elapsed time
+   - Phases completed vs remaining
+   - Current status

--- a/.claude/commands/observe/logs.md
+++ b/.claude/commands/observe/logs.md
@@ -1,0 +1,47 @@
+---
+description: Display recent comms log events for a project
+argument-hint: <project-name> [--type <event_type>] [--agent <agent-name>]
+---
+
+# /logs — Comms Log Viewer
+
+You are displaying the structured JSONL communication logs for a Zero Operators project.
+
+## Steps
+
+1. **Find JSONL log files** in `logs/comms/`. List available files sorted by date.
+
+2. **Read the most recent log file** (`logs/comms/{YYYY-MM-DD}.jsonl`). Parse each line as JSON.
+
+3. **Apply filters** if provided in the arguments:
+   - `--type <event_type>`: Filter to only events matching that type (message, decision, gate, error, checkpoint)
+   - `--agent <agent-name>`: Filter to only events from that agent
+   - If no filters, show all events
+
+4. **Display events** in a readable table format. Show the last 20 events by default:
+
+   ```
+   Comms Log: {project-name} ({date})
+   Showing: {filter description or "all events"}
+
+   TIMESTAMP    AGENT              TYPE        SUMMARY
+   ─────────────────────────────────────────────────────────
+   14:32:15     model-builder      message     Requested updated DataLoader from data-engineer
+   14:35:00     data-engineer      status      DataLoader ready with 3 splits
+   14:36:12     oracle-qa          gate        Gate 3: RMSE 0.042 <= 0.05 PASS
+   14:40:00     lead-orchestrator  decision    Proceed to Phase 4
+   14:50:00     data-engineer      error       Sensor 12 data 45% NaN in Q3
+   ```
+
+5. **For each event type, extract the most useful summary**:
+   - `message`: Show subject or first line of body
+   - `decision`: Show title and outcome
+   - `gate`: Show metric, value, threshold, and pass/fail
+   - `error`: Show description and severity
+   - `checkpoint`: Show phase, progress, and current metric
+
+6. **Show metadata** at the bottom:
+   - Total events in log file
+   - Events shown (after filtering)
+   - Date range of log file
+   - Available log files if more than one exists

--- a/.claude/commands/observe/watch.md
+++ b/.claude/commands/observe/watch.md
@@ -1,0 +1,38 @@
+---
+description: Watch a running ZO session or show last known state
+argument-hint: <project-name>
+---
+
+# /watch — Live Session Monitor
+
+You are checking the current status of a Zero Operators project session.
+
+## Steps
+
+1. **Check if a ZO session is currently running**:
+   - Look for running Claude processes: `ps aux | grep claude`
+   - Check for active team files: `ls ~/.claude/teams/` for any team directories related to the project
+   - Check for active task files: `ls ~/.claude/tasks/` for any task directories related to the project
+
+2. **If a session is running**:
+   - Read the team config from `~/.claude/teams/{team-name}/config.json` to get agent list and statuses
+   - Display each agent's current state: name, type, status (active/idle/blocked)
+   - Read the task list from `~/.claude/tasks/{team-name}/` to show current task assignments and progress
+   - Read the most recent JSONL comms log (`logs/comms/{latest-date}.jsonl`) and display the last 10 events in a readable format:
+     ```
+     TIME       AGENT              EVENT     SUMMARY
+     14:32:15   model-builder      message   Requested updated DataLoader
+     14:35:00   data-engineer      status    DataLoader ready, 3 splits produced
+     14:36:12   oracle-qa          gate      Tier 1: 0.92 >= 0.85 PASS
+     ```
+
+3. **If no session is running**:
+   - Read `memory/{project-name}/STATE.md` and display the last known state
+   - Show: current phase, phase status, last updated timestamp, any blockers
+   - Show the most recent session summary from `memory/{project-name}/sessions/`
+   - Report: "No active session detected. Showing last known state."
+
+4. **Always show** at the bottom:
+   - Project name
+   - Current/last phase
+   - Time since last activity

--- a/.claude/commands/project/connect.md
+++ b/.claude/commands/project/connect.md
@@ -1,0 +1,90 @@
+---
+description: Clone a repo and scaffold a ZO project target for it
+argument-hint: <github-url>
+---
+
+# /connect — Clone repo and create ZO project target
+
+You are connecting a new repository to Zero Operators. Follow these steps precisely.
+
+## 1. Parse the GitHub URL
+
+Extract the repo name from the argument `$ARGUMENTS`. The project name is the repo name (e.g., `https://github.com/user/my-project` becomes `my-project`).
+
+If no argument is provided, ask the user for a GitHub URL.
+
+## 2. Clone the repository
+
+Clone to a sibling directory of the ZO root (one level up from the zero-operators directory).
+
+```bash
+!cd "$(git rev-parse --show-toplevel)/.." && git clone $ARGUMENTS
+```
+
+Verify the clone succeeded and that the directory is a valid git repo:
+
+```bash
+!cd "$(git rev-parse --show-toplevel)/../{project-name}" && git rev-parse --is-inside-work-tree
+```
+
+## 3. Detect the default branch
+
+```bash
+!cd "$(git rev-parse --show-toplevel)/../{project-name}" && git symbolic-ref refs/remotes/origin/HEAD | sed 's@^refs/remotes/origin/@@'
+```
+
+Store this as `target_branch`.
+
+## 4. Create the target file
+
+Create `targets/{project-name}.target.md` with this structure:
+
+```yaml
+---
+project: "{project-name}"
+target_repo: "../{project-name}"
+target_branch: "{detected-branch}"
+worktree_base: ".worktrees"
+git_author_name: "ZO Agent"
+git_author_email: "zo-agent@zero-operators.dev"
+agent_working_dirs:
+  data-engineer: "data/"
+  model-builder: "src/"
+  oracle-qa: "reports/"
+  test-engineer: "tests/"
+zo_only_paths:
+  - "memory/"
+  - "logs/"
+  - ".claude/"
+  - ".zo/"
+  - "CLAUDE.md"
+  - "STATE.md"
+enforce_isolation: true
+---
+```
+
+Adjust `agent_working_dirs` based on the actual directory structure found in the cloned repo. If `src/` exists, use it. If `lib/` exists, use that instead. Adapt to what is actually present.
+
+## 5. Initialize memory scaffold
+
+Run the ZO init command to create the memory directory structure:
+
+```bash
+!cd "$(git rev-parse --show-toplevel)" && python -m zo.cli init {project-name}
+```
+
+If `zo.cli` is not available, create the scaffold manually:
+
+- `memory/{project-name}/STATE.md`
+- `memory/{project-name}/DECISION_LOG.md`
+- `memory/{project-name}/PRIORS.md`
+- `memory/{project-name}/sessions/` (empty directory)
+
+## 6. Report
+
+Print a summary of everything created:
+
+- Target file path and key fields
+- Memory directory structure
+- Cloned repo location and default branch
+- Next steps: suggest running `/project/import` to analyze the codebase and draft a plan

--- a/.claude/commands/project/import.md
+++ b/.claude/commands/project/import.md
@@ -1,0 +1,102 @@
+---
+description: Clone a repo, analyze the codebase, and draft a full plan.md
+argument-hint: <github-url>
+---
+
+# /import — Point at a repo and go
+
+You are importing a new project into Zero Operators. This is the full onboarding command: clone, scaffold, analyze, and draft a plan.
+
+## 1. Run /connect first
+
+Execute all the steps from the `/project/connect` command using `$ARGUMENTS` as the GitHub URL. This clones the repo, creates the target file, and initializes the memory scaffold. Do all of those steps now before proceeding.
+
+## 2. Analyze the codebase
+
+Navigate to the cloned repo and perform a thorough analysis.
+
+### 2a. Structure analysis
+
+```bash
+!find "../{project-name}" -type f -not -path '*/.git/*' -not -path '*/node_modules/*' -not -path '*/__pycache__/*' -not -path '*/.venv/*' | head -200
+```
+
+Note the top-level directory structure, primary language, and organization pattern.
+
+### 2b. Dependency analysis
+
+Look for dependency files and read them:
+- `requirements.txt`, `pyproject.toml`, `setup.py`, `setup.cfg` (Python)
+- `package.json` (Node.js)
+- `Cargo.toml` (Rust)
+- `go.mod` (Go)
+
+From the dependencies, determine:
+- **Workflow mode**: `deep_learning` if torch/tensorflow/jax present, `classical_ml` if sklearn/xgboost/lightgbm present, `research` if paper/latex/arxiv references found, otherwise `classical_ml`
+- **Key frameworks**: list the major libraries
+- **Data sources**: look for data loading code, CSV/parquet references, API clients
+
+### 2c. README and docs
+
+Read the README and any docs/ directory. Extract:
+- Project purpose and description
+- Any existing success metrics or evaluation criteria
+- Known constraints or requirements
+- Domain context
+
+### 2d. Existing tests
+
+```bash
+!find "../{project-name}" -type f -name "test_*" -o -name "*_test.*" -o -name "*.test.*" | head -50
+```
+
+Note the testing framework and coverage.
+
+### 2e. Existing code analysis
+
+Read the main source files (entry points, core modules). Understand:
+- What the code currently does
+- What state it is in (prototype, production, broken)
+- Architecture patterns used
+
+## 3. Draft the plan
+
+Create `plans/{project-name}.md` following the 8-section schema from `specs/plan.md`. Use everything gathered from the analysis.
+
+### Required sections
+
+**1. Project Identity** (YAML frontmatter):
+- `project_name`: from the repo name
+- `version`: "0.1.0"
+- `created`: today's date
+- `last_modified`: today's date
+- `status`: active
+- `owner`: "Sam"
+
+**2. Objective**: Synthesize from README and code analysis. Be specific about the deliverable.
+
+**3. Oracle Definition**: If metrics exist in the code (loss functions, eval scripts), extract them. Otherwise, propose reasonable metrics based on the project type and mark them as needing review.
+
+**4. Workflow Configuration**: Set `mode` based on dependency analysis. Configure default gates.
+
+**5. Data Sources**: Document any data files, data loading code, or API connections found.
+
+**6. Domain Context and Priors**: Extract domain knowledge from README, comments, and docstrings. Note any assumptions or constraints mentioned in the code.
+
+**7. Agent Configuration**: Default team unless the project clearly needs specific agents.
+
+**8. Constraints**: Extract from the codebase (Python version, framework requirements, etc.).
+
+### Optional sections
+
+Include Milestones, Delivery Specification, Dependencies, and Open Questions as appropriate.
+
+## 4. Present for review
+
+Display the full drafted plan to the user. Highlight:
+- Any sections marked TODO or needing human input
+- Auto-detected workflow mode and rationale
+- Proposed oracle metrics and whether they need refinement
+- Open questions discovered during analysis
+
+Ask the user to review and approve before saving. Save only after confirmation.

--- a/.claude/commands/project/launch.md
+++ b/.claude/commands/project/launch.md
@@ -1,0 +1,103 @@
+---
+description: Launch an agent team to execute a project plan
+argument-hint: <project-name>
+---
+
+# /launch — Launch agent team for a project
+
+You are launching the ZO agent team for project `$ARGUMENTS`.
+
+If no argument is provided, check for active projects in `plans/` and ask the user which one to launch.
+
+## 1. Validate the plan
+
+Read and validate the plan file:
+
+```bash
+!ls "$(git rev-parse --show-toplevel)/plans/$ARGUMENTS.md" 2>/dev/null || echo "NOT FOUND"
+```
+
+If the plan does not exist, tell the user to run `/project/plan` or `/project/import` first.
+
+Read the plan file and verify all 8 required sections are present:
+1. Project Identity (YAML frontmatter with project_name, version, status)
+2. Objective
+3. Oracle Definition (primary metric, ground truth, evaluation method, threshold, frequency)
+4. Workflow Configuration (mode, gates)
+5. Data Sources
+6. Domain Context and Priors
+7. Agent Configuration
+8. Constraints
+
+If any required section is missing or contains only TODO placeholders, halt and tell the user which sections need to be completed.
+
+## 2. Validate the target file
+
+```bash
+!ls "$(git rev-parse --show-toplevel)/targets/$ARGUMENTS.target.md" 2>/dev/null || echo "NOT FOUND"
+```
+
+If the target file does not exist, tell the user to run `/project/connect` first.
+
+Read the target and verify `target_repo` points to a valid directory:
+
+```bash
+!test -d "$(git rev-parse --show-toplevel)/../{target_repo_basename}" && echo "EXISTS" || echo "NOT FOUND"
+```
+
+## 3. Initialize memory
+
+Check if memory is already initialized:
+
+```bash
+!ls "$(git rev-parse --show-toplevel)/memory/$ARGUMENTS/STATE.md" 2>/dev/null || echo "NOT INITIALIZED"
+```
+
+If not initialized, run init:
+
+```bash
+!cd "$(git rev-parse --show-toplevel)" && python -m zo.cli init $ARGUMENTS
+```
+
+## 4. Decompose the plan
+
+Read the plan and break it into execution phases based on the workflow mode:
+
+- **classical_ml**: Phase 1 (Data) -> Phase 2 (Features) -> Phase 3 (Model) -> Phase 4 (Training) -> Phase 5 (Validation) -> Phase 6 (Packaging)
+- **deep_learning**: Same phases but Phase 2 shifts to input representations, Phase 3 expands architecture
+- **research**: Adds Phase 0 (Literature Review) before Phase 1
+
+Identify:
+- Which phase to start with (read STATE.md for current progress)
+- Which agents are needed for the first phase
+- What the gate criteria are
+
+## 5. Build the lead prompt
+
+Construct the Lead Orchestrator prompt containing:
+- Full plan content
+- Target configuration
+- Current state from STATE.md
+- Relevant priors from PRIORS.md
+- Recent decisions from DECISION_LOG.md
+- Phase-specific instructions from the workflow
+
+## 6. Launch via zo build
+
+Execute the build command in supervised mode:
+
+```bash
+!cd "$(git rev-parse --show-toplevel)" && python -m zo.cli build "plans/$ARGUMENTS.md" --gate-mode supervised
+```
+
+If the CLI is not available or fails, explain to the user what the command would do and offer to launch manually by constructing the claude command directly.
+
+## 7. Report to user
+
+Display:
+- Project name and plan summary
+- Workflow mode and phases
+- Active agents for the first phase
+- Gate mode (supervised)
+- How to monitor progress: `zo status {project-name}`
+- How to continue after interruption: `zo continue {project-name}`

--- a/.claude/commands/project/plan.md
+++ b/.claude/commands/project/plan.md
@@ -1,0 +1,119 @@
+---
+description: Create or update a structured task plan for the current project
+argument-hint: <task-description>
+---
+
+# /plan — Create or update a task plan
+
+You are creating a structured task plan for the current ZO project. The task description is: `$ARGUMENTS`
+
+If no argument is provided, ask the user what they want to plan.
+
+## 1. Load context
+
+### Read current state
+
+Read `memory/*/STATE.md` to find the active project. If multiple projects exist, ask the user which one.
+
+```bash
+!find "$(git rev-parse --show-toplevel)/memory" -name "STATE.md" -type f 2>/dev/null
+```
+
+Read the STATE.md for the active project. Note:
+- Current mode and phase
+- Active blockers
+- Next steps already queued
+
+### Read priors
+
+Read `memory/{project-name}/PRIORS.md` if it exists. These are accumulated domain facts that should inform planning.
+
+### Read existing plan
+
+Check if `plans/{project-name}.md` already exists. If it does, read it to understand:
+- Current objective and oracle definition
+- Active workflow configuration
+- Existing constraints
+- What has already been planned
+
+### Read recent decisions
+
+Read `memory/{project-name}/DECISION_LOG.md` for the last 5-10 decisions. These inform what has been tried and what was decided.
+
+## 2. Analyze the codebase
+
+Search for files relevant to the task description:
+
+```bash
+!git rev-parse --show-toplevel
+```
+
+Use grep and glob to find code related to the task. Understand what exists, what needs to change, and what is missing.
+
+## 3. Write the task plan
+
+Structure the plan as follows:
+
+```markdown
+## Task: {task-description}
+
+**Date**: {today}
+**Mode**: build | continue | maintain
+**Estimated phases**: {number}
+
+### Objective
+{What this task aims to accomplish, specific and measurable}
+
+### Approach
+{High-level strategy for achieving the objective}
+
+### Agents Needed
+{Which agents are required and what each will do}
+- **data-engineer**: {role in this task, or "not needed"}
+- **model-builder**: {role in this task, or "not needed"}
+- **oracle-qa**: {role in this task, or "not needed"}
+- **test-engineer**: {role in this task, or "not needed"}
+
+### Subtasks
+{Ordered list of concrete subtasks with dependencies}
+
+1. **{subtask-name}** — {description}
+   - Agent: {assigned agent}
+   - Input: {what this subtask needs}
+   - Output: {what this subtask produces}
+   - Depends on: {previous subtask or "none"}
+
+2. **{subtask-name}** — {description}
+   ...
+
+### Acceptance Criteria
+{Specific, verifiable criteria for task completion}
+- [ ] {criterion 1}
+- [ ] {criterion 2}
+- [ ] {criterion 3}
+
+### Risks and Mitigations
+- **Risk**: {description} → **Mitigation**: {strategy}
+
+### Phase Breakdown
+- **Phase 1**: {description} → Gate: {gate type}
+- **Phase 2**: {description} → Gate: {gate type}
+```
+
+## 4. Integrate with existing plan
+
+If `plans/{project-name}.md` already exists:
+- **Build mode**: This is a new project plan. Create fresh.
+- **Continue mode**: Add the task as a new section within the existing plan, preserving all existing content.
+- **Maintain mode**: Create a targeted maintenance plan that references the existing plan but scopes changes narrowly.
+
+## 5. Present for review
+
+Display the complete plan to the user. Ask for approval before writing to disk.
+
+If approved:
+- Write or update `plans/{project-name}.md`
+- Log the planning decision to `memory/{project-name}/DECISION_LOG.md`
+- Update `memory/{project-name}/STATE.md` with the new next_steps
+
+Do not save until the user confirms.


### PR DESCRIPTION
## Summary

Complete command vocabulary for Zero Operators — 23 slash commands across 6 categories, usable from any Claude Code session in the ZO repo.

### Commands

| Category | Command | What it does |
|----------|---------|-------------|
| **Project** | `/project/import <url>` | Clone repo + analyze + draft plan (the front door) |
| | `/project/connect <url>` | Clone repo, create target file, scaffold |
| | `/project/plan <task>` | Write/update a task plan |
| | `/project/launch <project>` | Validate and launch agent team |
| **Memory** | `/memory/recall <query>` | Semantic search over decisions/priors |
| | `/memory/prime <project>` | Full context briefing ("catch me up") |
| | `/memory/priors <project>` | Show accumulated domain knowledge |
| | `/memory/session-summary` | Wrap up session cleanly |
| **Gates** | `/gates/approve` | Approve pending gate, advance phase |
| | `/gates/reject <reason>` | Reject gate, trigger iteration |
| | `/gates/gates <project>` | Display gate status table |
| **Observe** | `/observe/watch <project>` | Live agent activity monitor |
| | `/observe/logs <project>` | Tail JSONL comms logs |
| | `/observe/decisions <project>` | Browse DECISION_LOG |
| | `/observe/history <project>` | Session + git timeline |
| **Document** | `/document/code-docs` | Generate code documentation |
| | `/document/validation-report` | Oracle validation report |
| | `/document/model-card` | Standard model card |
| | `/document/retrospective` | Evolution engine retrospective |
| **Agents** | `/agents/agents` | List all 16 agent definitions |
| | `/agents/spawn <agent>` | Manually spawn one agent |
| | `/agents/create-agent <name>` | Create new agent definition |
| **Utility** | `/commit` | Conventional commit with ZO format |

23 files, 1,743 lines of command instructions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)