### PR TITLE
feat: v1.0.1 — interactive tmux sessions, brand panel, smart CLI

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@
 <br/>
 
 [![Status](https://img.shields.io/badge/status-validated-F0C040?style=flat-square&labelColor=080808)](#status)
-[![Tests](https://img.shields.io/badge/tests-296_passing-F0C040?style=flat-square&labelColor=080808)](#status)
+[![Tests](https://img.shields.io/badge/tests-295_passing-F0C040?style=flat-square&labelColor=080808)](#status)
 [![Agents](https://img.shields.io/badge/agents-16_defined-F0C040?style=flat-square&labelColor=080808)](#agent-teams)
 [![E2E](https://img.shields.io/badge/MNIST-99%25_accuracy-F0C040?style=flat-square&labelColor=080808)](#e2e-validation)
 
@@ -74,49 +74,46 @@ You stay in the loop at human checkpoints. ZO remembers everything across sessio
 
 **Step by step:**
 
-1. **Feed source docs** — `zo draft source-docs/ --project my-project` indexes your documents and generates a `plan.md` with all 8 required sections (objective, oracle, workflow, data sources, domain priors, agents, constraints)
-2. **Review the plan** — edit `plans/my-project.md` to sharpen the objective, set oracle thresholds, add domain knowledge the agent missed
-3. **Launch** — `zo build plans/my-project.md` spawns the agent team. You watch them work in tmux split panes
-4. **Approve at gates** — in supervised mode (default), every phase transition pauses for your review. You see a summary of what was done, key metrics, and the recommended next action
-5. **Session continuity** — stop anytime. `zo continue my-project` reads STATE.md and picks up exactly where you left off. Semantic search over past decisions provides context
+1. **Feed source docs** — `zo draft ~/docs/req.md ~/data/ --project my-project` indexes your documents and generates a `plan.md`, then opens an interactive Claude session to refine it
+2. **Review the plan** — edit `plans/my-project.md` to sharpen the objective, set oracle thresholds, add domain knowledge
+3. **Launch** — `zo build plans/my-project.md` shows a phase review (subtasks, agents, oracle criteria), prompts for additional instructions, then spawns the agent team in tmux
+4. **Approve at gates** — in supervised mode (default), every phase transition pauses for your review. You can also type directly into the Lead Orchestrator's Claude Code session
+5. **Session continuity** — stop anytime. Run `zo build` again — it auto-detects the current phase and resumes. Or use `zo continue my-project` as shorthand
 6. **Self-evolution** — when something fails, ZO runs a post-mortem: fix the symptom, update the rule that allowed it, verify the rule prevents recurrence
 7. **Clean delivery** — your project repo contains only code, models, reports, and tests. Zero ZO infrastructure
 
 ---
 
-## Operating Modes
+## Commands
 
-### `zo build` — Start from scratch
+### `zo build` — The primary command
 
 ```bash
 zo build plans/my-project.md --gate-mode supervised
 ```
 
-Parses the plan, initializes project memory, decomposes into phases, and launches the agent team. This is how you start a new project.
+Smart mode detection:
+- **Fresh project** (no state) — builds from scratch
+- **Existing state** — continues from the current phase
+- **Plan edited** since last run — re-decomposes and resumes
 
-### `zo continue` — Resume where you left off
+Shows a brand panel, phase review with subtasks/agents/oracle criteria, and prompts for additional instructions before launching.
+
+### `zo continue` — Resume shorthand
 
 ```bash
 zo continue my-project
 ```
 
-Reads `STATE.md` from the last session, queries the semantic index for relevant past decisions, and resumes from the exact phase and subtask where work stopped. No context is lost.
-
-### `zo maintain` — Apply updates
-
-```bash
-zo maintain my-project
-```
-
-Detects changes to `plan.md` since the last session. Computes a diff, identifies which phases need re-execution, and presents the replan for your approval before resuming.
+Finds `plans/{project}.md` and runs `zo build` on it. Shorthand for when you don't want to type the plan path.
 
 ### `zo draft` — Generate a plan from documents
 
 ```bash
-zo draft source-docs/ --project my-project
+zo draft ~/docs/requirements.md ~/data/notes/ /path/to/specs.txt --project my-project
 ```
 
-Indexes all source documents (PDFs, CSVs, READMEs), then generates a compliant `plan.md` following the 8-section schema. You review and edit before launching.
+Accepts **multiple file and directory paths**. Indexes all source documents, generates a compliant `plan.md`, then opens an interactive Claude Code session to refine it with you. Use `--no-tmux` to skip the interactive session.
 
 ### `zo init` — Scaffold a new project
 
@@ -124,15 +121,7 @@ Indexes all source documents (PDFs, CSVs, READMEs), then generates a compliant `
 zo init my-project
 ```
 
-Creates the project directory structure:
-```
-memory/my-project/STATE.md
-memory/my-project/DECISION_LOG.md
-memory/my-project/PRIORS.md
-memory/my-project/sessions/
-targets/my-project.target.md    (template)
-plans/my-project.md             (template with all 8 sections)
-```
+Creates: `memory/`, `targets/`, `plans/` with template files for the project.
 
 ### `zo status` — Check current state
 
@@ -173,20 +162,28 @@ uv sync --extra dev
 zo init my-project
 
 # 4. Option A: Draft a plan from source documents
-zo draft ~/path/to/source-docs/ --project my-project
+zo draft ~/docs/requirements.md ~/data/ --project my-project
 
 # 4. Option B: Write a plan manually
 #    Edit plans/my-project.md — fill in all 8 sections
 
-# 5. Launch
+# 5. Start tmux (required for agent visibility)
+tmux new -s zo
+
+# 6. Launch — you'll see a phase review, then agents in tmux panes
 zo build plans/my-project.md
 
-# 6. Watch agents work in tmux split panes
-# 7. Approve at human checkpoints
-# 8. Resume if interrupted
+# 7. Navigate tmux panes
+#    Ctrl-b n     → switch to agent window
+#    Ctrl-b p     → back to monitoring window
+#    Ctrl-b q N   → jump to pane N
+#    Ctrl-b z     → zoom current pane
+
+# 8. Approve at human checkpoints (supervised mode)
+# 9. Resume if interrupted
 zo continue my-project
 
-# 9. Check status anytime
+# 10. Check status anytime
 zo status my-project
 ```
 
@@ -334,7 +331,7 @@ Over time, `PRIORS.md` accumulates domain knowledge. The same mistake never happ
 ```
 zero-operators/
 ├── src/zo/                     # Platform code (10 modules)
-│   ├── cli.py                  # CLI: zo build/continue/maintain/init/status/draft
+│   ├── cli.py                  # CLI: zo build/continue/init/status/draft
 │   ├── draft.py                # Agentic plan generation from source docs
 │   ├── plan.py                 # Plan parser and validator (8 sections)
 │   ├── target.py               # Target file parser, isolation enforcer
@@ -401,7 +398,7 @@ mnist-delivery/          ← delivery repo (clean)
 | 4 | Evolution engine, CLI, integration tests | Done |
 | 5 | E2E validation (MNIST: 99% accuracy) | Done |
 
-296 platform tests. 92% coverage. ruff clean.
+295 platform tests. 92% coverage. ruff clean.
 
 ---
 
@@ -413,7 +410,7 @@ mnist-delivery/          ← delivery repo (clean)
 <br/>
 <br/>
 
-`ZERO OPERATORS` · `v1.0` · `validated` · `99% MNIST accuracy`
+`ZERO OPERATORS` · `v1.0.1` · `validated` · `99% MNIST accuracy`
 
 <br/>
 </div>

--- a/memory/zo-platform/DECISION_LOG.md
+++ b/memory/zo-platform/DECISION_LOG.md
@@ -206,3 +206,22 @@ Append-only. Every orchestration decision with timestamp, rationale, and outcome
 **Rationale:** First live user test revealed that `zo build` appeared stuck — "Monitoring session: pid=XXXXX" with no visible output. The wrapper was running Claude as an invisible background process with stdout piped to log files. The `use_tmux` parameter was accepted but never used. Users need to see agent teams working (the whole point of tmux teammateMode).
 **Alternatives considered:** (1) Stream subprocess stdout to terminal — doesn't work for TUI rendering. (2) Always use headless + progress bar — loses the live agent visibility that makes ZO compelling. (3) Visible tmux pane (chosen) — natural integration with Claude Code's native teammateMode.
 **Outcome:** wrapper.py split into `_launch_tmux` / `_launch_headless` + `_wait_tmux` / `_wait_headless`. LeadProcess gains `tmux_pane_id` field. CLI shows pane navigation tips. 296 tests pass, 7 new tests added.
+
+---
+
+## Decision: 2026-04-10T11:00:00Z
+**Type:** ARCHITECTURE
+**Title:** Interactive tmux launch via send-keys + paste-buffer
+**Decision:** Launch Claude Code interactively (no `-p`, no `--dangerously-skip-permissions`) using tmux send-keys to type the command and tmux paste-buffer to submit the prompt. This gives the user the exact same experience as manually opening Claude Code.
+**Rationale:** Three approaches failed: (1) subprocess.Popen — no TTY, no TUI. (2) Launcher scripts — shell escaping issues, stderr redirect hid TUI. (3) `-p` with `--dangerously-skip-permissions` — runs non-interactively, no TUI. (4) `--dangerously-skip-permissions` alone — shows warning and exits in interactive mode. The send-keys approach simulates manual user interaction and works reliably.
+**Alternatives considered:** (1) Popen (no TTY). (2) Launcher script (escaping). (3) -p flag (no TUI). (4) --dangerously-skip-permissions (exits). (5) send-keys + paste-buffer (chosen).
+**Outcome:** Users see full Claude Code TUI with agent team panes. Permissions handled via .claude/settings.json allow/deny rules.
+
+---
+
+## Decision: 2026-04-10T12:00:00Z
+**Type:** ARCHITECTURE
+**Title:** Merge continue/maintain into smart zo build, add brand panel
+**Decision:** (1) `zo build` auto-detects mode (fresh/continue/plan-edited). (2) `zo continue` becomes a thin alias. (3) `zo maintain` removed entirely. (4) Phase review shows in ALL modes. (5) `zo draft` accepts multiple paths. (6) ZO brand panel at startup.
+**Rationale:** `zo continue` and `zo maintain` were doing almost the same thing as `zo build` — parsing plan, decomposing, launching agents. Having three commands confused the user. Smart detection in `zo build` handles all cases. Brand panel gives professional identity matching Claude Code's startup experience.
+**Outcome:** Simplified CLI: build (primary), continue (alias), draft, init, status. 295 tests pass.

--- a/memory/zo-platform/STATE.md
+++ b/memory/zo-platform/STATE.md
@@ -8,7 +8,7 @@ status: complete
 
 ## Current Position
 
-ZO v1.0 is **complete and validated**. v1.0.1 patch applied: tmux-visible agent sessions. Ready for IVL F5.
+ZO v1.0.1 — **complete, validated, and user-tested**. Interactive tmux agent sessions working. Brand panel, smart build, simplified CLI. Ready for IVL F5.
 
 ## Completed
 
@@ -21,22 +21,31 @@ ZO v1.0 is **complete and validated**. v1.0.1 patch applied: tmux-visible agent 
 - [x] Slash commands: 23 commands across 6 categories
 - [x] Documentation: COMMANDS.md reference, interactive HTML demo
 - [x] README: full user workflow, architecture, commands, e2e results
-- [x] v1.0.1: tmux-visible agent sessions (wrapper launches Claude in visible tmux pane)
+- [x] v1.0.1: Interactive tmux agent sessions (send-keys + paste-buffer)
+- [x] v1.0.1: ZO brand panel at startup (project, mode, phase, gate info)
+- [x] v1.0.1: Smart build (auto-detects fresh/continue/plan-edited)
+- [x] v1.0.1: Pre-launch phase review in all modes
+- [x] v1.0.1: zo maintain removed (zo build handles plan edits)
+- [x] v1.0.1: zo continue is thin alias for zo build
+- [x] v1.0.1: zo draft accepts multiple file/dir paths + interactive refinement
+- [x] v1.0.1: Live monitoring dashboard (tasks, team, comms events)
 
 ## Known Issues
 
 1. Phase state not persisted between zo build calls — re-decomposes each time
 2. Blocking gates cause repeated sessions in auto mode without advancing
 3. MNIST Phase 6 (packaging: model card, validation report) not completed
+4. Agent permissions need broader .claude/settings.json allow patterns
 
 ## What's Next
 
 1. **IVL F5** — first real production project
 2. Fix phase persistence between sessions
-3. v1.1: phase-in agents, multi-project support
+3. Broader permission patterns in settings.json (Bash(cd *), Bash(pip *), etc.)
+4. v1.1: phase-in agents, multi-project support
 
 ## Session Metadata
 
-last_checkpoint: 2026-04-10T10:00:00Z
-last_session: session-007
+last_checkpoint: 2026-04-10T12:00:00Z
+last_session: session-008
 branch: claude/blissful-babbage

--- a/src/zo/cli.py
+++ b/src/zo/cli.py
@@ -108,8 +108,13 @@ def _show_phase_review(phase, decomp, plan, gate_mode: str) -> None:  # noqa: AN
     console.print(Rule(style=_DIM))
 
 
-def _ask_additional_instructions() -> str:
-    """Prompt the user for additional instructions before launch."""
+def _ask_additional_instructions(gate_mode: str) -> str:
+    """Prompt the user for additional instructions before launch.
+
+    Skipped in full-auto mode (no human interaction).
+    """
+    if gate_mode == "full-auto":
+        return ""
     console.print(
         f"  [{_AMBER}]Additional instructions?[/]"
         f" [{_DIM}](press Enter to skip, or type your request)[/]"
@@ -119,6 +124,135 @@ def _ask_additional_instructions() -> str:
     if user_input:
         console.print(f"  [{_DIM}]Added to lead prompt.[/]")
     return user_input
+
+
+def _launch_and_monitor(
+    *,
+    wrapper,  # noqa: ANN001
+    prompt: str,
+    team_name: str,
+    zo_root: Path,
+    orchestrator,  # noqa: ANN001
+    semantic,  # noqa: ANN001
+    no_tmux: bool,
+) -> None:
+    """Shared launch → monitor → end-session flow for all modes."""
+    use_tmux = not no_tmux
+    console.print(f"\n[{_AMBER}]Launching lead session:[/] team={team_name}")
+    process = wrapper.launch_lead_session(
+        prompt, cwd=str(zo_root), team_name=team_name, use_tmux=use_tmux,
+    )
+
+    if process.tmux_pane_id:
+        console.print(f"[{_AMBER}]Agent session running in tmux.[/]")
+        console.print(
+            f"[{_DIM}]Ctrl-b n → agent window  |  Ctrl-b p → back here[/]"
+        )
+        console.print(
+            f"[{_DIM}]Ctrl-b q N → jump to pane N  |  Ctrl-b z → zoom pane[/]"
+        )
+    else:
+        console.print(f"[{_AMBER}]Monitoring session:[/] pid={process.pid}")
+        console.print(
+            f"[{_DIM}]Headless mode — logs at: logs/wrapper/{team_name}-stdout.log[/]"
+        )
+    console.print()
+
+    _seen_events: set[str] = set()
+
+    def _print_status(team_status, pane_snapshot=""):  # noqa: ANN001
+        from datetime import UTC, datetime
+
+        elapsed = ""
+        if process.started_at:
+            secs = int((datetime.now(UTC) - process.started_at).total_seconds())
+            mins, sec = divmod(secs, 60)
+            elapsed = f"{mins}m{sec:02d}s"
+
+        header_parts = []
+        if elapsed:
+            header_parts.append(f"[{_DIM}][{elapsed}][/]")
+        if team_status.members:
+            names = ", ".join(m.name for m in team_status.members)
+            header_parts.append(f"[{_AMBER}]Team:[/] {names}")
+        if team_status.tasks_total > 0:
+            header_parts.append(
+                f"Tasks: [{_AMBER}]{team_status.tasks_completed}[/]"
+                f"/{team_status.tasks_total} done, "
+                f"{team_status.tasks_in_progress} active"
+            )
+        if header_parts:
+            console.print("  " + "  ".join(header_parts))
+
+        tasks = wrapper.read_task_list(process.team_name)
+        for task in tasks:
+            st = task.get("status", "")
+            content = task.get("content", "")[:60]
+            owner = task.get("owner", "")
+            if st == "completed":
+                icon = "[green]✓[/]"
+            elif st == "in_progress":
+                icon = f"[{_AMBER}]▶[/]"
+            else:
+                icon = f"[{_DIM}]○[/]"
+            owner_str = f" [{_DIM}]({owner})[/]" if owner else ""
+            console.print(f"    {icon} {content}{owner_str}")
+
+        comms_dir = zo_root / "logs" / "comms"
+        if comms_dir.is_dir():
+            import json as _json
+            for log_file in sorted(comms_dir.glob("*.jsonl"), reverse=True)[:1]:
+                try:
+                    lines = log_file.read_text(encoding="utf-8").splitlines()
+                except OSError:
+                    continue
+                for line in lines[-10:]:
+                    line = line.strip()
+                    if not line:
+                        continue
+                    try:
+                        evt = _json.loads(line)
+                    except ValueError:
+                        continue
+                    eid = evt.get("event_id", "")
+                    if eid in _seen_events:
+                        continue
+                    _seen_events.add(eid)
+                    etype = evt.get("event_type", "")
+                    agent = evt.get("agent", "")
+                    if etype == "decision":
+                        title = evt.get("title", "")[:70]
+                        console.print(
+                            f"    [{_AMBER}]◆ DECISION[/] [{_DIM}]{agent}:[/] {title}"
+                        )
+                    elif etype == "gate":
+                        result = evt.get("result", "")
+                        gphase = evt.get("phase_id", "")
+                        console.print(
+                            f"    [{_AMBER}]⊘ GATE[/] {gphase}: {result}"
+                        )
+                    elif etype == "checkpoint":
+                        progress = evt.get("progress", "")[:70]
+                        console.print(f"    [{_DIM}]↳ {agent}: {progress}[/]")
+                    elif etype == "error":
+                        desc = evt.get("description", "")[:70]
+                        console.print(
+                            f"    [red]✗ ERROR[/] [{_DIM}]{agent}:[/] {desc}"
+                        )
+
+        if not tasks and not header_parts:
+            console.print(f"  [{_DIM}][{elapsed}] Waiting for agents...[/]")
+        console.print()
+
+    process = wrapper.wait_for_completion(process, on_status=_print_status)
+
+    if process.status == "completed":
+        console.print("[green bold]Session completed successfully.[/]")
+    else:
+        console.print(f"[red bold]Session ended with status:[/] {process.status}")
+
+    orchestrator.end_session()
+    semantic.close()
 
 
 @cli.command()
@@ -217,12 +351,9 @@ def build(plan_path: Path, gate_mode: str, no_tmux: bool) -> None:
         console.print("[red bold]No actionable phase found.[/]")
         raise SystemExit(1)
 
-    # 8b. Pre-launch review (supervised mode)
-    if gm == GateMode.SUPERVISED:
-        _show_phase_review(phase, decomp, plan, gate_mode)
-        extra = _ask_additional_instructions()
-    else:
-        extra = ""
+    # 8b. Pre-launch review (all modes) + additional instructions
+    _show_phase_review(phase, decomp, plan, gate_mode)
+    extra = _ask_additional_instructions(gate_mode)
 
     prompt = orchestrator.build_lead_prompt(phase)
     if extra:
@@ -232,139 +363,17 @@ def build(plan_path: Path, gate_mode: str, no_tmux: bool) -> None:
             f"{extra}\n"
         )
 
-    # 9. Launch via LifecycleWrapper
+    # 9-10. Launch, monitor, end session
     wrapper = LifecycleWrapper(comms=comms, log_dir=zo_root / "logs" / "wrapper")
-    team_name = f"zo-{project_name}"
-
-    use_tmux = not no_tmux
-    console.print(f"\n[{_AMBER}]Launching lead session:[/] team={team_name}")
-    process = wrapper.launch_lead_session(
-        prompt,
-        cwd=str(zo_root),
-        team_name=team_name,
-        use_tmux=use_tmux,
+    _launch_and_monitor(
+        wrapper=wrapper,
+        prompt=prompt,
+        team_name=f"zo-{project_name}",
+        zo_root=zo_root,
+        orchestrator=orchestrator,
+        semantic=semantic,
+        no_tmux=no_tmux,
     )
-
-    # 10. Monitor and handle gates
-    if process.tmux_pane_id:
-        console.print(f"[{_AMBER}]Agent session running in tmux.[/]")
-        console.print(
-            f"[{_DIM}]Ctrl-b n → agent window  |  Ctrl-b p → back here[/]"
-        )
-        console.print(
-            f"[{_DIM}]Ctrl-b q N → jump to pane N  |  Ctrl-b z → zoom pane[/]"
-        )
-    else:
-        console.print(f"[{_AMBER}]Monitoring session:[/] pid={process.pid}")
-        console.print(
-            f"[{_DIM}]Headless mode — logs at: logs/wrapper/{team_name}-stdout.log[/]"
-        )
-    console.print()
-
-    _seen_events: set[str] = set()
-
-    def _print_status(team_status, pane_snapshot=""):  # noqa: ANN001
-        """Print live dashboard: elapsed, team, tasks, recent comms events."""
-        from datetime import UTC, datetime
-
-        # -- Elapsed --
-        elapsed = ""
-        if process.started_at:
-            secs = int((datetime.now(UTC) - process.started_at).total_seconds())
-            mins, sec = divmod(secs, 60)
-            elapsed = f"{mins}m{sec:02d}s"
-
-        # -- Header line: elapsed + team summary --
-        header_parts = []
-        if elapsed:
-            header_parts.append(f"[{_DIM}][{elapsed}][/]")
-        if team_status.members:
-            names = ", ".join(m.name for m in team_status.members)
-            header_parts.append(f"[{_AMBER}]Team:[/] {names}")
-        if team_status.tasks_total > 0:
-            header_parts.append(
-                f"Tasks: [{_AMBER}]{team_status.tasks_completed}[/]"
-                f"/{team_status.tasks_total} done, "
-                f"{team_status.tasks_in_progress} active"
-            )
-        if header_parts:
-            console.print("  " + "  ".join(header_parts))
-
-        # -- Task board --
-        tasks = wrapper.read_task_list(process.team_name)
-        for task in tasks:
-            status = task.get("status", "")
-            content = task.get("content", "")[:60]
-            owner = task.get("owner", "")
-            if status == "completed":
-                icon = "[green]✓[/]"
-            elif status == "in_progress":
-                icon = f"[{_AMBER}]▶[/]"
-            else:
-                icon = f"[{_DIM}]○[/]"
-            owner_str = f" [{_DIM}]({owner})[/]" if owner else ""
-            console.print(f"    {icon} {content}{owner_str}")
-
-        # -- Recent comms events (JSONL log) --
-        comms_dir = zo_root / "logs" / "comms"
-        if comms_dir.is_dir():
-            import json as _json
-            for log_file in sorted(comms_dir.glob("*.jsonl"), reverse=True)[:1]:
-                try:
-                    lines = log_file.read_text(encoding="utf-8").splitlines()
-                except OSError:
-                    continue
-                for line in lines[-10:]:
-                    line = line.strip()
-                    if not line:
-                        continue
-                    try:
-                        evt = _json.loads(line)
-                    except ValueError:
-                        continue
-                    eid = evt.get("event_id", "")
-                    if eid in _seen_events:
-                        continue
-                    _seen_events.add(eid)
-                    etype = evt.get("event_type", "")
-                    agent = evt.get("agent", "")
-                    if etype == "decision":
-                        title = evt.get("title", "")[:70]
-                        console.print(
-                            f"    [{_AMBER}]◆ DECISION[/] [{_DIM}]{agent}:[/] {title}"
-                        )
-                    elif etype == "gate":
-                        result = evt.get("result", "")
-                        phase = evt.get("phase_id", "")
-                        console.print(
-                            f"    [{_AMBER}]⊘ GATE[/] {phase}: {result}"
-                        )
-                    elif etype == "checkpoint":
-                        progress = evt.get("progress", "")[:70]
-                        console.print(
-                            f"    [{_DIM}]↳ {agent}: {progress}[/]"
-                        )
-                    elif etype == "error":
-                        desc = evt.get("description", "")[:70]
-                        console.print(
-                            f"    [red]✗ ERROR[/] [{_DIM}]{agent}:[/] {desc}"
-                        )
-
-        # -- Separator between polls --
-        if not tasks and not header_parts:
-            console.print(f"  [{_DIM}][{elapsed}] Waiting for agents...[/]")
-        console.print()
-
-    process = wrapper.wait_for_completion(process, on_status=_print_status)
-
-    if process.status == "completed":
-        console.print("[green bold]Session completed successfully.[/]")
-    else:
-        console.print(f"[red bold]Session ended with status:[/] {process.status}")
-
-    # End session
-    orchestrator.end_session()
-    semantic.close()
 
 
 @cli.command("continue")
@@ -374,14 +383,24 @@ def build(plan_path: Path, gate_mode: str, no_tmux: bool) -> None:
     type=click.Choice(["supervised", "auto", "full-auto"]),
     default="supervised",
 )
-def continue_(project_name: str, gate_mode: str) -> None:
-    """Resume a paused project from STATE.md."""
+@click.option("--no-tmux", is_flag=True, help="Disable tmux agent visibility")
+def continue_(project_name: str, gate_mode: str, no_tmux: bool) -> None:
+    """Resume a paused project from STATE.md.
+
+    Reads the project's memory, finds the plan, resumes from the
+    current phase, and launches an interactive agent session.
+    """
     from zo.comms import CommsLogger
     from zo.memory import MemoryManager
+    from zo.orchestrator import Orchestrator
+    from zo.plan import parse_plan, validate_plan
     from zo.semantic import SemanticIndex
+    from zo.target import parse_target
+    from zo.wrapper import LifecycleWrapper
 
     zo_root = _zo_root()
 
+    # 1. Recover session state
     memory = MemoryManager(project_dir=zo_root, project_name=project_name)
     state = memory.recover_session()
 
@@ -393,38 +412,108 @@ def continue_(project_name: str, gate_mode: str) -> None:
         raise SystemExit(1)
 
     console.print(f"[{_AMBER}]Recovering session:[/] {project_name}")
-    console.print(f"  Mode: {state.mode}")
-    console.print(f"  Phase: {state.phase}")
-    console.print(f"  Blockers: {state.active_blockers or 'none'}")
+    console.print(f"  Mode: {state.mode}  Phase: {state.phase}")
+    if state.active_blockers:
+        console.print(f"  Blockers: {', '.join(state.active_blockers)}")
 
-    session_id = f"s-{uuid.uuid4().hex[:8]}"
-    log_dir = zo_root / "logs" / "comms"
-    CommsLogger(log_dir=log_dir, project=project_name, session_id=session_id)
-
-    db_path = memory.memory_root / "index.db"
-    semantic = SemanticIndex(db_path=db_path)
-
-    # Query for relevant context
+    # Show recent session context
     recent = memory.read_recent_summaries(count=3)
     if recent:
         console.print(f"[{_AMBER}]Recent sessions:[/]")
         for s in recent:
-            console.print(f"  {s.date}: {', '.join(s.accomplished[:2]) or 'no summary'}")
+            console.print(
+                f"  {s.date}: {', '.join(s.accomplished[:2]) or 'no summary'}"
+            )
 
-    console.print(
-        f"\n[{_AMBER}]Continue mode ready.[/] "
-        "Full orchestrator launch requires a plan file — use [bold]zo build[/] "
-        "to re-launch with updated plan."
+    # 2. Find and parse the plan
+    plan_path = zo_root / "plans" / f"{project_name}.md"
+    if not plan_path.exists():
+        console.print(f"[red bold]Plan not found:[/] {plan_path}")
+        raise SystemExit(1)
+    plan = parse_plan(plan_path)
+    report = validate_plan(plan)
+    if not report.valid:
+        console.print("[red bold]Plan validation failed.[/]")
+        raise SystemExit(1)
+
+    # 3. Parse target
+    target_path = zo_root / "targets" / f"{project_name}.target.md"
+    if not target_path.exists():
+        console.print(f"[red bold]Target not found:[/] {target_path}")
+        raise SystemExit(1)
+    target = parse_target(target_path)
+
+    # 4. Set up orchestrator
+    session_id = f"s-{uuid.uuid4().hex[:8]}"
+    comms = CommsLogger(
+        log_dir=zo_root / "logs" / "comms",
+        project=project_name, session_id=session_id,
     )
+    db_path = memory.memory_root / "index.db"
+    semantic = SemanticIndex(db_path=db_path)
 
-    semantic.close()
+    decisions = memory.read_decisions()
+    priors = memory.read_priors()
+    if decisions:
+        semantic.index_decisions(decisions)
+    if priors:
+        semantic.index_priors(priors)
+
+    gm = _gate_mode_from_str(gate_mode)
+    orchestrator = Orchestrator(
+        plan=plan, target=target, memory=memory, comms=comms,
+        semantic=semantic, zo_root=zo_root, gate_mode=gm,
+    )
+    orchestrator.start_session()
+    decomp = orchestrator.decompose_plan()
+
+    # 5. Get current phase
+    phase = orchestrator.get_current_phase()
+    if phase is None:
+        console.print("[green bold]All phases complete. Nothing to continue.[/]")
+        raise SystemExit(0)
+
+    # 6. Review and launch
+    _show_phase_review(phase, decomp, plan, gate_mode)
+    extra = _ask_additional_instructions(gate_mode)
+
+    prompt = orchestrator.build_lead_prompt(phase)
+    if extra:
+        prompt += f"\n\n---\n\n# Additional Human Instructions\n\n{extra}\n"
+
+    wrapper = LifecycleWrapper(comms=comms, log_dir=zo_root / "logs" / "wrapper")
+    _launch_and_monitor(
+        wrapper=wrapper,
+        prompt=prompt,
+        team_name=f"zo-{project_name}",
+        zo_root=zo_root,
+        orchestrator=orchestrator,
+        semantic=semantic,
+        no_tmux=no_tmux,
+    )
 
 
 @cli.command()
 @click.argument("project_name")
-def maintain(project_name: str) -> None:
-    """Apply updated plan instructions to a running project."""
+@click.option(
+    "--gate-mode",
+    type=click.Choice(["supervised", "auto", "full-auto"]),
+    default="supervised",
+)
+@click.option("--no-tmux", is_flag=True, help="Disable tmux agent visibility")
+def maintain(project_name: str, gate_mode: str, no_tmux: bool) -> None:
+    """Apply updated plan instructions to a running project.
+
+    Reads the plan, detects changes, and launches an interactive
+    agent session focused on targeted updates rather than full rebuild.
+    """
+    from zo.comms import CommsLogger
     from zo.memory import MemoryManager
+    from zo.orchestrator import Orchestrator
+    from zo.plan import parse_plan, validate_plan
+    from zo.semantic import SemanticIndex
+    from zo.target import parse_target
+    from zo.wrapper import LifecycleWrapper
 
     zo_root = _zo_root()
     memory = MemoryManager(project_dir=zo_root, project_name=project_name)
@@ -438,9 +527,66 @@ def maintain(project_name: str) -> None:
 
     console.print(f"[{_AMBER}]Maintain mode:[/] {project_name}")
     console.print(f"  Current phase: {state.phase}")
-    console.print(
-        "  Apply plan edits by running [bold]zo build[/] with the updated plan. "
-        "The orchestrator will detect changes and re-decompose."
+
+    # Parse plan and target
+    plan_path = zo_root / "plans" / f"{project_name}.md"
+    if not plan_path.exists():
+        console.print(f"[red bold]Plan not found:[/] {plan_path}")
+        raise SystemExit(1)
+    plan = parse_plan(plan_path)
+    report = validate_plan(plan)
+    if not report.valid:
+        console.print("[red bold]Plan validation failed.[/]")
+        raise SystemExit(1)
+
+    target_path = zo_root / "targets" / f"{project_name}.target.md"
+    if not target_path.exists():
+        console.print(f"[red bold]Target not found:[/] {target_path}")
+        raise SystemExit(1)
+    target = parse_target(target_path)
+
+    # Set up orchestrator
+    session_id = f"s-{uuid.uuid4().hex[:8]}"
+    comms = CommsLogger(
+        log_dir=zo_root / "logs" / "comms",
+        project=project_name, session_id=session_id,
+    )
+    db_path = memory.memory_root / "index.db"
+    semantic = SemanticIndex(db_path=db_path)
+
+    gm = _gate_mode_from_str(gate_mode)
+    orchestrator = Orchestrator(
+        plan=plan, target=target, memory=memory, comms=comms,
+        semantic=semantic, zo_root=zo_root, gate_mode=gm,
+    )
+    orchestrator.start_session()
+    decomp = orchestrator.decompose_plan()
+
+    # Check for plan edits
+    if orchestrator.check_plan_edited():
+        console.print(f"[{_AMBER}]Plan changed since last run — will re-decompose.[/]")
+
+    phase = orchestrator.get_current_phase()
+    if phase is None:
+        console.print("[green bold]All phases complete.[/]")
+        raise SystemExit(0)
+
+    _show_phase_review(phase, decomp, plan, gate_mode)
+    extra = _ask_additional_instructions(gate_mode)
+
+    prompt = orchestrator.build_lead_prompt(phase)
+    if extra:
+        prompt += f"\n\n---\n\n# Additional Human Instructions\n\n{extra}\n"
+
+    wrapper = LifecycleWrapper(comms=comms, log_dir=zo_root / "logs" / "wrapper")
+    _launch_and_monitor(
+        wrapper=wrapper,
+        prompt=prompt,
+        team_name=f"zo-{project_name}",
+        zo_root=zo_root,
+        orchestrator=orchestrator,
+        semantic=semantic,
+        no_tmux=no_tmux,
     )
 
 
@@ -543,20 +689,35 @@ def status(project_name: str) -> None:
 
 
 @cli.command()
-@click.argument("source_dir", type=click.Path(exists=True, path_type=Path))
+@click.argument("source_paths", nargs=-1, type=click.Path(exists=True, path_type=Path))
 @click.option("--project", "-p", required=True, help="Project name for the generated plan")
-def draft(source_dir: Path, project: str) -> None:
+@click.option("--no-tmux", is_flag=True, help="Skip interactive refinement session")
+def draft(source_paths: tuple[Path, ...], project: str, no_tmux: bool) -> None:
     """Generate a plan.md from source documents.
 
-    Indexes source documents, then generates a compliant plan.md
-    following the 8-section schema from specs/plan.md.
+    Accepts multiple file and/or directory paths. Indexes all documents,
+    generates a compliant plan.md, then optionally launches an interactive
+    Claude Code session to refine it with you.
+
+    Usage::
+
+        zo draft ~/docs/requirements.md ~/data/notes/ --project my-project
+        zo draft ./specs --project alpha --no-tmux
     """
     from zo.draft import PlanDrafter
 
-    zo_root = _zo_root()
-    drafter = PlanDrafter(source_dir=source_dir, project_name=project, zo_root=zo_root)
+    if not source_paths:
+        console.print("[red bold]No source paths provided.[/]")
+        raise SystemExit(1)
 
-    console.print(f"[{_AMBER}]Indexing documents:[/] {source_dir}")
+    zo_root = _zo_root()
+    drafter = PlanDrafter(
+        source_paths=list(source_paths), project_name=project, zo_root=zo_root,
+    )
+
+    console.print(f"[{_AMBER}]Indexing documents from {len(source_paths)} path(s):[/]")
+    for sp in source_paths:
+        console.print(f"  [{_DIM}]{sp}[/]")
     count = drafter.index_documents()
     console.print(f"[green]Indexed {count} documents.[/]")
 
@@ -572,6 +733,77 @@ def draft(source_dir: Path, project: str) -> None:
             f"[yellow bold]Plan has validation issues.[/] "
             f"Edit {plan_path} to fix them."
         )
+
+    # Interactive refinement session
+    if not no_tmux:
+        from zo.wrapper import LifecycleWrapper
+
+        console.print(
+            f"\n[{_AMBER}]Opening interactive session to refine the plan...[/]"
+        )
+        from zo.comms import CommsLogger
+
+        session_id = f"s-{uuid.uuid4().hex[:8]}"
+        comms = CommsLogger(
+            log_dir=zo_root / "logs" / "comms",
+            project=project, session_id=session_id,
+        )
+        wrapper = LifecycleWrapper(comms=comms, log_dir=zo_root / "logs" / "wrapper")
+
+        refine_prompt = (
+            f"I've drafted a plan.md at {plan_path} for project '{project}'.\n\n"
+            f"The plan was generated from {count} source documents.\n"
+            f"Please review it, suggest improvements, and help me refine the "
+            f"oracle definition, constraints, and agent configuration.\n\n"
+            f"The plan schema is defined in specs/plan.md — ensure compliance."
+        )
+
+        prompt_file = zo_root / "logs" / "wrapper" / f"zo-draft-{project}-prompt.txt"
+        prompt_file.parent.mkdir(parents=True, exist_ok=True)
+        prompt_file.write_text(refine_prompt, encoding="utf-8")
+
+        # Launch interactive claude to refine the plan
+        result = __import__("subprocess").run(
+            ["tmux", "new-window", "-d", "-n", f"draft-{project}",
+             "-P", "-F", "#{pane_id}"],
+            capture_output=True, text=True, timeout=10,
+        )
+        pane_id = result.stdout.strip()
+
+        import shlex
+        claude_abs = wrapper._resolve_claude_bin()
+        cmd = (
+            f'{shlex.quote(claude_abs)}'
+            f' --model sonnet'
+            f' --add-dir {shlex.quote(str(zo_root))}'
+        )
+        __import__("subprocess").run(
+            ["tmux", "send-keys", "-t", pane_id, cmd, "Enter"],
+            capture_output=True, text=True, timeout=10,
+        )
+
+        import time
+        time.sleep(3)
+        __import__("subprocess").run(
+            ["tmux", "load-buffer", str(prompt_file)],
+            capture_output=True, text=True, timeout=10,
+        )
+        __import__("subprocess").run(
+            ["tmux", "paste-buffer", "-t", pane_id],
+            capture_output=True, text=True, timeout=10,
+        )
+        time.sleep(0.5)
+        __import__("subprocess").run(
+            ["tmux", "send-keys", "-t", pane_id, "Enter"],
+            capture_output=True, text=True, timeout=10,
+        )
+
+        console.print(
+            f"[{_AMBER}]Refinement session opened.[/] "
+            f"[{_DIM}]Ctrl-b n to switch to it.[/]"
+        )
+
+    drafter.close()
 
 
 # ---------------------------------------------------------------------------

--- a/src/zo/cli.py
+++ b/src/zo/cli.py
@@ -164,56 +164,113 @@ def build(plan_path: Path, gate_mode: str, no_tmux: bool) -> None:
 
     # 10. Monitor and handle gates
     if process.tmux_pane_id:
+        console.print(f"[{_AMBER}]Agent session running in tmux.[/]")
         console.print(
-            f"[{_AMBER}]Agent session running in tmux pane:[/] {process.tmux_pane_id}"
+            f"[{_DIM}]Ctrl-b n → agent window  |  Ctrl-b p → back here[/]"
         )
         console.print(
-            f"[{_DIM}]Switch to the '{team_name}' tmux window to watch agents work.[/]"
+            f"[{_DIM}]Ctrl-b q N → jump to pane N  |  Ctrl-b z → zoom pane[/]"
         )
-        console.print(
-            f"[{_DIM}]Tip: Ctrl-b n (next window) / Ctrl-b p (prev window)[/]"
-        )
-        console.print()
     else:
         console.print(f"[{_AMBER}]Monitoring session:[/] pid={process.pid}")
         console.print(
             f"[{_DIM}]Headless mode — logs at: logs/wrapper/{team_name}-stdout.log[/]"
         )
+    console.print()
 
-    _last_snapshot = {"text": ""}
+    _seen_events: set[str] = set()
 
     def _print_status(team_status, pane_snapshot=""):  # noqa: ANN001
-        """Print live team/pane status during monitoring."""
-        parts: list[str] = []
+        """Print live dashboard: elapsed, team, tasks, recent comms events."""
+        from datetime import UTC, datetime
+
+        # -- Elapsed --
         elapsed = ""
         if process.started_at:
-            from datetime import UTC, datetime
             secs = int((datetime.now(UTC) - process.started_at).total_seconds())
             mins, sec = divmod(secs, 60)
             elapsed = f"{mins}m{sec:02d}s"
 
+        # -- Header line: elapsed + team summary --
+        header_parts = []
+        if elapsed:
+            header_parts.append(f"[{_DIM}][{elapsed}][/]")
         if team_status.members:
-            members_str = ", ".join(m.name for m in team_status.members)
-            parts.append(
-                f"[{_AMBER}]Team:[/] {members_str} | "
-                f"Tasks: {team_status.tasks_completed}/{team_status.tasks_total} done"
+            names = ", ".join(m.name for m in team_status.members)
+            header_parts.append(f"[{_AMBER}]Team:[/] {names}")
+        if team_status.tasks_total > 0:
+            header_parts.append(
+                f"Tasks: [{_AMBER}]{team_status.tasks_completed}[/]"
+                f"/{team_status.tasks_total} done, "
+                f"{team_status.tasks_in_progress} active"
             )
+        if header_parts:
+            console.print("  " + "  ".join(header_parts))
 
-        # Show latest pane activity (last non-empty line)
-        if pane_snapshot and pane_snapshot.strip():
-            lines = [ln for ln in pane_snapshot.strip().splitlines() if ln.strip()]
-            if lines:
-                last_line = lines[-1].strip()[:100]
-                if last_line != _last_snapshot["text"]:
-                    _last_snapshot["text"] = last_line
-                    parts.append(f"[{_DIM}]Agent: {last_line}[/]")
+        # -- Task board --
+        tasks = wrapper.read_task_list(process.team_name)
+        for task in tasks:
+            status = task.get("status", "")
+            content = task.get("content", "")[:60]
+            owner = task.get("owner", "")
+            if status == "completed":
+                icon = "[green]✓[/]"
+            elif status == "in_progress":
+                icon = f"[{_AMBER}]▶[/]"
+            else:
+                icon = f"[{_DIM}]○[/]"
+            owner_str = f" [{_DIM}]({owner})[/]" if owner else ""
+            console.print(f"    {icon} {content}{owner_str}")
 
-        if parts:
-            prefix = f"[{_DIM}][{elapsed}][/] " if elapsed else ""
-            for p in parts:
-                console.print(f"  {prefix}{p}")
-        elif elapsed:
-            console.print(f"  [{_DIM}][{elapsed}] Running...[/]")
+        # -- Recent comms events (JSONL log) --
+        comms_dir = zo_root / "logs" / "comms"
+        if comms_dir.is_dir():
+            import json as _json
+            for log_file in sorted(comms_dir.glob("*.jsonl"), reverse=True)[:1]:
+                try:
+                    lines = log_file.read_text(encoding="utf-8").splitlines()
+                except OSError:
+                    continue
+                for line in lines[-10:]:
+                    line = line.strip()
+                    if not line:
+                        continue
+                    try:
+                        evt = _json.loads(line)
+                    except ValueError:
+                        continue
+                    eid = evt.get("event_id", "")
+                    if eid in _seen_events:
+                        continue
+                    _seen_events.add(eid)
+                    etype = evt.get("event_type", "")
+                    agent = evt.get("agent", "")
+                    if etype == "decision":
+                        title = evt.get("title", "")[:70]
+                        console.print(
+                            f"    [{_AMBER}]◆ DECISION[/] [{_DIM}]{agent}:[/] {title}"
+                        )
+                    elif etype == "gate":
+                        result = evt.get("result", "")
+                        phase = evt.get("phase_id", "")
+                        console.print(
+                            f"    [{_AMBER}]⊘ GATE[/] {phase}: {result}"
+                        )
+                    elif etype == "checkpoint":
+                        progress = evt.get("progress", "")[:70]
+                        console.print(
+                            f"    [{_DIM}]↳ {agent}: {progress}[/]"
+                        )
+                    elif etype == "error":
+                        desc = evt.get("description", "")[:70]
+                        console.print(
+                            f"    [red]✗ ERROR[/] [{_DIM}]{agent}:[/] {desc}"
+                        )
+
+        # -- Separator between polls --
+        if not tasks and not header_parts:
+            console.print(f"  [{_DIM}][{elapsed}] Waiting for agents...[/]")
+        console.print()
 
     process = wrapper.wait_for_completion(process, on_status=_print_status)
 

--- a/src/zo/cli.py
+++ b/src/zo/cli.py
@@ -1,16 +1,15 @@
 """CLI entry point for Zero Operators.
 
 Provides the ``zo`` command group with subcommands for building,
-continuing, maintaining, initializing, and inspecting ZO projects.
+continuing, initializing, and inspecting ZO projects.
 
 Usage::
 
     zo build plans/my-project.md --gate-mode auto
+    zo continue my-project
     zo init my-project
     zo status my-project
-    zo continue my-project
-    zo maintain my-project
-    zo draft ./docs --project my-project
+    zo draft ~/docs/req.md ~/data/ --project my-project
 """
 
 from __future__ import annotations
@@ -29,6 +28,8 @@ console = Console()
 # ZO brand amber for highlights
 _AMBER = "bold #F0C040"
 _DIM = "#8a6020"
+_VOID = "#080808"
+_VERSION = "1.0.1"
 
 
 def _zo_root() -> Path:
@@ -46,8 +47,43 @@ def _gate_mode_from_str(value: str) -> GateMode:
     return mapping[value]
 
 
+def _show_banner(
+    project: str = "",
+    mode: str = "",
+    phase: str = "",
+    gate_mode: str = "",
+) -> None:
+    """Display the ZO brand panel at startup."""
+    from rich.panel import Panel
+    from rich.text import Text
+
+    logo = Text()
+    logo.append("  ◎ ", style="#F0C040 bold")
+    logo.append("Zero Operators", style="#F0C040 bold")
+    logo.append(f"  v{_VERSION}\n", style=_DIM)
+    logo.append("     Autonomous AI Research & Engineering Teams\n", style=_DIM)
+    if project:
+        logo.append("\n  Project:   ", style=_DIM)
+        logo.append(project, style="#F0C040")
+    if mode:
+        logo.append("\n  Mode:      ", style=_DIM)
+        logo.append(mode, style="#F0C040")
+    if phase:
+        logo.append("\n  Phase:     ", style=_DIM)
+        logo.append(phase, style="#F0C040")
+    if gate_mode:
+        logo.append("\n  Gates:     ", style=_DIM)
+        logo.append(gate_mode, style="#F0C040")
+
+    console.print(Panel(
+        logo,
+        border_style="#F0C040",
+        padding=(0, 1),
+    ))
+
+
 @click.group()
-@click.version_option(package_name="zero-operators")
+@click.version_option(version=_VERSION, package_name="zero-operators")
 def cli() -> None:
     """Zero Operators -- Autonomous AI research and engineering team system."""
 
@@ -267,8 +303,10 @@ def _launch_and_monitor(
 def build(plan_path: Path, gate_mode: str, no_tmux: bool) -> None:
     """Launch a project from a plan.md file.
 
-    Parses the plan, validates it, initializes memory, decomposes into
-    phases, and launches the Lead Orchestrator via Claude Code agent team.
+    Smart mode detection:
+    - Fresh project (no state) -> build from scratch
+    - Existing state -> continue from current phase
+    - Plan edited since last run -> re-decompose and continue
     """
     from zo.comms import CommsLogger
     from zo.memory import MemoryManager
@@ -281,7 +319,6 @@ def build(plan_path: Path, gate_mode: str, no_tmux: bool) -> None:
     zo_root = _zo_root()
 
     # 1. Parse and validate plan
-    console.print(f"[{_AMBER}]Parsing plan:[/] {plan_path}")
     plan = parse_plan(plan_path)
     report = validate_plan(plan)
     if not report.valid:
@@ -289,7 +326,6 @@ def build(plan_path: Path, gate_mode: str, no_tmux: bool) -> None:
         for issue in report.issues:
             console.print(f"  [{_DIM}]{issue.section}:[/] {issue.message}")
         raise SystemExit(1)
-    console.print(f"[green]Plan validated:[/] {plan.frontmatter.project_name}")
 
     project_name = plan.frontmatter.project_name
 
@@ -299,22 +335,30 @@ def build(plan_path: Path, gate_mode: str, no_tmux: bool) -> None:
         console.print(f"[red bold]Target file not found:[/] {target_path}")
         raise SystemExit(1)
     target = parse_target(target_path)
-    console.print(f"[green]Target loaded:[/] {target.project}")
 
-    # 3. Initialize memory
+    # 3. Initialize memory and detect mode
     memory = MemoryManager(project_dir=zo_root, project_name=project_name)
     memory.initialize_project()
-    console.print(f"[green]Memory initialized:[/] {memory.memory_root}")
+    state_check = memory.read_state()
+    detected_mode = "build" if state_check.phase == "init" else "continue"
 
-    # 4. Create CommsLogger and SemanticIndex
+    # 4. Show brand banner
+    _show_banner(
+        project=project_name,
+        mode=detected_mode,
+        phase=state_check.phase if detected_mode == "continue" else "starting",
+        gate_mode=gate_mode,
+    )
+
+    # 5. Create CommsLogger and SemanticIndex
     session_id = f"s-{uuid.uuid4().hex[:8]}"
-    log_dir = zo_root / "logs" / "comms"
-    comms = CommsLogger(log_dir=log_dir, project=project_name, session_id=session_id)
-
+    comms = CommsLogger(
+        log_dir=zo_root / "logs" / "comms",
+        project=project_name, session_id=session_id,
+    )
     db_path = memory.memory_root / "index.db"
     semantic = SemanticIndex(db_path=db_path)
 
-    # Index existing decisions and priors
     decisions = memory.read_decisions()
     priors = memory.read_priors()
     if decisions:
@@ -322,48 +366,39 @@ def build(plan_path: Path, gate_mode: str, no_tmux: bool) -> None:
     if priors:
         semantic.index_priors(priors)
 
-    # 5. Create Orchestrator
+    # 6. Create Orchestrator
     gm = _gate_mode_from_str(gate_mode)
     orchestrator = Orchestrator(
-        plan=plan,
-        target=target,
-        memory=memory,
-        comms=comms,
-        semantic=semantic,
-        zo_root=zo_root,
-        gate_mode=gm,
+        plan=plan, target=target, memory=memory, comms=comms,
+        semantic=semantic, zo_root=zo_root, gate_mode=gm,
     )
+    orchestrator.start_session()
 
-    # 6. Start session
-    state = orchestrator.start_session()
-    console.print(f"[{_AMBER}]Session started:[/] mode={state.mode}, phase={state.phase}")
-
-    # 7. Decompose plan
+    # 7. Check for plan edits (continue mode)
     decomp = orchestrator.decompose_plan()
+    if detected_mode == "continue" and orchestrator.check_plan_edited():
+        console.print(f"[{_AMBER}]Plan changed since last run — re-decomposed.[/]")
+
     console.print(
-        f"[{_AMBER}]Plan decomposed:[/] {len(decomp.phases)} phases, "
-        f"{len(decomp.agent_contracts)} contracts"
+        f"[{_DIM}]{len(decomp.phases)} phases, "
+        f"{len(decomp.agent_contracts)} contracts[/]"
     )
 
-    # 8. Get current phase and build lead prompt
+    # 8. Get current phase
     phase = orchestrator.get_current_phase()
     if phase is None:
-        console.print("[red bold]No actionable phase found.[/]")
-        raise SystemExit(1)
+        console.print("[green bold]All phases complete. Nothing to do.[/]")
+        raise SystemExit(0)
 
-    # 8b. Pre-launch review (all modes) + additional instructions
+    # 9. Phase review + additional instructions
     _show_phase_review(phase, decomp, plan, gate_mode)
     extra = _ask_additional_instructions(gate_mode)
 
     prompt = orchestrator.build_lead_prompt(phase)
     if extra:
-        prompt += (
-            "\n\n---\n\n"
-            "# Additional Human Instructions\n\n"
-            f"{extra}\n"
-        )
+        prompt += f"\n\n---\n\n# Additional Human Instructions\n\n{extra}\n"
 
-    # 9-10. Launch, monitor, end session
+    # 10. Launch, monitor, end session
     wrapper = LifecycleWrapper(comms=comms, log_dir=zo_root / "logs" / "wrapper")
     _launch_and_monitor(
         wrapper=wrapper,
@@ -385,209 +420,20 @@ def build(plan_path: Path, gate_mode: str, no_tmux: bool) -> None:
 )
 @click.option("--no-tmux", is_flag=True, help="Disable tmux agent visibility")
 def continue_(project_name: str, gate_mode: str, no_tmux: bool) -> None:
-    """Resume a paused project from STATE.md.
+    """Resume a paused project. Shorthand for zo build with the existing plan.
 
-    Reads the project's memory, finds the plan, resumes from the
-    current phase, and launches an interactive agent session.
+    Finds plans/{project_name}.md and runs zo build on it.
     """
-    from zo.comms import CommsLogger
-    from zo.memory import MemoryManager
-    from zo.orchestrator import Orchestrator
-    from zo.plan import parse_plan, validate_plan
-    from zo.semantic import SemanticIndex
-    from zo.target import parse_target
-    from zo.wrapper import LifecycleWrapper
-
     zo_root = _zo_root()
-
-    # 1. Recover session state
-    memory = MemoryManager(project_dir=zo_root, project_name=project_name)
-    state = memory.recover_session()
-
-    if state.phase == "init":
-        console.print(
-            f"[red bold]Project '{project_name}' has not been built yet.[/] "
-            "Run [bold]zo build[/] first."
-        )
-        raise SystemExit(1)
-
-    console.print(f"[{_AMBER}]Recovering session:[/] {project_name}")
-    console.print(f"  Mode: {state.mode}  Phase: {state.phase}")
-    if state.active_blockers:
-        console.print(f"  Blockers: {', '.join(state.active_blockers)}")
-
-    # Show recent session context
-    recent = memory.read_recent_summaries(count=3)
-    if recent:
-        console.print(f"[{_AMBER}]Recent sessions:[/]")
-        for s in recent:
-            console.print(
-                f"  {s.date}: {', '.join(s.accomplished[:2]) or 'no summary'}"
-            )
-
-    # 2. Find and parse the plan
     plan_path = zo_root / "plans" / f"{project_name}.md"
     if not plan_path.exists():
         console.print(f"[red bold]Plan not found:[/] {plan_path}")
-        raise SystemExit(1)
-    plan = parse_plan(plan_path)
-    report = validate_plan(plan)
-    if not report.valid:
-        console.print("[red bold]Plan validation failed.[/]")
+        console.print("Run [bold]zo build plans/your-plan.md[/] first.")
         raise SystemExit(1)
 
-    # 3. Parse target
-    target_path = zo_root / "targets" / f"{project_name}.target.md"
-    if not target_path.exists():
-        console.print(f"[red bold]Target not found:[/] {target_path}")
-        raise SystemExit(1)
-    target = parse_target(target_path)
-
-    # 4. Set up orchestrator
-    session_id = f"s-{uuid.uuid4().hex[:8]}"
-    comms = CommsLogger(
-        log_dir=zo_root / "logs" / "comms",
-        project=project_name, session_id=session_id,
-    )
-    db_path = memory.memory_root / "index.db"
-    semantic = SemanticIndex(db_path=db_path)
-
-    decisions = memory.read_decisions()
-    priors = memory.read_priors()
-    if decisions:
-        semantic.index_decisions(decisions)
-    if priors:
-        semantic.index_priors(priors)
-
-    gm = _gate_mode_from_str(gate_mode)
-    orchestrator = Orchestrator(
-        plan=plan, target=target, memory=memory, comms=comms,
-        semantic=semantic, zo_root=zo_root, gate_mode=gm,
-    )
-    orchestrator.start_session()
-    decomp = orchestrator.decompose_plan()
-
-    # 5. Get current phase
-    phase = orchestrator.get_current_phase()
-    if phase is None:
-        console.print("[green bold]All phases complete. Nothing to continue.[/]")
-        raise SystemExit(0)
-
-    # 6. Review and launch
-    _show_phase_review(phase, decomp, plan, gate_mode)
-    extra = _ask_additional_instructions(gate_mode)
-
-    prompt = orchestrator.build_lead_prompt(phase)
-    if extra:
-        prompt += f"\n\n---\n\n# Additional Human Instructions\n\n{extra}\n"
-
-    wrapper = LifecycleWrapper(comms=comms, log_dir=zo_root / "logs" / "wrapper")
-    _launch_and_monitor(
-        wrapper=wrapper,
-        prompt=prompt,
-        team_name=f"zo-{project_name}",
-        zo_root=zo_root,
-        orchestrator=orchestrator,
-        semantic=semantic,
-        no_tmux=no_tmux,
-    )
-
-
-@cli.command()
-@click.argument("project_name")
-@click.option(
-    "--gate-mode",
-    type=click.Choice(["supervised", "auto", "full-auto"]),
-    default="supervised",
-)
-@click.option("--no-tmux", is_flag=True, help="Disable tmux agent visibility")
-def maintain(project_name: str, gate_mode: str, no_tmux: bool) -> None:
-    """Apply updated plan instructions to a running project.
-
-    Reads the plan, detects changes, and launches an interactive
-    agent session focused on targeted updates rather than full rebuild.
-    """
-    from zo.comms import CommsLogger
-    from zo.memory import MemoryManager
-    from zo.orchestrator import Orchestrator
-    from zo.plan import parse_plan, validate_plan
-    from zo.semantic import SemanticIndex
-    from zo.target import parse_target
-    from zo.wrapper import LifecycleWrapper
-
-    zo_root = _zo_root()
-    memory = MemoryManager(project_dir=zo_root, project_name=project_name)
-    state = memory.read_state()
-
-    if state.phase == "init":
-        console.print(
-            f"[red bold]Project '{project_name}' has not been initialized.[/]"
-        )
-        raise SystemExit(1)
-
-    console.print(f"[{_AMBER}]Maintain mode:[/] {project_name}")
-    console.print(f"  Current phase: {state.phase}")
-
-    # Parse plan and target
-    plan_path = zo_root / "plans" / f"{project_name}.md"
-    if not plan_path.exists():
-        console.print(f"[red bold]Plan not found:[/] {plan_path}")
-        raise SystemExit(1)
-    plan = parse_plan(plan_path)
-    report = validate_plan(plan)
-    if not report.valid:
-        console.print("[red bold]Plan validation failed.[/]")
-        raise SystemExit(1)
-
-    target_path = zo_root / "targets" / f"{project_name}.target.md"
-    if not target_path.exists():
-        console.print(f"[red bold]Target not found:[/] {target_path}")
-        raise SystemExit(1)
-    target = parse_target(target_path)
-
-    # Set up orchestrator
-    session_id = f"s-{uuid.uuid4().hex[:8]}"
-    comms = CommsLogger(
-        log_dir=zo_root / "logs" / "comms",
-        project=project_name, session_id=session_id,
-    )
-    db_path = memory.memory_root / "index.db"
-    semantic = SemanticIndex(db_path=db_path)
-
-    gm = _gate_mode_from_str(gate_mode)
-    orchestrator = Orchestrator(
-        plan=plan, target=target, memory=memory, comms=comms,
-        semantic=semantic, zo_root=zo_root, gate_mode=gm,
-    )
-    orchestrator.start_session()
-    decomp = orchestrator.decompose_plan()
-
-    # Check for plan edits
-    if orchestrator.check_plan_edited():
-        console.print(f"[{_AMBER}]Plan changed since last run — will re-decompose.[/]")
-
-    phase = orchestrator.get_current_phase()
-    if phase is None:
-        console.print("[green bold]All phases complete.[/]")
-        raise SystemExit(0)
-
-    _show_phase_review(phase, decomp, plan, gate_mode)
-    extra = _ask_additional_instructions(gate_mode)
-
-    prompt = orchestrator.build_lead_prompt(phase)
-    if extra:
-        prompt += f"\n\n---\n\n# Additional Human Instructions\n\n{extra}\n"
-
-    wrapper = LifecycleWrapper(comms=comms, log_dir=zo_root / "logs" / "wrapper")
-    _launch_and_monitor(
-        wrapper=wrapper,
-        prompt=prompt,
-        team_name=f"zo-{project_name}",
-        zo_root=zo_root,
-        orchestrator=orchestrator,
-        semantic=semantic,
-        no_tmux=no_tmux,
-    )
+    # Delegate to build
+    ctx = click.get_current_context()
+    ctx.invoke(build, plan_path=plan_path, gate_mode=gate_mode, no_tmux=no_tmux)
 
 
 @cli.command("init")

--- a/src/zo/cli.py
+++ b/src/zo/cli.py
@@ -52,6 +52,75 @@ def cli() -> None:
     """Zero Operators -- Autonomous AI research and engineering team system."""
 
 
+def _show_phase_review(phase, decomp, plan, gate_mode: str) -> None:  # noqa: ANN001
+    """Display phase overview for human review before launch."""
+    from rich.rule import Rule
+
+    console.print()
+    console.print(Rule(f"[{_AMBER}] Phase Review ", style=_AMBER))
+    console.print()
+
+    # Phase header
+    console.print(f"  [{_AMBER}]Phase:[/]  {phase.phase_id} — {phase.name}")
+    console.print(f"  [{_AMBER}]Goal:[/]   {phase.description}")
+    console.print(f"  [{_AMBER}]Gate:[/]   {phase.gate_type} ({gate_mode} mode)")
+    console.print()
+
+    # Subtasks
+    console.print(f"  [{_AMBER}]Subtasks:[/]")
+    for i, st in enumerate(phase.subtasks, 1):
+        console.print(f"    {i}. {st}")
+    console.print()
+
+    # Agents
+    console.print(f"  [{_AMBER}]Agents:[/]  {', '.join(phase.assigned_agents)}")
+    console.print()
+
+    # Contracts summary
+    phase_contracts = [
+        c for c in decomp.agent_contracts if c.phase_id == phase.phase_id
+    ]
+    if phase_contracts:
+        console.print(f"  [{_AMBER}]Contracts:[/]")
+        for c in phase_contracts:
+            owns = ", ".join(c.ownership) if c.ownership else "n/a"
+            console.print(f"    [{_DIM}]{c.agent_name}[/] → owns: {owns}")
+        console.print()
+
+    # Oracle / gate criteria
+    if plan.oracle:
+        console.print(f"  [{_AMBER}]Gate Criteria (Oracle):[/]")
+        if plan.oracle.primary_metric:
+            console.print(f"    Metric: {plan.oracle.primary_metric}")
+        if plan.oracle.target_threshold:
+            console.print(f"    Target: {plan.oracle.target_threshold}")
+        if plan.oracle.evaluation_method:
+            console.print(f"    Method: {plan.oracle.evaluation_method}")
+        console.print()
+
+    # Dependencies
+    if phase.depends_on:
+        console.print(
+            f"  [{_AMBER}]Depends on:[/]  {', '.join(phase.depends_on)}"
+        )
+        console.print()
+
+    console.print(Rule(style=_DIM))
+
+
+def _ask_additional_instructions() -> str:
+    """Prompt the user for additional instructions before launch."""
+    console.print(
+        f"  [{_AMBER}]Additional instructions?[/]"
+        f" [{_DIM}](press Enter to skip, or type your request)[/]"
+    )
+    console.print()
+    user_input = console.input(f"  [{_AMBER}]>[/] ").strip()
+    if user_input:
+        console.print(f"  [{_DIM}]Added to lead prompt.[/]")
+    return user_input
+
+
 @cli.command()
 @click.argument("plan_path", type=click.Path(exists=True, path_type=Path))
 @click.option(
@@ -147,14 +216,28 @@ def build(plan_path: Path, gate_mode: str, no_tmux: bool) -> None:
     if phase is None:
         console.print("[red bold]No actionable phase found.[/]")
         raise SystemExit(1)
+
+    # 8b. Pre-launch review (supervised mode)
+    if gm == GateMode.SUPERVISED:
+        _show_phase_review(phase, decomp, plan, gate_mode)
+        extra = _ask_additional_instructions()
+    else:
+        extra = ""
+
     prompt = orchestrator.build_lead_prompt(phase)
+    if extra:
+        prompt += (
+            "\n\n---\n\n"
+            "# Additional Human Instructions\n\n"
+            f"{extra}\n"
+        )
 
     # 9. Launch via LifecycleWrapper
     wrapper = LifecycleWrapper(comms=comms, log_dir=zo_root / "logs" / "wrapper")
     team_name = f"zo-{project_name}"
 
     use_tmux = not no_tmux
-    console.print(f"[{_AMBER}]Launching lead session:[/] team={team_name}")
+    console.print(f"\n[{_AMBER}]Launching lead session:[/] team={team_name}")
     process = wrapper.launch_lead_session(
         prompt,
         cwd=str(zo_root),

--- a/src/zo/draft.py
+++ b/src/zo/draft.py
@@ -27,50 +27,71 @@ class PlanDrafter:
     """Generates a plan.md from indexed source documents.
 
     Args:
-        source_dir: Directory containing source documents to index.
+        source_paths: Files and/or directories to index.
         project_name: Name for the generated project plan.
         zo_root: Root directory of the ZO repository.
+        source_dir: Deprecated — use ``source_paths`` instead.
     """
 
-    def __init__(self, source_dir: Path, project_name: str, zo_root: Path) -> None:
-        self._source_dir = Path(source_dir)
+    def __init__(
+        self,
+        project_name: str,
+        zo_root: Path,
+        *,
+        source_paths: list[Path] | None = None,
+        source_dir: Path | None = None,
+    ) -> None:
+        # Backwards compat: source_dir → source_paths
+        if source_paths is not None:
+            self._source_paths = [Path(p) for p in source_paths]
+        elif source_dir is not None:
+            self._source_paths = [Path(source_dir)]
+        else:
+            self._source_paths = []
         self._project_name = project_name
         self._zo_root = Path(zo_root)
         self._db_path = zo_root / "memory" / project_name / "draft_index.db"
         self._index = SemanticIndex(db_path=self._db_path)
 
     def index_documents(self) -> int:
-        """Index all documents in source_dir using SemanticIndex.
+        """Index documents from all source paths.
+
+        Each path can be a file (indexed directly) or a directory
+        (recursed for supported file types).
 
         Returns:
             Count of indexed documents.
         """
         count = 0
-        for path in sorted(self._source_dir.rglob("*")):
-            if not path.is_file():
-                continue
-            if path.suffix.lower() not in _SUPPORTED_EXTENSIONS:
-                continue
-            try:
-                text = path.read_text(encoding="utf-8")
-            except (UnicodeDecodeError, OSError):
-                continue
-
-            # Use first line as summary, full text for retrieval
-            lines = text.strip().splitlines()
-            summary = lines[0][:200] if lines else path.name
-            rel_path = str(path.relative_to(self._source_dir))
-
-            entry = IndexEntry(
-                entry_id=f"doc-{count:04d}",
-                summary=f"[{rel_path}] {summary}",
-                full_text=text[:5000],  # Truncate very large files
-                source="document",
-            )
-            self._index.index_entry(entry)
-            count += 1
-
+        for src in self._source_paths:
+            if src.is_file():
+                count += self._index_file(src, count)
+            elif src.is_dir():
+                for path in sorted(src.rglob("*")):
+                    if path.is_file():
+                        count += self._index_file(path, count)
         return count
+
+    def _index_file(self, path: Path, offset: int) -> int:
+        """Index a single file. Returns 1 on success, 0 on skip."""
+        if path.suffix.lower() not in _SUPPORTED_EXTENSIONS:
+            return 0
+        try:
+            text = path.read_text(encoding="utf-8")
+        except (UnicodeDecodeError, OSError):
+            return 0
+
+        lines = text.strip().splitlines()
+        summary = lines[0][:200] if lines else path.name
+
+        entry = IndexEntry(
+            entry_id=f"doc-{offset:04d}",
+            summary=f"[{path.name}] {summary}",
+            full_text=text[:5000],
+            source="document",
+        )
+        self._index.index_entry(entry)
+        return 1
 
     def generate_plan(self) -> Path:
         """Generate a plan.md from indexed documents.

--- a/src/zo/wrapper.py
+++ b/src/zo/wrapper.py
@@ -142,13 +142,14 @@ class LifecycleWrapper:
         )
         pane_id = result.stdout.strip()
 
-        # 2. Start claude interactively (NO -p flag → shows TUI)
+        # 2. Start claude interactively (NO -p, NO --dangerously-skip-permissions)
+        #    --dangerously-skip-permissions exits immediately in interactive mode.
+        #    Permissions are handled via .claude/settings.json allow/deny rules.
         interactive_cmd = (
             f'{shlex.quote(claude_abs)}'
             f' --model {shlex.quote(model)}'
             f' --max-turns {max_turns}'
             f' --add-dir {shlex.quote(cwd)}'
-            f' --dangerously-skip-permissions'
         )
         subprocess.run(
             ["tmux", "send-keys", "-t", pane_id, interactive_cmd, "Enter"],

--- a/src/zo/wrapper.py
+++ b/src/zo/wrapper.py
@@ -115,14 +115,17 @@ class LifecycleWrapper:
         model: str,
         max_turns: int,
     ) -> LeadProcess:
-        """Launch Claude Code in a visible tmux window.
+        """Launch Claude Code interactively in a visible tmux window.
 
-        Instead of running a script, this does exactly what the user
-        would do manually: opens a tmux window, types the claude
-        command, and presses Enter.  Claude gets a real interactive
-        TTY and renders its TUI normally.
+        ``claude -p "..." --dangerously-skip-permissions`` runs
+        non-interactively (no TUI).  To get the full interactive
+        experience the user wants, we:
+
+        1. Open a tmux window and start ``claude`` without ``-p``
+        2. Wait for the TUI to render
+        3. Paste the prompt into the TUI via tmux's paste buffer
+        4. Send Enter — Claude processes it with the TUI visible
         """
-        # Save the prompt to a file — too large for command-line args
         prompt_file = self._log_dir / f"{team_name}-prompt.txt"
         prompt_file.write_text(prompt, encoding="utf-8")
 
@@ -131,7 +134,7 @@ class LifecycleWrapper:
 
         claude_abs = self._resolve_claude_bin()
 
-        # 1. Create a new tmux window with a plain shell
+        # 1. Create a new tmux window with a shell
         result = subprocess.run(
             ["tmux", "new-window", "-d", "-n", team_name,
              "-P", "-F", "#{pane_id}"],
@@ -139,18 +142,37 @@ class LifecycleWrapper:
         )
         pane_id = result.stdout.strip()
 
-        # 2. Type the claude command into the shell, exactly like the
-        #    user would.  send-keys handles quoting naturally.
-        cmd = (
+        # 2. Start claude interactively (NO -p flag → shows TUI)
+        interactive_cmd = (
             f'{shlex.quote(claude_abs)}'
             f' --model {shlex.quote(model)}'
             f' --max-turns {max_turns}'
             f' --add-dir {shlex.quote(cwd)}'
             f' --dangerously-skip-permissions'
-            f' -p "$(cat {shlex.quote(str(prompt_file))})"'
         )
         subprocess.run(
-            ["tmux", "send-keys", "-t", pane_id, cmd, "Enter"],
+            ["tmux", "send-keys", "-t", pane_id, interactive_cmd, "Enter"],
+            capture_output=True, text=True, timeout=10,
+        )
+
+        # 3. Wait for TUI to initialize before pasting
+        time.sleep(3)
+
+        # 4. Load the prompt into tmux's paste buffer and paste it
+        #    into the Claude TUI input field
+        subprocess.run(
+            ["tmux", "load-buffer", str(prompt_file)],
+            capture_output=True, text=True, timeout=10,
+        )
+        subprocess.run(
+            ["tmux", "paste-buffer", "-t", pane_id],
+            capture_output=True, text=True, timeout=10,
+        )
+
+        # 5. Send Enter to submit the prompt
+        time.sleep(0.5)
+        subprocess.run(
+            ["tmux", "send-keys", "-t", pane_id, "Enter"],
             capture_output=True, text=True, timeout=10,
         )
 

--- a/src/zo/wrapper.py
+++ b/src/zo/wrapper.py
@@ -115,50 +115,44 @@ class LifecycleWrapper:
         model: str,
         max_turns: int,
     ) -> LeadProcess:
-        """Launch Claude Code in a visible tmux pane (interactive TUI)."""
+        """Launch Claude Code in a visible tmux window.
+
+        Instead of running a script, this does exactly what the user
+        would do manually: opens a tmux window, types the claude
+        command, and presses Enter.  Claude gets a real interactive
+        TTY and renders its TUI normally.
+        """
+        # Save the prompt to a file — too large for command-line args
         prompt_file = self._log_dir / f"{team_name}-prompt.txt"
         prompt_file.write_text(prompt, encoding="utf-8")
 
-        stderr_log = self._log_dir / f"{team_name}-stderr.log"
         stdout_log = self._log_dir / f"{team_name}-stdout.log"
+        stderr_log = self._log_dir / f"{team_name}-stderr.log"
 
-        # Resolve the absolute path to claude so tmux doesn't rely on PATH
         claude_abs = self._resolve_claude_bin()
 
-        # Write a launcher script. Uses login shell to inherit PATH.
-        # Do NOT redirect stderr — Claude Code renders its TUI to stderr.
-        launcher = self._log_dir / f"{team_name}-launch.sh"
-        launcher.write_text(
-            f'#!/bin/bash -l\n'
-            f'PROMPT=$(cat {shlex.quote(str(prompt_file))})\n'
+        # 1. Create a new tmux window with a plain shell
+        result = subprocess.run(
+            ["tmux", "new-window", "-d", "-n", team_name,
+             "-P", "-F", "#{pane_id}"],
+            capture_output=True, text=True, timeout=10,
+        )
+        pane_id = result.stdout.strip()
+
+        # 2. Type the claude command into the shell, exactly like the
+        #    user would.  send-keys handles quoting naturally.
+        cmd = (
             f'{shlex.quote(claude_abs)}'
             f' --model {shlex.quote(model)}'
             f' --max-turns {max_turns}'
             f' --add-dir {shlex.quote(cwd)}'
             f' --dangerously-skip-permissions'
-            f' -p "$PROMPT"\n'
-            f'EXIT_CODE=$?\n'
-            f'if [ $EXIT_CODE -ne 0 ]; then\n'
-            f'  echo ""\n'
-            f'  echo "[ZO] Claude exited with code $EXIT_CODE"\n'
-            f'  echo "[ZO] Press Enter to close this window..."\n'
-            f'  read\n'
-            f'fi\n',
-            encoding="utf-8",
+            f' -p "$(cat {shlex.quote(str(prompt_file))})"'
         )
-        launcher.chmod(0o755)
-
-        # Create a new tmux window running the launcher script
-        result = subprocess.run(
-            [
-                "tmux", "new-window", "-d",
-                "-n", team_name,
-                "-P", "-F", "#{pane_id}",
-                str(launcher),
-            ],
+        subprocess.run(
+            ["tmux", "send-keys", "-t", pane_id, cmd, "Enter"],
             capture_output=True, text=True, timeout=10,
         )
-        pane_id = result.stdout.strip()
 
         lead = LeadProcess(
             pid=None, status=AgentStatus.SPAWNING,

--- a/src/zo/wrapper.py
+++ b/src/zo/wrapper.py
@@ -125,24 +125,22 @@ class LifecycleWrapper:
         # Resolve the absolute path to claude so tmux doesn't rely on PATH
         claude_abs = self._resolve_claude_bin()
 
-        # Write a launcher script. Uses login shell (-l) to inherit PATH,
-        # logs stderr, and keeps the window open on failure so the user
-        # can read the error.
+        # Write a launcher script. Uses login shell to inherit PATH.
+        # Do NOT redirect stderr — Claude Code renders its TUI to stderr.
         launcher = self._log_dir / f"{team_name}-launch.sh"
         launcher.write_text(
-            f'#!/usr/bin/env bash -l\n'
+            f'#!/bin/bash -l\n'
             f'PROMPT=$(cat {shlex.quote(str(prompt_file))})\n'
             f'{shlex.quote(claude_abs)}'
             f' --model {shlex.quote(model)}'
             f' --max-turns {max_turns}'
             f' --add-dir {shlex.quote(cwd)}'
             f' --dangerously-skip-permissions'
-            f' -p "$PROMPT"'
-            f' 2>{shlex.quote(str(stderr_log))}\n'
+            f' -p "$PROMPT"\n'
             f'EXIT_CODE=$?\n'
             f'if [ $EXIT_CODE -ne 0 ]; then\n'
-            f'  echo "\\n[ZO] Claude exited with code $EXIT_CODE"\n'
-            f'  echo "[ZO] stderr: {stderr_log}"\n'
+            f'  echo ""\n'
+            f'  echo "[ZO] Claude exited with code $EXIT_CODE"\n'
             f'  echo "[ZO] Press Enter to close this window..."\n'
             f'  read\n'
             f'fi\n',

--- a/tests/unit/test_cli.py
+++ b/tests/unit/test_cli.py
@@ -25,7 +25,7 @@ class TestCliGroup:
     """Tests for the CLI group and its registered commands."""
 
     def test_cli_group_has_all_commands(self) -> None:
-        expected = {"build", "continue", "maintain", "init", "status", "draft"}
+        expected = {"build", "continue", "init", "status", "draft"}
         actual = set(cli.commands.keys())
         assert expected == actual
 
@@ -221,38 +221,15 @@ class TestBuildCommand:
 class TestContinueCommand:
     """Tests for the ``zo continue`` command."""
 
-    def test_continue_unbuilt_project(
+    def test_continue_missing_plan(
         self, runner: click.testing.CliRunner, tmp_path: Path
     ) -> None:
-        # Init but don't build
-        mem_root = tmp_path / "memory" / "test-project"
-        mem_root.mkdir(parents=True)
-        (mem_root / "sessions").mkdir()
-        (mem_root / "STATE.md").touch()
-
+        """zo continue fails if no plan file exists for the project."""
         with patch("zo.cli._zo_root", return_value=tmp_path):
             result = runner.invoke(cli, ["continue", "test-project"])
 
         assert result.exit_code == 1
-        assert "not been built" in result.output
-
-
-# ---------------------------------------------------------------------------
-# maintain command
-# ---------------------------------------------------------------------------
-
-
-class TestMaintainCommand:
-    """Tests for the ``zo maintain`` command."""
-
-    def test_maintain_uninitialized(
-        self, runner: click.testing.CliRunner, tmp_path: Path
-    ) -> None:
-        with patch("zo.cli._zo_root", return_value=tmp_path):
-            result = runner.invoke(cli, ["maintain", "nonexistent"])
-
-        assert result.exit_code == 1
-        assert "not been initialized" in result.output
+        assert "Plan not found" in result.output
 
 
 # ---------------------------------------------------------------------------

--- a/tests/unit/test_wrapper.py
+++ b/tests/unit/test_wrapper.py
@@ -142,11 +142,13 @@ class TestLaunchLeadSession:
         assert "--add-dir" in cmd
         assert "/my/delivery" in cmd
 
+    @mock.patch("zo.wrapper.time.sleep")
     @mock.patch("zo.wrapper.subprocess.run")
     def test_tmux_launch_creates_pane(
-        self, mock_run: mock.MagicMock, wrapper: LifecycleWrapper
+        self, mock_run: mock.MagicMock, mock_sleep: mock.MagicMock,
+        wrapper: LifecycleWrapper,
     ) -> None:
-        """When inside tmux, creates a window and sends the command."""
+        """When inside tmux, creates window, starts claude, pastes prompt."""
         mock_run.return_value = mock.MagicMock(
             stdout="%5\n", returncode=0
         )
@@ -161,19 +163,15 @@ class TestLaunchLeadSession:
                 use_tmux=True,
             )
 
-        # Two tmux calls: new-window then send-keys
-        assert mock_run.call_count == 3  # which + new-window + send-keys
+        # Calls: which + new-window + send-keys(cmd) + load-buffer +
+        #        paste-buffer + send-keys(Enter)
         calls = mock_run.call_args_list
-        # First call: which claude (resolve binary)
-        # Second call: tmux new-window
-        new_window_args = calls[1][0][0]
-        assert new_window_args[0] == "tmux"
-        assert "new-window" in new_window_args
-        # Third call: tmux send-keys
-        send_keys_args = calls[2][0][0]
-        assert send_keys_args[0] == "tmux"
-        assert "send-keys" in send_keys_args
-        assert "Enter" in send_keys_args
+        tmux_calls = [c for c in calls if c[0][0][0] == "tmux"]
+        actions = [c[0][0][1] for c in tmux_calls]
+        assert "new-window" in actions
+        assert "send-keys" in actions
+        assert "load-buffer" in actions
+        assert "paste-buffer" in actions
 
         assert result.tmux_pane_id == "%5"
         assert result.pid is None

--- a/tests/unit/test_wrapper.py
+++ b/tests/unit/test_wrapper.py
@@ -146,7 +146,7 @@ class TestLaunchLeadSession:
     def test_tmux_launch_creates_pane(
         self, mock_run: mock.MagicMock, wrapper: LifecycleWrapper
     ) -> None:
-        """When inside tmux, launches in a visible tmux pane."""
+        """When inside tmux, creates a window and sends the command."""
         mock_run.return_value = mock.MagicMock(
             stdout="%5\n", returncode=0
         )
@@ -161,13 +161,22 @@ class TestLaunchLeadSession:
                 use_tmux=True,
             )
 
-        # Should have called tmux new-window
-        call_args = mock_run.call_args[0][0]
-        assert call_args[0] == "tmux"
-        assert "new-window" in call_args
+        # Two tmux calls: new-window then send-keys
+        assert mock_run.call_count == 3  # which + new-window + send-keys
+        calls = mock_run.call_args_list
+        # First call: which claude (resolve binary)
+        # Second call: tmux new-window
+        new_window_args = calls[1][0][0]
+        assert new_window_args[0] == "tmux"
+        assert "new-window" in new_window_args
+        # Third call: tmux send-keys
+        send_keys_args = calls[2][0][0]
+        assert send_keys_args[0] == "tmux"
+        assert "send-keys" in send_keys_args
+        assert "Enter" in send_keys_args
 
         assert result.tmux_pane_id == "%5"
-        assert result.pid is None  # No subprocess in tmux mode
+        assert result.pid is None
         assert result.status == AgentStatus.SPAWNING
         assert result.team_name == "alpha"
 


### PR DESCRIPTION
## Summary

Major UX overhaul for ZO v1.0.1:

- **Interactive tmux agent sessions** — Claude Code TUI renders in visible tmux panes. Users watch agents work in real-time, navigate with Ctrl-b, and type directly into the Lead Orchestrator
- **ZO brand panel** at startup — project, mode, phase, gate info styled with amber #F0C040
- **Smart `zo build`** — auto-detects fresh/continue/plan-edited. One command handles all cases
- **Pre-launch phase review** in all modes — subtasks, agents, contracts, oracle criteria displayed before agents spawn
- **Additional instructions prompt** — inject human guidance into the lead prompt before launch
- **Live monitoring dashboard** — task board, team status, comms events in the monitoring window
- **`zo draft` multi-path** — accepts multiple files/dirs, interactive refinement session
- **Simplified CLI** — `zo maintain` removed (build handles it), `zo continue` is thin alias
- **Updated README** — new quick start with tmux guide, updated commands reference

## Key technical decisions

1. `--dangerously-skip-permissions` exits in interactive mode → use `.claude/settings.json` permissions instead
2. Claude TUI renders to stderr → never redirect stderr in tmux mode
3. `tmux send-keys` + `tmux paste-buffer` is the only reliable way to get an interactive TUI
4. Subprocess.Popen, launcher scripts, and `-p` flag all fail to render TUI

## Test plan
- [x] 295 tests pass, ruff clean
- [x] `tmux new -s zo` → `zo build plans/mnist-digit-classifier.md` → brand panel shows, phase review shows, agents visible in tmux
- [x] `zo continue mnist-digit-classifier` → delegates to build
- [x] `zo draft file1 dir/ -p test` → indexes multiple paths
- [ ] `--no-tmux` → headless fallback works

🤖 Generated with [Claude Code](https://claude.com/claude-code)