### PR TITLE
docs: /zo-dev command, session pickup guide, demo font increase

### DIFF
--- a/.claude/commands/zo-dev.md
+++ b/.claude/commands/zo-dev.md
@@ -1,0 +1,43 @@
+---
+description: Resume building/improving ZO itself — loads full platform context and picks up where we left off
+---
+
+# /zo-dev — Continue developing the Zero Operators platform
+
+You are resuming work on the Zero Operators platform itself (not a project ZO is running — the platform code).
+
+## 1. Load context
+
+Read these files in order:
+
+1. `CLAUDE.md` — project rules, coding conventions, self-evolution protocol
+2. `memory/zo-platform/STATE.md` — where we are
+3. `memory/zo-platform/DECISION_LOG.md` — recent decisions (last 5)
+4. `memory/zo-platform/PRIORS.md` — accumulated learnings from failures
+
+## 2. Present briefing
+
+Show the user a concise summary:
+- Current state and what's been done
+- Known issues
+- What's next
+- Any priors relevant to the likely next task
+
+## 3. Ask what to work on
+
+After the briefing, ask the user what they'd like to work on. Common tasks:
+- **IVL F5** — first production project (plan drafting, source docs)
+- **Bug fixes** — from the known issues list
+- **New features** — agent improvements, CLI enhancements, workflow changes
+- **Testing** — running MNIST again, testing a specific mode
+
+## 4. Follow the protocol
+
+Remember the AUTOMATIC Memory & Docs Protocol from CLAUDE.md:
+- Update STATE.md on every commit
+- Append to DECISION_LOG for every decision
+- Add to PRIORS.md if any failure occurs
+- Cascade doc updates if public interface changes
+- Run self-evolution on any error
+
+This is non-negotiable and automatic — don't wait for the user to ask.

--- a/README.md
+++ b/README.md
@@ -189,12 +189,30 @@ zo status my-project
 
 ---
 
-## Commands
+## Session Pickup
 
-ZO provides 23 slash commands for Claude Code. See [docs/COMMANDS.md](docs/COMMANDS.md) for the full reference.
+Starting a new Claude Code session? Use `/zo-dev` to get full context:
+
+```
+/zo-dev
+```
+
+This loads STATE.md, DECISION_LOG, PRIORS, presents a briefing of where you are, and asks what to work on. No need to explain context manually — ZO remembers everything.
+
+Other session commands:
+- `/memory/prime zo-platform` — detailed context briefing with semantic search
+- `/memory/recall "query"` — search past decisions for a specific topic
+- `/memory/session-summary` — wrap up the current session cleanly
+
+---
+
+## Slash Commands
+
+ZO provides 24 slash commands for Claude Code. See [docs/COMMANDS.md](docs/COMMANDS.md) for the full reference.
 
 | Category | Key Commands |
 |----------|-------------|
+| Platform | `/zo-dev` |
 | Project | `/project/import`, `/project/connect`, `/project/plan`, `/project/launch` |
 | Memory | `/memory/recall`, `/memory/prime`, `/memory/priors`, `/memory/session-summary` |
 | Gates | `/gates/approve`, `/gates/reject`, `/gates/gates` |
@@ -262,7 +280,7 @@ Adds **Phase 0: Literature Review** (prior art survey, baseline definition). Pha
 │  ├── Agent(name="oracle-qa", team_name="project")           │
 │  └── Agents communicate peer-to-peer via SendMessage        │
 │                                                             │
-│  The Lead knows all 16 agents and creates new ones on the   │
+│  The Lead knows all 17 agents and creates new ones on the   │
 │  fly if the project needs expertise not in the roster.      │
 │                                                             │
 ├─────────────────────────────────────────────────────────────┤
@@ -388,18 +406,19 @@ mnist-delivery/          ← delivery repo (clean)
 
 ## Status
 
-**All phases complete. Validated end-to-end.**
+**v1.0.1 — All phases complete. Validated end-to-end. Interactive tmux sessions working.**
 
 | Phase | What | Status |
 |-------|------|--------|
-| 0 | Agent definitions + Claude Code setup | Done |
+| 0 | Agent definitions (17) + Claude Code setup | Done |
 | 1 | Plan parser, target parser, comms logger, setup | Done |
 | 2 | Memory layer, semantic index | Done |
 | 3 | Orchestration engine + lifecycle wrapper | Done |
 | 4 | Evolution engine, CLI, integration tests | Done |
 | 5 | E2E validation (MNIST: 99% accuracy) | Done |
+| 1.0.1 | Interactive tmux, brand panel, smart build, Research Scout, self-evolution | Done |
 
-295 platform tests. 92% coverage. ruff clean.
+295 platform tests. ruff clean. 17 agents. 24 slash commands.
 
 ---
 

--- a/docs/COMMANDS.md
+++ b/docs/COMMANDS.md
@@ -2,7 +2,7 @@
 
 ## Overview
 
-Zero Operators provides 23 slash commands for Claude Code, covering the full project lifecycle from import to retrospective. Commands are organized into seven categories: Project Lifecycle, Memory & Continuity, Gate Management, Observability, Documentation, Agent Management, and Utility.
+Zero Operators provides 24 slash commands for Claude Code, covering the full project lifecycle from import to retrospective. Commands are organized into eight categories: Project Lifecycle, Memory & Continuity, Gate Management, Observability, Documentation, Agent Management, Platform Development, and Utility.
 
 All commands are defined in `.claude/commands/` and invoked as `/category/command` in a Claude Code session.
 
@@ -489,6 +489,30 @@ Create a new agent definition file interactively.
 **Example:**
 ```
 /agents/create-agent time-series-specialist
+```
+
+---
+
+## Platform Development
+
+### /zo-dev
+
+Resume building/improving ZO itself -- loads full platform context and picks up where we left off.
+
+**Arguments:** None
+
+**What happens:**
+
+1. Reads CLAUDE.md for project rules and self-evolution protocol.
+2. Reads memory/zo-platform/STATE.md for current state.
+3. Reads recent decisions from DECISION_LOG.md.
+4. Reads accumulated learnings from PRIORS.md.
+5. Presents a concise briefing: state, recent work, what's next.
+6. Asks what to work on.
+
+**Example:**
+```
+/zo-dev
 ```
 
 ---

--- a/docs/demo.html
+++ b/docs/demo.html
@@ -45,7 +45,7 @@
 
   .tab {
     font-family: 'Share Tech Mono', monospace;
-    font-size: 10px;
+    font-size: 13px;
     letter-spacing: 0.2em;
     text-transform: uppercase;
     color: var(--amber-dim);
@@ -85,7 +85,7 @@
 
   /* ── SECTION LABEL ── */
   .section-label {
-    font-size: 9px;
+    font-size: 12px;
     letter-spacing: 0.25em;
     color: #3a2e0c;
     text-transform: uppercase;
@@ -107,7 +107,7 @@
   h1 {
     font-family: 'Rajdhani', sans-serif;
     font-weight: 700;
-    font-size: 42px;
+    font-size: 55px;
     letter-spacing: 0.08em;
     color: var(--amber);
     margin-bottom: 8px;
@@ -116,7 +116,7 @@
   h2 {
     font-family: 'Rajdhani', sans-serif;
     font-weight: 700;
-    font-size: 28px;
+    font-size: 36px;
     letter-spacing: 0.06em;
     color: var(--amber);
     margin-bottom: 8px;
@@ -125,21 +125,21 @@
   h3 {
     font-family: 'Rajdhani', sans-serif;
     font-weight: 600;
-    font-size: 18px;
+    font-size: 23px;
     letter-spacing: 0.05em;
     color: var(--amber);
     margin-bottom: 4px;
   }
 
   .subtitle {
-    font-size: 12px;
+    font-size: 16px;
     color: var(--amber-dim);
     letter-spacing: 0.1em;
     margin-bottom: 32px;
   }
 
   p {
-    font-size: 12px;
+    font-size: 16px;
     color: #8a7a40;
     line-height: 1.7;
     letter-spacing: 0.04em;
@@ -165,19 +165,19 @@
   .stat-num {
     font-family: 'Rajdhani', sans-serif;
     font-weight: 700;
-    font-size: 36px;
+    font-size: 47px;
     color: var(--amber);
     line-height: 1;
   }
 
   .stat-unit {
-    font-size: 11px;
+    font-size: 14px;
     color: var(--amber-dim);
     margin-left: 4px;
   }
 
   .stat-label {
-    font-size: 9px;
+    font-size: 12px;
     letter-spacing: 0.18em;
     color: #3a2e0c;
     text-transform: uppercase;
@@ -204,7 +204,7 @@
   }
 
   .arch-layer-label {
-    font-size: 9px;
+    font-size: 12px;
     letter-spacing: 0.2em;
     color: var(--amber-dim);
     text-transform: uppercase;
@@ -212,7 +212,7 @@
   }
 
   .arch-layer-content {
-    font-size: 11px;
+    font-size: 14px;
     color: #8a7a40;
     line-height: 1.6;
   }
@@ -220,7 +220,7 @@
   .arch-arrow {
     text-align: center;
     color: var(--amber);
-    font-size: 16px;
+    font-size: 21px;
     margin: 4px 0;
     opacity: 0.4;
   }
@@ -240,7 +240,7 @@
     border: 1px solid var(--rule);
     border-radius: 4px;
     padding: 12px 18px;
-    font-size: 11px;
+    font-size: 14px;
     color: var(--amber-dim);
     letter-spacing: 0.1em;
     transition: all 0.4s ease;
@@ -255,7 +255,7 @@
 
   .flow-arrow {
     color: var(--amber);
-    font-size: 14px;
+    font-size: 18px;
     opacity: 0.3;
     transition: opacity 0.4s ease;
   }
@@ -291,7 +291,7 @@
   }
 
   .terminal-title {
-    font-size: 9px;
+    font-size: 12px;
     color: #3a2e0c;
     letter-spacing: 0.15em;
     text-transform: uppercase;
@@ -300,7 +300,7 @@
 
   .terminal-body {
     padding: 16px 20px;
-    font-size: 12px;
+    font-size: 16px;
     line-height: 1.6;
     color: #8a7a40;
     overflow-x: auto;
@@ -340,7 +340,7 @@
   .step-number {
     font-family: 'Rajdhani', sans-serif;
     font-weight: 700;
-    font-size: 24px;
+    font-size: 31px;
     color: var(--amber-dim);
     min-width: 32px;
     transition: color 0.3s ease;
@@ -351,7 +351,7 @@
   .step-title {
     font-family: 'Rajdhani', sans-serif;
     font-weight: 600;
-    font-size: 16px;
+    font-size: 21px;
     color: var(--amber-dim);
     letter-spacing: 0.06em;
     transition: color 0.3s ease;
@@ -362,7 +362,7 @@
   .step-chevron {
     margin-left: auto;
     color: var(--amber-dim);
-    font-size: 12px;
+    font-size: 16px;
     transition: transform 0.3s ease;
   }
 
@@ -415,14 +415,14 @@
   .agent-name {
     font-family: 'Rajdhani', sans-serif;
     font-weight: 600;
-    font-size: 14px;
+    font-size: 18px;
     color: var(--amber);
     letter-spacing: 0.06em;
     margin-bottom: 4px;
   }
 
   .agent-model {
-    font-size: 9px;
+    font-size: 12px;
     letter-spacing: 0.15em;
     text-transform: uppercase;
     margin-bottom: 8px;
@@ -433,7 +433,7 @@
   .agent-model.haiku { color: #3a2e0c; }
 
   .agent-role {
-    font-size: 10px;
+    font-size: 13px;
     color: #5a4a20;
     line-height: 1.5;
   }
@@ -442,7 +442,7 @@
     position: absolute;
     top: 10px;
     right: 10px;
-    font-size: 8px;
+    font-size: 10px;
     letter-spacing: 0.15em;
     text-transform: uppercase;
     padding: 2px 8px;
@@ -468,7 +468,7 @@
     display: flex;
     gap: 16px;
     margin-bottom: 8px;
-    font-size: 11px;
+    font-size: 14px;
   }
 
   .agent-detail-label {
@@ -476,7 +476,7 @@
     min-width: 100px;
     letter-spacing: 0.1em;
     text-transform: uppercase;
-    font-size: 9px;
+    font-size: 12px;
   }
 
   .agent-detail-value {
@@ -509,7 +509,7 @@
   .pipeline-number {
     font-family: 'Rajdhani', sans-serif;
     font-weight: 700;
-    font-size: 28px;
+    font-size: 36px;
     color: var(--amber-dim);
     min-width: 40px;
   }
@@ -521,7 +521,7 @@
   .pipeline-title {
     font-family: 'Rajdhani', sans-serif;
     font-weight: 600;
-    font-size: 15px;
+    font-size: 20px;
     color: var(--amber-dim);
     letter-spacing: 0.05em;
   }
@@ -529,7 +529,7 @@
   .pipeline-node.expanded .pipeline-title { color: var(--amber); }
 
   .pipeline-gate {
-    font-size: 9px;
+    font-size: 12px;
     letter-spacing: 0.15em;
     text-transform: uppercase;
     padding: 2px 8px;
@@ -556,7 +556,7 @@
   }
 
   .pipeline-subtask {
-    font-size: 11px;
+    font-size: 14px;
     color: #5a4a20;
     padding: 4px 0;
     display: flex;
@@ -581,7 +581,7 @@
 
   .mode-btn {
     font-family: 'Share Tech Mono', monospace;
-    font-size: 10px;
+    font-size: 13px;
     letter-spacing: 0.15em;
     text-transform: uppercase;
     padding: 10px 20px;
@@ -600,7 +600,7 @@
   /* ── COMMAND PALETTE ── */
   .cmd-search {
     font-family: 'Share Tech Mono', monospace;
-    font-size: 13px;
+    font-size: 17px;
     letter-spacing: 0.08em;
     background: #050505;
     border: 1px solid var(--rule);
@@ -622,7 +622,7 @@
   .cmd-category-header {
     font-family: 'Rajdhani', sans-serif;
     font-weight: 600;
-    font-size: 14px;
+    font-size: 18px;
     color: var(--amber-dim);
     letter-spacing: 0.1em;
     padding: 8px 0;
@@ -638,7 +638,7 @@
   .cmd-category-header:hover { color: var(--amber); }
 
   .cmd-category-chevron {
-    font-size: 10px;
+    font-size: 13px;
     transition: transform 0.2s ease;
   }
 
@@ -657,13 +657,13 @@
   .cmd-item:hover { border-color: var(--rule); background: var(--surface); }
 
   .cmd-item-name {
-    font-size: 12px;
+    font-size: 16px;
     color: var(--amber);
     margin-bottom: 2px;
   }
 
   .cmd-item-desc {
-    font-size: 10px;
+    font-size: 13px;
     color: #5a4a20;
   }
 
@@ -711,20 +711,20 @@
   .timeline-phase {
     font-family: 'Rajdhani', sans-serif;
     font-weight: 600;
-    font-size: 13px;
+    font-size: 17px;
     color: var(--amber);
     letter-spacing: 0.06em;
   }
 
   .timeline-desc {
-    font-size: 10px;
+    font-size: 13px;
     color: #5a4a20;
     line-height: 1.5;
     margin-top: 4px;
   }
 
   .timeline-commit {
-    font-size: 10px;
+    font-size: 13px;
     color: #3a2e0c;
     margin-top: 4px;
   }
@@ -745,7 +745,7 @@
   }
 
   .ba-label {
-    font-size: 9px;
+    font-size: 12px;
     letter-spacing: 0.2em;
     text-transform: uppercase;
     margin-bottom: 12px;
@@ -755,7 +755,7 @@
   .ba-label.after { color: var(--amber); }
 
   .tree-line {
-    font-size: 11px;
+    font-size: 14px;
     color: #5a4a20;
     line-height: 1.6;
     padding-left: 8px;
@@ -868,7 +868,7 @@
   /* ── THEME TOGGLE BUTTON ── */
   .theme-toggle {
     font-family: 'Share Tech Mono', monospace;
-    font-size: 14px;
+    font-size: 18px;
     background: transparent;
     border: 1px solid var(--rule);
     color: var(--amber-dim);
@@ -916,7 +916,7 @@
     border-top: 1px solid var(--rule);
     padding: 32px 24px;
     text-align: center;
-    font-size: 9px;
+    font-size: 12px;
     letter-spacing: 0.2em;
     color: #3a2e0c;
     text-transform: uppercase;
@@ -929,9 +929,9 @@
     .stat-block { grid-template-columns: 1fr; }
     .agent-grid { grid-template-columns: 1fr 1fr; }
     .ba-grid { grid-template-columns: 1fr; }
-    h1 { font-size: 28px; }
+    h1 { font-size: 36px; }
     .tabs { padding: 0 8px; }
-    .tab { padding: 12px 12px 10px; font-size: 9px; }
+    .tab { padding: 12px 12px 10px; font-size: 12px; }
     .panel { padding: 24px 16px 60px; }
   }
 </style>
@@ -996,7 +996,7 @@
 
     <div class="stat-block">
       <div class="stat-item scanlines">
-        <div class="stat-num">16<span class="stat-unit">agents</span></div>
+        <div class="stat-num">17<span class="stat-unit">agents</span></div>
         <div class="stat-label">Defined</div>
       </div>
       <div class="stat-item scanlines">
@@ -1254,16 +1254,23 @@
     </div>
 
     <h1>AGENT TEAMS</h1>
-    <div class="subtitle">16 agents across project delivery and platform build</div>
+    <div class="subtitle">17 agents across project delivery and platform build</div>
 
     <div class="section-label">Project Delivery Team -- Launch Agents</div>
 
     <div class="agent-grid" id="agent-grid-launch">
     <div class="agent-card" onclick="selectAgent(this, 'lead-orchestrator')" data-agent="lead-orchestrator">
+  'research-scout': { model: 'Opus', team: 'Project Delivery', role: 'Surveys literature for relevant approaches, identifies SOTA and analogous benchmarks, catalogs open-source implementations, designs experiment plans with baselines. Handles customer projects with no published benchmarks.', owns: 'research/', when: 'Phase 0 (Literature Review) and Phase 3 (Model Design)' },
       <div class="agent-badge launch">launch</div>
       <div class="agent-name">Lead Orchestrator</div>
       <div class="agent-model opus">Opus</div>
       <div class="agent-role">Creates team, decomposes phases, manages gates, coordinates all agents</div>
+    </div>
+    <div class="agent-card" onclick="selectAgent(this, 'research-scout')" data-agent="research-scout">
+      <div class="agent-badge launch">launch</div>
+      <div class="agent-name">Research Scout</div>
+      <div class="agent-model opus">Opus</div>
+      <div class="agent-role">Literature survey, SOTA analysis, open-source code, experiment plans</div>
     </div>
     <div class="agent-card" onclick="selectAgent(this, 'data-engineer')" data-agent="data-engineer">
       <div class="agent-badge launch">launch</div>
@@ -1294,6 +1301,12 @@
       <div class="agent-name">Test Engineer</div>
       <div class="agent-model sonnet">Sonnet</div>
       <div class="agent-role">Unit, integration, and regression test suites</div>
+    </div>
+    <div class="agent-card" onclick="selectAgent(this, 'research-scout')" data-agent="research-scout">
+      <div class="agent-badge launch">launch</div>
+      <div class="agent-name">Research Scout</div>
+      <div class="agent-model opus">Opus</div>
+      <div class="agent-role">Surveys literature, finds SOTA, designs experiment plans</div>
     </div>
   </div>
 
@@ -1420,7 +1433,7 @@
       <div class="pipeline-detail-inner">
         <div class="pipeline-subtask">Prior art survey and baseline definition</div>
         <div class="pipeline-subtask">Paper analysis and method comparison</div>
-        <div class="pipeline-subtask">Agents: Lead Orchestrator, Domain Evaluator</div>
+        <div class="pipeline-subtask">Agents: Research Scout (owner), Lead Orchestrator, Domain Evaluator</div>
       </div>
     </div>
 
@@ -1536,7 +1549,7 @@
 <div class="panel" id="panel-commands">
 
   <h1>COMMANDS</h1>
-  <div class="subtitle">23 slash commands for Claude Code</div>
+  <div class="subtitle">24 slash commands for Claude Code</div>
 
   <input type="text" class="cmd-search" id="cmd-search" placeholder="Type to filter commands..." oninput="filterCommands()">
 
@@ -1684,6 +1697,18 @@
       <div class="cmd-item" data-search="commit git conventional stage">
         <div class="cmd-item-name">/commit</div>
         <div class="cmd-item-desc">Stage and commit changes with a conventional commit message</div>
+      </div>
+    </div>
+  </div>
+
+  <div class="cmd-category" id="cat-platform">
+    <div class="cmd-category-header" onclick="toggleCategory(this)">
+      <span class="cmd-category-chevron">&rsaquo;</span> Platform Development
+    </div>
+    <div class="cmd-list">
+      <div class="cmd-item" data-search="zo-dev platform development build improve resume context">
+        <div class="cmd-item-name">/zo-dev</div>
+        <div class="cmd-item-desc">Resume building/improving ZO itself -- loads full platform context and picks up where we left off</div>
       </div>
     </div>
   </div>
@@ -1875,6 +1900,7 @@ function toggleStep(el) {
 // ── Agent cards ──
 const agentData = {
   'lead-orchestrator': { model: 'Opus', team: 'Project Delivery', role: 'Creates the agent team, decomposes the plan into phases, manages gate transitions, coordinates all agent communication. The central hub.', owns: 'Orchestration, phase management, gate coordination', when: 'Always active -- present in every phase' },
+  'research-scout': { model: 'Opus', team: 'Project Delivery', role: 'Surveys literature for relevant approaches, identifies SOTA and analogous benchmarks, catalogs open-source implementations, designs experiment plans with baselines. Handles customer projects with no published benchmarks.', owns: 'research/', when: 'Phase 0 (Literature Review) and Phase 3 (Model Design)' },
   'data-engineer': { model: 'Sonnet', team: 'Project Delivery', role: 'Builds and validates the data pipeline. Handles data cleaning, EDA, profiling, DataLoader construction, train/val/test splits, and data versioning.', owns: 'data/, DataLoaders, data tests', when: 'Phases 1-2 (Data Review, Feature Engineering)' },
   'model-builder': { model: 'Opus', team: 'Project Delivery', role: 'Designs model architecture, writes training loops, runs the iteration protocol (train, evaluate, adjust). Handles architecture selection, loss function design, and hyperparameter strategy.', owns: 'src/model.py, src/train.py, models/', when: 'Phases 3-5 (Model Design through Validation)' },
   'oracle-qa': { model: 'Sonnet', team: 'Project Delivery', role: 'The hard evaluator. Runs tiered metric evaluation (Tier 1 core, Tier 2 operational, Tier 3 robustness). Enforces pass/fail gating with no negotiation on thresholds.', owns: 'oracle/, reports/validation_report.md', when: 'Phases 3-5 (every evaluation cycle)' },
@@ -1883,7 +1909,8 @@ const agentData = {
   'xai-agent': { model: 'Sonnet', team: 'Project Delivery (Phase-in)', role: 'Produces explainability analysis: SHAP values, feature importance rankings, GradCAM visualizations, and interpretability reports.', owns: 'xai/, experiments/explainability/', when: 'Phase 5 (Analysis & Validation)' },
   'domain-evaluator': { model: 'Opus', team: 'Project Delivery (Phase-in)', role: 'Validates model outputs against domain knowledge. Checks plausibility, extracts domain priors, and flags results that are statistically valid but domain-implausible.', owns: 'PRIORS.md updates, domain validation reports', when: 'Phase 5 (domain-specific validation)' },
   'ml-engineer': { model: 'Sonnet', team: 'Project Delivery (Phase-in)', role: 'Optimizes the inference pipeline, manages experiment tracking, handles model serving configuration, and ensures production readiness.', owns: 'src/inference.py, experiments/', when: 'Phases 4-6 (Training through Packaging)' },
-  'infra-engineer': { model: 'Haiku', team: 'Project Delivery (Phase-in)', role: 'Handles environment setup, dependency management, packaging (pyproject.toml), deployment configs, and CI/CD pipeline setup.', owns: 'pyproject.toml, setup.sh, CI configs', when: 'Phases 1, 6 (initial setup, final packaging)' }
+  'infra-engineer': { model: 'Haiku', team: 'Project Delivery (Phase-in)', role: 'Handles environment setup, dependency management, packaging (pyproject.toml), deployment configs, and CI/CD pipeline setup.', owns: 'pyproject.toml, setup.sh, CI configs', when: 'Phases 1, 6 (initial setup, final packaging)' },
+  'research-scout': { model: 'Opus', team: 'Project Delivery', role: 'Surveys literature, finds state-of-the-art methods, designs experiment plans. Owns the Phase 0 literature review and baseline definition.', owns: 'Literature surveys, experiment design docs, PRIORS.md contributions', when: 'Phase 0 (Literature Review)' }
 };
 
 function selectAgent(el, name) {

--- a/plans/zero-operators-build.md
+++ b/plans/zero-operators-build.md
@@ -64,7 +64,7 @@ Deliverables: a working ZO platform deployed as a Python package in the `zero-op
 - Phase 6: Packaging and release
 
 **Gates:**
-- Gate 0: blocking (human verifies all 16 agent definitions are correct, Claude Code setup validated)
+- Gate 0: blocking (human verifies all 17 agent definitions are correct, Claude Code setup validated)
 - Gate 1: automated (plan parser, target parser, comms logger, setup tooling pass unit tests)
 - Gate 2: blocking (human reviews module contracts and integration plan)
 - Gate 3: automated (orchestration engine passes unit tests with mocked agents)


### PR DESCRIPTION
## Summary
2 commits that landed after PR #14 was merged:

- **`/zo-dev` slash command** — resume ZO platform development. Loads STATE.md, DECISION_LOG, PRIORS, presents briefing, asks what to work on.
- **README** — added "Session Pickup" section with `/zo-dev` usage, updated commands table (24 commands, Platform category)
- **COMMANDS.md** — 24 commands across 8 categories, `/zo-dev` documented
- **demo.html** — all font sizes increased ~30%, Research Scout card + JS data, 17 agents, 24 commands

## Test plan
- [x] 295 tests pass, ruff clean
- [x] Zero stale references

🤖 Generated with [Claude Code](https://claude.com/claude-code)