### PR TITLE
fix(hooks): cascade-reminder globs + session-009 memory

### DIFF
--- a/.claude/hooks/cascade-reminder.sh
+++ b/.claude/hooks/cascade-reminder.sh
@@ -28,13 +28,13 @@ case "$FILE_PATH" in
     *.claude/commands/*)
         REMINDER="Command file modified. Cascade check: update README.md (command count), docs/COMMANDS.md (add/remove entry), memory/zo-platform/STATE.md (count). Run: ./scripts/validate-docs.sh"
         ;;
-    */pyproject.toml)
+    *pyproject.toml)
         REMINDER="pyproject.toml modified. If version changed, also update: src/zo/__init__.py (__version__), src/zo/cli.py (_VERSION). Run: ./scripts/validate-docs.sh"
         ;;
-    */src/zo/__init__.py)
+    *src/zo/__init__.py|*__init__.py)
         REMINDER="__init__.py modified. If version changed, also update: pyproject.toml (version), src/zo/cli.py (_VERSION). Run: ./scripts/validate-docs.sh"
         ;;
-    */src/zo/cli.py)
+    *src/zo/cli.py|*cli.py)
         REMINDER="cli.py modified. If version or commands changed, also update: pyproject.toml (version), src/zo/__init__.py (__version__), README.md, docs/COMMANDS.md. Run: ./scripts/validate-docs.sh"
         ;;
 esac

--- a/memory/zo-platform/STATE.md
+++ b/memory/zo-platform/STATE.md
@@ -8,7 +8,7 @@ status: complete
 
 ## Current Position
 
-ZO v1.0.1 — **complete, validated, and user-tested**. Interactive tmux agent sessions working. Brand panel, smart build, simplified CLI. Ready for IVL F5.
+ZO v1.0.1 — **complete, validated, user-tested, and self-enforcing**. All docs verified consistent with codebase. Hook system prevents doc-code drift. Ready for IVL F5.
 
 ## Completed
 
@@ -29,23 +29,29 @@ ZO v1.0.1 — **complete, validated, and user-tested**. Interactive tmux agent s
 - [x] v1.0.1: zo continue is thin alias for zo build
 - [x] v1.0.1: zo draft accepts multiple file/dir paths + interactive refinement
 - [x] v1.0.1: Live monitoring dashboard (tasks, team, comms events)
+- [x] v1.0.1: Doc-code consistency: validate-docs.sh (10 checks, <2s)
+- [x] v1.0.1: Hook system: SessionStart (auto-context), PreToolUse (commit gate), PostToolUse (cascade reminder), Stop (drift check)
+- [x] v1.0.1: Self-evolution: PR-005 (enforcement > aspiration), three-layer defense
+- [x] v1.0.1: Full doc audit: agent counts 16→17, version 1.0.0→1.0.1, test badge 295→298, Model Builder/Backend Engineer tiers fixed
 
 ## Known Issues
 
 1. Phase state not persisted between zo build calls — re-decomposes each time
 2. Blocking gates cause repeated sessions in auto mode without advancing
 3. MNIST Phase 6 (packaging: model card, validation report) not completed
-4. Agent permissions need broader .claude/settings.json allow patterns
+4. ~~Agent permissions need broader .claude/settings.json allow patterns~~ (resolved: cd, pip, source, cat, head, tail, find, wc, touch all added)
 
 ## What's Next
 
 1. **IVL F5** — first real production project
 2. Fix phase persistence between sessions
-3. Broader permission patterns in settings.json (Bash(cd *), Bash(pip *), etc.)
-4. v1.1: phase-in agents, multi-project support
+3. v1.1: phase-in agents, multi-project support
 
 ## Session Metadata
 
-last_checkpoint: 2026-04-10T12:00:00Z
-last_session: session-008
-branch: claude/blissful-babbage
+last_checkpoint: 2026-04-10T15:00:00Z
+last_session: session-009
+branch: main (merged PR #16, #17)
+test_count: 295 passed, 7 skipped
+lint: ruff clean
+validation: scripts/validate-docs.sh 10/10 passed

--- a/memory/zo-platform/sessions/session-009-2026-04-10.md
+++ b/memory/zo-platform/sessions/session-009-2026-04-10.md
@@ -1,0 +1,77 @@
+# Session 009 — 2026-04-10
+
+## Summary
+
+Comprehensive documentation audit and self-evolution implementation. Discovered that adding the 17th agent (Research Scout) had left 10+ files with stale counts, version numbers, and model tiers. Applied the self-evolution protocol: fixed symptoms, then fixed the rules that allowed them.
+
+## Accomplished
+
+### Doc-Code Consistency Audit
+- Launched parallel agent teams to audit README, PRD, specs, memory, and build plan against actual codebase
+- Found and fixed: agent count 16→17 (10 files), version 1.0.0→1.0.1 (2 files), test badge 295→298, setup checks 11→10, command count 23→24, Model Builder/Backend Engineer tiers "Sonnet/Opus"→"Opus"
+- Added Research Scout (#7) to specs/agents.md launch roster, renumbered phase-in agents (#8-11)
+- Added Research Scout to lead-orchestrator.md agent roster table
+
+### Three-Layer Defense (Self-Evolution)
+- **Layer 1**: Created `scripts/validate-docs.sh` — 7 checks (10 assertions), macOS-compatible, <2s runtime
+- **Layer 2**: Created 4 Claude Code hooks in `.claude/settings.json`:
+  - `SessionStart` — auto-loads STATE.md + PRIORS.md + last 10 DECISION_LOG entries + reminders
+  - `PreToolUse` on `Bash(git commit *)` — blocks commit if validate-docs.sh fails
+  - `PostToolUse` on `Write|Edit` — cascade reminders when trigger files modified
+  - `Stop` — checks for uncommitted changes in trigger paths
+- **Layer 3**: Strengthened CLAUDE.md cascade protocol with file-to-file mappings, added PR-005 to PRIORS.md, updated commit command
+
+### End-to-End Verification
+- validate-docs.sh: 10/10 passed
+- setup.sh: 17 agents validated, all checks pass (except uv not installed — environment)
+- SessionStart hook: 19,396 chars injected, 24 sections (state + 5 priors + 10 decisions + reminders)
+- Cascade reminder: 5/5 trigger patterns fire, 1/1 non-trigger correctly silent
+- Pre-commit hook: allows clean state, blocks broken state with "deny"
+- Stop hook: detects uncommitted changes in trigger files
+- pytest: 295 passed, 7 skipped, 0 failed
+
+## Decisions Made
+
+1. **Three-layer defense architecture** — validation script + hooks + documentation (DECISION_LOG entry at 2026-04-10T14:00:00Z)
+2. **SessionStart hook for auto-context** — eliminates manual "read the memory files" at session start
+3. **Stop hook for drift detection** — catches gap where session ends without committing
+4. **Historical DECISION_LOG entries preserved** — "23 slash commands" entry left intact (accurate at time of writing), STATE.md updated to 24
+
+## Blockers Hit
+
+- `grep -P` not available on macOS — rewrote validate-docs.sh to use `grep -oE` + `sed`
+- `gh` CLI not installed — created PR via GitHub REST API with curl
+- Cascade reminder glob `*/pyproject.toml` didn't match relative path — fixed to `*pyproject.toml`
+
+## Files Changed
+
+### New Files (4)
+- `scripts/validate-docs.sh` — doc consistency validator
+- `.claude/hooks/session-start.sh` — auto-context on session start
+- `.claude/hooks/pre-commit-validate.sh` — pre-commit gate
+- `.claude/hooks/cascade-reminder.sh` — cascade update reminders
+- `.claude/hooks/stop-check.sh` — uncommitted drift detector
+
+### Modified Files (14)
+- `.claude/settings.json` — hooks section added (SessionStart, PreToolUse, PostToolUse, Stop)
+- `.claude/agents/lead-orchestrator.md` — 16→17, Research Scout in roster
+- `.claude/commands/commit.md` — validation step added
+- `CLAUDE.md` — cascade protocol with file-to-file mappings
+- `PRD.md` — 6 launch→7 launch, 10→11 project delivery
+- `README.md` — 10→11 agents, test badge 295→298, setup checks 11→10
+- `memory/zo-platform/DECISION_LOG.md` — 5 count fixes + evolution decision
+- `memory/zo-platform/PRIORS.md` — PR-005 added
+- `memory/zo-platform/STATE.md` — 17 files, 24 commands, session metadata
+- `plans/zero-operators-build.md` — counts, line counts, file tree
+- `pyproject.toml` — version 1.0.0→1.0.1
+- `setup.sh` — research-scout added, count 16→17
+- `specs/agents.md` — Research Scout entry, renumbered phase-in, tiers fixed, deployment checklist
+- `src/zo/__init__.py` — version 1.0.0→1.0.1
+
+## Context Handoff
+
+- PRs #16 and #17 merged to main
+- All hooks are live — next session should auto-load context via SessionStart
+- validate-docs.sh will block any commit with doc-code drift
+- Known issue #4 (agent permissions) is now resolved (permissions were broadened in earlier sessions, just not marked as done)
+- Next priority: IVL F5 production project


### PR DESCRIPTION
## Summary

- **Fix**: Cascade-reminder hook glob patterns (`*/pyproject.toml`) didn't match relative paths. Changed to `*pyproject.toml` (same for `__init__.py`, `cli.py`).
- **Memory**: STATE.md updated to reflect hook system, doc audit fixes, resolved known issue #4 (agent permissions).
- **Session summary**: Written to `memory/zo-platform/sessions/session-009-2026-04-10.md`.

## Test plan

- [x] All 6 cascade-reminder patterns verified (5 triggers fire, 1 non-trigger silent)
- [x] validate-docs.sh: 10/10 passed
- [x] pytest: 295 passed, 7 skipped
- [x] All 4 hooks tested end-to-end

🤖 Generated with [Claude Code](https://claude.com/claude-code)