### PR TITLE
feat(orchestrator): wire artifact validation, notebooks, and Docker into pipeline

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@
 <br/>
 
 [![Status](https://img.shields.io/badge/status-validated-F0C040?style=flat-square&labelColor=080808)](#status)
-[![Tests](https://img.shields.io/badge/tests-334_passing-F0C040?style=flat-square&labelColor=080808)](#status)
+[![Tests](https://img.shields.io/badge/tests-338_passing-F0C040?style=flat-square&labelColor=080808)](#status)
 [![Agents](https://img.shields.io/badge/agents-17_defined-F0C040?style=flat-square&labelColor=080808)](#agent-teams)
 [![E2E](https://img.shields.io/badge/MNIST-99%25_accuracy-F0C040?style=flat-square&labelColor=080808)](#e2e-validation)
 
@@ -375,7 +375,7 @@ zero-operators/
 ├── memory/                     # Per-project state (STATE.md, DECISION_LOG, PRIORS)
 ├── logs/                       # JSONL audit trails
 ├── targets/                    # Delivery repo configuration
-├── tests/                      # 334 tests (unit + integration)
+├── tests/                      # 338 tests (unit + integration)
 ├── setup.sh                    # Environment validation (10 checks)
 └── pyproject.toml              # Python package config
 ```
@@ -428,7 +428,7 @@ mnist-delivery/          ← delivery repo (clean)
 | 1.0.1 | Interactive tmux, brand panel, smart build, Research Scout, self-evolution | Done |
 | pre-F5 | Phase persistence, auto-notebooks, delivery scaffold + Docker, preflight | Done |
 
-334 platform tests. ruff clean. 17 agents. 24 slash commands.
+338 platform tests. ruff clean. 17 agents. 24 slash commands.
 
 ---
 

--- a/memory/zo-platform/DECISION_LOG.md
+++ b/memory/zo-platform/DECISION_LOG.md
@@ -323,3 +323,13 @@ Append-only. Every orchestration decision with timestamp, rationale, and outcome
 **Rationale:** Combined user's production ML experience (configs dir, experiment tracking, granular src) with ZO's agent-driven patterns (auto-notebooks, phase reports, artifact contracts). Key insight: experiments/README.md as index + exp-NNN/notes.md for detail follows the same lazy-loading pattern as ZO's own memory (STATE.md as index, drill into DECISION_LOG for detail).
 **Alternatives considered:** (1) Keep original flat structure — too vague for real projects. (2) User's exact past structure — lacked ZO-specific patterns (auto-notebooks, reports). (3) Combined best of both (chosen) — responsibility-based code, YAML configs, experiment trail, context-optimised.
 **Outcome:** scaffold.py updated (20 dirs, 9 template files), STRUCTURE.md template, experiments/README.md template, configs/experiment/base.yaml template. notebooks.py writes to notebooks/phase/. Architecture spec updated. 334 tests passing.
+
+---
+
+## Decision: 2026-04-12T15:00:00Z
+**Type:** FEATURE
+**Title:** Orchestrator pipeline wiring — artifact validation, notebooks, Docker in prompt
+**Decision:** Wire three previously-disconnected modules into the orchestrator's advance_phase() flow: (1) _check_artifacts() verifies required_artifacts exist in delivery repo before gate passes — missing artifacts return ITERATE. (2) _generate_notebook() auto-generates per-phase Jupyter notebook after gate passes (both automated and human-approved). (3) Lead prompt updated with required artifacts list per phase, Docker build/run commands, STRUCTURE.md reference, configs/ workflow, and experiments/ context trail instructions.
+**Rationale:** Modules were built and independently tested but not connected to the orchestrator. Without wiring, a real run would produce no auto-notebooks and no artifact validation — defeating the purpose of building them. Non-negotiable for production use.
+**Alternatives considered:** (1) Leave as independent modules, call manually — defeats automation. (2) Wire only notebooks, skip artifact checks — misses the enforcement value. (3) Wire everything into advance_phase() (chosen) — single enforcement point, both automated and human gates covered.
+**Outcome:** 4 new tests verify: missing artifacts block gate, present artifacts pass + generate notebook, prompt includes artifacts, prompt includes Docker. 338 tests total.

--- a/memory/zo-platform/PRIORS.md
+++ b/memory/zo-platform/PRIORS.md
@@ -259,3 +259,27 @@ pip one-at-a-time installs, source builds in single stage, 80+ apt packages.
    tests/unit/ = code correctness (Test Engineer). tests/ml/ = oracle
    thresholds and benchmarks (Oracle/QA Agent). Different agents, different
    pass/fail criteria, different run frequencies.
+
+---
+
+## PR-009: Built Modules Must Be Wired Before Declaring Ready
+**Source:** Session 010 (2026-04-12), orchestrator wiring gap discovery
+**Root cause category:** missing_rule
+**Failure:** notebooks.py, scaffold.py, and preflight.py were built and independently tested, but not connected to the orchestrator pipeline. A real run would have produced no auto-notebooks and no artifact validation.
+
+### Rules
+
+1. **"Built and tested" is not "wired and enforced."**
+   A module that passes unit tests but is never called from the pipeline
+   provides zero value in production. After building any new capability,
+   verify it is called from the orchestrator/CLI flow.
+
+2. **Add an integration test that traces the full call path.**
+   test_artifacts_present_allows_gate verifies: subtasks complete →
+   artifacts checked → gate passes → notebook generated. This catches
+   wiring gaps that unit tests miss.
+
+3. **The advance_phase() method is the single enforcement point.**
+   All phase-exit logic (artifact checks, notebook generation, comms logging)
+   routes through advance_phase() for automated gates and apply_human_decision()
+   for human gates. New phase-exit behaviors must be wired into both paths.

--- a/memory/zo-platform/STATE.md
+++ b/memory/zo-platform/STATE.md
@@ -8,7 +8,7 @@ status: complete
 
 ## Current Position
 
-ZO v1.0.2-pre — **pre-IVL F5 hardening complete**. Phase persistence fixed, delivery scaffold with Docker added, auto-notebook generation built, preflight validation added. 334 tests, ruff clean, validate-docs 9/9. Ready for IVL F5.
+ZO v1.0.2-pre — **pre-IVL F5 hardening complete**. Phase persistence fixed, delivery scaffold with Docker added, auto-notebook generation built, preflight validation added, orchestrator pipeline wired. 338 tests, ruff clean, validate-docs 9/9. Ready for CIFAR-10 demo.
 
 ## Completed
 
@@ -40,6 +40,7 @@ ZO v1.0.2-pre — **pre-IVL F5 hardening complete**. Phase persistence fixed, de
 - [x] v1.0.2-pre: Delivery repo scaffold with Docker (scaffold.py, Dockerfile, docker-compose.yml)
 - [x] v1.0.2-pre: zo preflight command (10 validation checks, GPU/Docker detection)
 - [x] v1.0.2-pre: Delivery repo structure redesign (configs/, src/ by responsibility, experiments context trail, tests unit/ml split, docker/ subdir, STRUCTURE.md)
+- [x] v1.0.2-pre: Orchestrator pipeline wiring (artifact validation at gates, auto-notebook generation, Docker/STRUCTURE.md in lead prompt)
 
 ## Known Issues
 
@@ -52,7 +53,7 @@ ZO v1.0.2-pre — **pre-IVL F5 hardening complete**. Phase persistence fixed, de
 
 ## What's Next
 
-1. **IVL F5** — first real production project (oil & gas refinery optimization)
+1. **CIFAR-10 demo** — smoke test full pipeline on new machine, then IVL F5
 2. Phase completion snapshots (C1) — capture context at phase boundaries for reports
 3. Phase summary reports (B3) — markdown reports per phase with embedded plots
 4. Domain evaluator refactor — make project-specific via plan.md domain priors
@@ -64,6 +65,6 @@ ZO v1.0.2-pre — **pre-IVL F5 hardening complete**. Phase persistence fixed, de
 last_checkpoint: 2026-04-12T12:30:00Z
 last_session: session-010
 branch: claude/mystifying-chatterjee (worktree)
-test_count: 334 passed, 7 skipped
+test_count: 338 passed, 7 skipped
 lint: ruff clean (src/zo/)
 validation: scripts/validate-docs.sh 9/9 passed, 1 warning (test badge)

--- a/memory/zo-platform/sessions/session-010-2026-04-12.md
+++ b/memory/zo-platform/sessions/session-010-2026-04-12.md
@@ -19,6 +19,9 @@
 - docs/DELIVERY_STRUCTURE.md reference doc with agent ownership table
 - STRUCTURE.md template in scaffold for in-repo navigation
 - notebooks.py updated to write to notebooks/phase/
+- Orchestrator pipeline wiring: artifact validation at gates, auto-notebook generation, Docker in lead prompt
+- 4 new integration tests for wiring (missing artifacts block, present artifacts pass + notebook, prompt checks)
+- Test count: 334 → 338
 
 ## Decisions Made
 - Phase persistence via SessionState extension (not separate file)
@@ -30,16 +33,18 @@
 - Delivery repo structure: combined user's ML experience with ZO agent patterns
 - STRUCTURE.md as context-efficient in-repo reference (agents read by section)
 - experiments/ as context trail with index + per-experiment drill-down
+- Wire everything through advance_phase() as single enforcement point
+- Lead prompt now includes Docker commands, STRUCTURE.md reference, experiment trail instructions
 
 ## Blockers Hit
 - None
 
 ## Next Steps
-- IVL F5 project setup and launch
+- CIFAR-10 demo on new machine — smoke test full pipeline
+- IVL F5 after CIFAR-10 validates
 - Phase completion snapshots (C1) during IVL F5
 - Phase summary reports (B3) during IVL F5
 - Domain evaluator refactor before IVL F5 Phase 5
-- Device detection and directory path config in plan schema
 
 ## Files Changed
 - src/zo/_memory_models.py (phase_states fields)

--- a/src/zo/orchestrator.py
+++ b/src/zo/orchestrator.py
@@ -352,11 +352,21 @@ class Orchestrator:
             return ev
 
         if all_done:
+            missing = self._check_artifacts(phase)
+            if missing:
+                ev = GateEvaluation(
+                    phase_id=phase_id, gate_type=GateType.AUTOMATED,
+                    decision=GateDecision.ITERATE,
+                    rationale=f"Subtasks done but artifacts missing: {', '.join(missing)}",
+                )
+                self._log_gate(ev)
+                return ev
             phase.status = PhaseStatus.COMPLETED
+            self._generate_notebook(phase)
             ev = GateEvaluation(
                 phase_id=phase_id, gate_type=GateType.AUTOMATED,
                 decision=GateDecision.PROCEED,
-                rationale="All subtasks complete; automated gate passed.",
+                rationale="All subtasks complete; artifacts verified; automated gate passed.",
             )
         else:
             remaining = set(phase.subtasks) - set(phase.completed_subtasks)
@@ -430,6 +440,7 @@ class Orchestrator:
         phase = self._find_phase(phase_id)
         if decision == GateDecision.PROCEED:
             phase.status = PhaseStatus.COMPLETED
+            self._generate_notebook(phase)
         elif decision == GateDecision.ITERATE:
             phase.status = PhaseStatus.ACTIVE
             phase.completed_subtasks.clear()
@@ -475,6 +486,51 @@ class Orchestrator:
             content = self._plan.objective.encode()
         return hashlib.sha256(content).hexdigest()
 
+    def _check_artifacts(self, phase: PhaseDefinition) -> list[str]:
+        """Return list of required artifacts missing from the delivery repo."""
+        if not phase.required_artifacts:
+            return []
+        target_repo = Path(self._target.target_repo)
+        if not target_repo.is_dir():
+            return []
+        missing: list[str] = []
+        for artifact in phase.required_artifacts:
+            path = target_repo / artifact
+            if artifact.endswith("/"):
+                if not path.is_dir() or not any(path.iterdir()):
+                    missing.append(artifact)
+            elif not path.exists():
+                missing.append(artifact)
+        return missing
+
+    def _generate_notebook(self, phase: PhaseDefinition) -> None:
+        """Generate a Jupyter notebook for a completed phase."""
+        target_repo = Path(self._target.target_repo)
+        if not target_repo.is_dir():
+            return
+        try:
+            from zo.notebooks import generate_phase_notebook
+            phase_num = phase.phase_id.removeprefix("phase_")
+            generate_phase_notebook(
+                phase_id=phase_num,
+                phase_name=phase.name,
+                delivery_repo=target_repo,
+                artifacts=phase.required_artifacts,
+                phase_summary=f"Phase {phase_num} ({phase.name}) completed.",
+            )
+            self._comms.log_checkpoint(
+                agent="orchestrator", phase=phase.phase_id,
+                subtask="notebook_generation",
+                progress=f"Generated notebook for {phase.name}",
+            )
+        except Exception as exc:  # noqa: BLE001
+            self._comms.log_error(
+                agent="orchestrator",
+                error_type="notebook_generation_failed",
+                message=f"Failed to generate notebook for {phase.phase_id}: {exc}",
+                severity="warning",
+            )
+
     def _log_gate(self, evaluation: GateEvaluation) -> None:
         self._comms.log_decision(
             agent="orchestrator",
@@ -518,6 +574,11 @@ class Orchestrator:
         subtasks = "\n".join(f"- {s}" for s in phase.subtasks)
         agents = ", ".join(phase.assigned_agents) or "none assigned"
         deps = ", ".join(phase.depends_on) or "none"
+        artifacts = (
+            "\n".join(f"- {a}" for a in phase.required_artifacts)
+            if phase.required_artifacts
+            else "- (none specified)"
+        )
         return dedent(f"""\
             # Current Phase: {phase.name} ({phase.phase_id})
 
@@ -525,6 +586,9 @@ class Orchestrator:
 
             **Subtasks:**
             {subtasks}
+
+            **Required artifacts (must exist before gate passes):**
+            {artifacts}
 
             **Assigned agents:** {agents}
             **Gate type:** {phase.gate_type}
@@ -580,7 +644,25 @@ class Orchestrator:
             - Define ALL integration contracts before parallel spawn.
             - Log every decision to DECISION_LOG.md.
             - Update STATE.md at every phase transition.
-            - Escalate to human if blockers persist after one debate round.""")
+            - Escalate to human if blockers persist after one debate round.
+
+            # Delivery Repo
+
+            - Read **STRUCTURE.md** in the delivery repo for directory layout.
+            - Agents read ONLY their relevant section to stay context-efficient.
+            - **configs/** — YAML configuration. Edit configs, not code, to change experiments.
+            - **experiments/** — Context trail. Update experiments/README.md index after each run.
+            - Each experiment gets: frozen config snapshot, results.json, notes.md.
+            - **Required artifacts** must exist before gate advances (see phase section above).
+            - A Jupyter notebook is auto-generated after each phase completes.
+
+            # Docker
+
+            - All compute (training, evaluation, benchmarks) runs inside Docker.
+            - Build: `docker compose -f docker/docker-compose.yml build`
+            - Run: `docker compose -f docker/docker-compose.yml run --rm gpu <command>`
+            - Agents may modify docker/Dockerfile to add project-specific packages.
+            - Never install dependencies outside Docker — use pyproject.toml + uv sync.""")
 
     def _prompt_gate_criteria(self, phase: PhaseDefinition) -> str:
         if not self._plan.oracle:

--- a/tests/unit/test_orchestrator.py
+++ b/tests/unit/test_orchestrator.py
@@ -803,3 +803,125 @@ class TestPhasePersistence:
         decomp2 = orch2.decompose_plan()
         restored_p1 = decomp2.phases[0]
         assert first_sub in restored_p1.completed_subtasks
+
+
+# ---------------------------------------------------------------------------
+# Artifact validation and notebook generation wiring
+# ---------------------------------------------------------------------------
+
+
+class TestArtifactAndNotebookWiring:
+    """Verify orchestrator checks artifacts and generates notebooks."""
+
+    def test_missing_artifacts_blocks_gate(
+        self, plan: Plan, tmp_path: Path,
+    ) -> None:
+        """Gate returns ITERATE when required artifacts are missing."""
+        # Create a target with a real delivery repo directory
+        delivery = tmp_path / "delivery"
+        delivery.mkdir()
+        target = TargetConfig(
+            project="test-project",
+            target_repo=str(delivery),
+            target_branch="main",
+            worktree_base="/tmp/worktrees",
+            git_author_name="ZO", git_author_email="zo@test.dev",
+            agent_working_dirs={}, zo_only_paths=[], enforce_isolation=False,
+        )
+        memory = MemoryManager(project_dir=tmp_path, project_name="test-proj")
+        memory.initialize_project()
+        comms = CommsLogger(
+            log_dir=tmp_path / "logs" / "comms",
+            project="test-proj", session_id="sess-1",
+        )
+        semantic = SemanticIndex(db_path=tmp_path / "index.db")
+
+        orch = Orchestrator(
+            plan=plan, target=target, memory=memory, comms=comms,
+            semantic=semantic, zo_root=REPO_ROOT, gate_mode=GateMode.FULL_AUTO,
+        )
+        orch.start_session()
+        decomp = orch.decompose_plan()
+        phase_1 = decomp.phases[0]
+
+        # Complete all subtasks but DON'T create required artifacts
+        for sub in phase_1.subtasks:
+            orch.mark_subtask_complete(phase_1.phase_id, sub)
+
+        ev = orch.advance_phase(phase_1.phase_id)
+        # Should ITERATE because artifacts are missing
+        assert ev.decision == GateDecision.ITERATE
+        assert "artifacts missing" in ev.rationale
+
+    def test_artifacts_present_allows_gate(
+        self, plan: Plan, tmp_path: Path,
+    ) -> None:
+        """Gate proceeds when required artifacts exist."""
+        delivery = tmp_path / "delivery"
+        delivery.mkdir()
+        target = TargetConfig(
+            project="test-project",
+            target_repo=str(delivery),
+            target_branch="main",
+            worktree_base="/tmp/worktrees",
+            git_author_name="ZO", git_author_email="zo@test.dev",
+            agent_working_dirs={}, zo_only_paths=[], enforce_isolation=False,
+        )
+        memory = MemoryManager(project_dir=tmp_path, project_name="test-proj")
+        memory.initialize_project()
+        comms = CommsLogger(
+            log_dir=tmp_path / "logs" / "comms",
+            project="test-proj", session_id="sess-1",
+        )
+        semantic = SemanticIndex(db_path=tmp_path / "index.db")
+
+        orch = Orchestrator(
+            plan=plan, target=target, memory=memory, comms=comms,
+            semantic=semantic, zo_root=REPO_ROOT, gate_mode=GateMode.FULL_AUTO,
+        )
+        orch.start_session()
+        decomp = orch.decompose_plan()
+        phase_1 = decomp.phases[0]
+
+        # Create all required artifacts
+        for artifact in phase_1.required_artifacts:
+            path = delivery / artifact
+            if artifact.endswith("/"):
+                path.mkdir(parents=True, exist_ok=True)
+                (path / "data.csv").touch()  # non-empty dir
+            else:
+                path.parent.mkdir(parents=True, exist_ok=True)
+                path.write_text("artifact content")
+
+        for sub in phase_1.subtasks:
+            orch.mark_subtask_complete(phase_1.phase_id, sub)
+
+        ev = orch.advance_phase(phase_1.phase_id)
+        assert ev.decision == GateDecision.PROCEED
+        assert phase_1.status == PhaseStatus.COMPLETED
+
+        # Notebook should have been generated
+        nb_dir = delivery / "notebooks" / "phase"
+        assert nb_dir.exists()
+        notebooks = list(nb_dir.glob("*.ipynb"))
+        assert len(notebooks) == 1
+
+    def test_lead_prompt_includes_artifacts(
+        self, orchestrator: Orchestrator,
+    ) -> None:
+        """Lead prompt mentions required artifacts for the phase."""
+        decomp = orchestrator.decompose_plan()
+        phase = decomp.phases[0]
+        prompt = orchestrator.build_lead_prompt(phase)
+        assert "Required artifacts" in prompt
+        for artifact in phase.required_artifacts:
+            assert artifact in prompt
+
+    def test_lead_prompt_includes_docker(
+        self, orchestrator: Orchestrator,
+    ) -> None:
+        """Lead prompt includes Docker instructions."""
+        decomp = orchestrator.decompose_plan()
+        prompt = orchestrator.build_lead_prompt(decomp.phases[0])
+        assert "docker compose" in prompt.lower()
+        assert "STRUCTURE.md" in prompt


### PR DESCRIPTION
## Summary

Wires the three modules that were built but not connected into the orchestrator pipeline. This makes the full flow non-negotiable:

- **Artifact validation at gates** — `advance_phase()` checks that all `required_artifacts` exist in the delivery repo before allowing gate passage. Missing artifacts return `ITERATE`, not `PROCEED`. Directory artifacts verified non-empty.
- **Auto-notebook generation** — After any gate passes (automated or human-approved), a Jupyter notebook is generated for the completed phase via `notebooks.py`. Errors are caught and logged as warnings, not blockers.
- **Lead prompt includes artifacts + Docker** — Phase prompt lists required artifacts. Coordination prompt includes Docker build/run commands, STRUCTURE.md reference, configs/ workflow, and experiments/ context trail instructions.

## What the orchestrator now enforces end-to-end

```
subtasks complete → artifacts exist? → gate passes → notebook generated
         ↓ no              ↓ no            ↓
       ITERATE           ITERATE        (logged)
```

## Test plan

- [x] 338 tests passing (4 new), 7 skipped
- [x] `test_missing_artifacts_blocks_gate` — ITERATE when artifacts missing
- [x] `test_artifacts_present_allows_gate` — PROCEED + notebook generated
- [x] `test_lead_prompt_includes_artifacts` — required artifacts in prompt
- [x] `test_lead_prompt_includes_docker` — Docker commands in prompt
- [x] ruff clean, validate-docs 9/9

🤖 Generated with [Claude Code](https://claude.com/claude-code)