### PR TITLE
fix(setup): harden zo CLI install + stale symlink detection

### DIFF
--- a/memory/zo-platform/DECISION_LOG.md
+++ b/memory/zo-platform/DECISION_LOG.md
@@ -333,3 +333,43 @@ Append-only. Every orchestration decision with timestamp, rationale, and outcome
 **Rationale:** Modules were built and independently tested but not connected to the orchestrator. Without wiring, a real run would produce no auto-notebooks and no artifact validation — defeating the purpose of building them. Non-negotiable for production use.
 **Alternatives considered:** (1) Leave as independent modules, call manually — defeats automation. (2) Wire only notebooks, skip artifact checks — misses the enforcement value. (3) Wire everything into advance_phase() (chosen) — single enforcement point, both automated and human gates covered.
 **Outcome:** 4 new tests verify: missing artifacts block gate, present artifacts pass + generate notebook, prompt includes artifacts, prompt includes Docker. 338 tests total.
+
+---
+
+## Decision: 2026-04-12T20:00:00Z
+**Type:** UX
+**Title:** setup.sh interactive auto-fix — no flags, just prompt
+**Decision:** setup.sh now detects fixable failures (uv, Claude CLI, global settings) and prompts "N issue(s) can be auto-fixed. Install now? [Y/n]" instead of requiring a --fix flag. On success, re-execs itself for validation. Uses string-based tracking (FIXABLE_ITEMS/FIXABLE_COUNT) instead of bash arrays.
+**Rationale:** User ran setup.sh on a new machine for CIFAR-10 demo and hit 3 failures. Original script only reported errors with manual fix instructions. First iteration added --fix flag, but user correctly pointed out this should be automatic — the install commands are known, why make the user copy-paste them?
+**Alternatives considered:** (1) Report-only (original) — poor UX, forces manual copy-paste. (2) --fix flag — still requires user to know about the flag. (3) Interactive prompt with default Y (chosen) — zero-friction, user just hits Enter.
+**Outcome:** PR #22. Tested on macOS bash 3.2.57. Auto-installed uv 0.11.6 + Claude Code 2.1.104. Re-validation passed 11/11.
+
+---
+
+## Decision: 2026-04-12T20:00:00Z
+**Type:** BUGFIX
+**Title:** Claude CLI install command updated to official curl method
+**Decision:** Replaced `npm install -g @anthropic-ai/claude-code` with `curl -fsSL https://claude.ai/install.sh | bash` in both the check message and auto-fix function.
+**Rationale:** The npm method is deprecated. Official install is now via curl. Discovered during CIFAR-10 demo setup on new machine.
+**Alternatives considered:** npm (deprecated), brew (not official), curl (chosen — official method).
+**Outcome:** Claude Code 2.1.104 installed successfully via curl on fresh machine.
+
+---
+
+## Decision: 2026-04-12T20:00:00Z
+**Type:** BUGFIX
+**Title:** Bash 3.2 compatibility — replace array tracking with string counters
+**Decision:** Replaced `FIXABLE=()` array + `${#FIXABLE[@]}` length checks with `FIXABLE_ITEMS=""` string + `FIXABLE_COUNT=0` integer counter. Iterates with `for item in $FIXABLE_ITEMS` (word splitting).
+**Rationale:** macOS ships bash 3.2.57. In bash 3.2, `${#array[@]}` on an empty array with `set -u` throws "unbound variable" and silently kills the auto-fix block. The --fix flag appeared to do nothing on first attempt because of this.
+**Alternatives considered:** (1) Remove `set -u` — weakens safety. (2) Use `${FIXABLE[@]+"${FIXABLE[@]}"}` workaround — fragile, hard to read. (3) String + counter (chosen) — simple, works on all bash versions.
+**Outcome:** Auto-fix block now triggers correctly on macOS bash 3.2.57.
+
+---
+
+## Decision: 2026-04-12T20:30:00Z
+**Type:** BUGFIX
+**Title:** setup.sh must verify zo CLI is callable, not just deps resolvable
+**Decision:** Added check #11 to setup.sh: verify `command -v zo` passes. Auto-fix: `uv sync` to build .venv, then symlink `.venv/bin/zo` → `~/.local/bin/zo` (already on PATH from uv install). Changed dep check from dry-run to actual `uv sync --quiet`. Handles worktree case by checking superproject .venv.
+**Rationale:** User ran `uv sync` then `zo init` → "command not found". `uv sync` installs into `.venv/bin/` which isn't on PATH when conda/pyenv/system Python is active. setup.sh only checked deps *resolve* (dry-run), never verified the CLI was *callable*. This is the difference between "package manager happy" and "user can type the command".
+**Alternatives considered:** (1) Tell user to `source .venv/bin/activate` — adds manual step, breaks "just run setup.sh" promise. (2) `uv pip install -e .` into active env — fragile with conda, pollutes base env. (3) Symlink to `~/.local/bin/` (chosen) — clean, already on PATH, works with any Python env manager.
+**Outcome:** setup.sh now passes 12/12 checks. `zo, version 1.0.1` callable after setup. PR-012 prior added.

--- a/memory/zo-platform/PRIORS.md
+++ b/memory/zo-platform/PRIORS.md
@@ -283,3 +283,73 @@ pip one-at-a-time installs, source builds in single stage, 80+ apt packages.
    All phase-exit logic (artifact checks, notebook generation, comms logging)
    routes through advance_phase() for automated gates and apply_human_decision()
    for human gates. New phase-exit behaviors must be wired into both paths.
+
+---
+
+## PR-010: macOS Bash 3.2 Breaks Empty Array Checks Under set -u
+**Source:** Session 011 (2026-04-12), setup.sh --fix silent failure
+**Root cause category:** missing_rule
+**Failure:** setup.sh auto-fix block never triggered despite --fix flag. Bash 3.2.57 (macOS default) throws "unbound variable" on `${#ARRAY[@]}` when the array is empty and `set -u` is active. The error silently killed the auto-fix conditional.
+
+### Rules
+
+1. **Never use bash arrays with `set -u` if the script must run on macOS.**
+   macOS ships bash 3.2 (2007). Empty arrays + `set -u` = silent failure.
+   Use string variables with word splitting or integer counters instead.
+
+2. **Always test shell scripts on bash 3.2 when targeting macOS.**
+   `bash --version` on macOS returns 3.2.57. Scripts that work on bash 5+
+   (Linux, Homebrew) can silently break on stock macOS. Run `bash -n` for
+   syntax, but also test runtime behavior with actual bash 3.2.
+
+3. **Setup/bootstrap scripts must be maximally portable.**
+   These run on the widest variety of environments (fresh machines, CI,
+   different OS versions). Avoid bashisms that require 4.0+: associative
+   arrays, `${!var}`, `${array[@]}` with nounset, `&>`, `|&`.
+
+---
+
+## PR-011: Setup Scripts Should Auto-Fix, Not Just Report
+**Source:** Session 011 (2026-04-12), CIFAR-10 demo on new machine
+**Root cause category:** missing_rule
+**Failure:** User hit 3 setup failures, all with known install commands printed in the error messages. Had to manually copy-paste each command. First fix added --fix flag, but user pointed out this shouldn't require a flag — if the fix is known, just offer to run it.
+
+### Rules
+
+1. **If the fix is known and safe, offer to run it interactively.**
+   Report-only error messages with "run this command" are a UX anti-pattern
+   when the script already knows the command. Prompt "Install now? [Y/n]"
+   with Enter as default-yes.
+
+2. **After auto-fixing, re-run validation to confirm.**
+   Use `exec "$0"` to re-validate from scratch. Don't assume the fix worked
+   — prove it by passing the same checks that originally failed.
+
+3. **Keep install commands up to date in setup scripts.**
+   The Claude CLI install changed from npm to curl. Stale install commands
+   in setup scripts cause silent failures or confusion. When a dependency
+   changes its install method, update all references.
+
+---
+
+## PR-012: uv sync Does Not Put CLI Entry Points on PATH
+**Source:** Session 011 (2026-04-12), CIFAR-10 demo — `zo: command not found`
+**Root cause category:** missing_rule
+**Failure:** User ran `uv sync`, then `zo init` → "command not found". `uv sync` installs into `.venv/bin/` which is not on PATH when the user has conda, system Python, or any non-venv shell active. setup.sh checked that deps "resolve" (dry-run) but never verified the CLI was callable.
+
+### Rules
+
+1. **Checking ≠ installing ≠ callable.**
+   setup.sh must verify the full chain: (1) deps resolve, (2) deps installed,
+   (3) CLI entry points are on PATH and executable. A dry-run check that
+   passes means nothing if the user can't type the command.
+
+2. **`uv sync` isolates into `.venv/` — symlink entry points to `~/.local/bin/`.**
+   After `uv sync`, the `zo` binary lives at `.venv/bin/zo`. Users with conda,
+   pyenv, or system Python won't have `.venv/bin/` on PATH. Fix: symlink
+   `.venv/bin/zo` → `~/.local/bin/zo` (already on PATH from uv's own install).
+
+3. **Setup scripts must leave the user with a working command, not a working venv.**
+   The success criterion for setup is "can the user type `zo build` and have
+   it work?" — not "are dependencies resolved?". Test from the user's
+   perspective, not the package manager's.

--- a/memory/zo-platform/STATE.md
+++ b/memory/zo-platform/STATE.md
@@ -8,7 +8,7 @@ status: complete
 
 ## Current Position
 
-ZO v1.0.2-pre — **pre-IVL F5 hardening complete**. Phase persistence fixed, delivery scaffold with Docker added, auto-notebook generation built, preflight validation added, orchestrator pipeline wired. 338 tests, ruff clean, validate-docs 9/9. Ready for CIFAR-10 demo.
+ZO v1.0.2-pre — **CIFAR-10 demo setup in progress on new machine**. setup.sh now auto-fixes missing deps (uv, Claude CLI, global settings) with interactive prompt. Environment bootstrapped successfully. 338 tests, ruff clean, validate-docs 9/9. PR #22 merged for setup auto-fix.
 
 ## Completed
 
@@ -41,6 +41,10 @@ ZO v1.0.2-pre — **pre-IVL F5 hardening complete**. Phase persistence fixed, de
 - [x] v1.0.2-pre: zo preflight command (10 validation checks, GPU/Docker detection)
 - [x] v1.0.2-pre: Delivery repo structure redesign (configs/, src/ by responsibility, experiments context trail, tests unit/ml split, docker/ subdir, STRUCTURE.md)
 - [x] v1.0.2-pre: Orchestrator pipeline wiring (artifact validation at gates, auto-notebook generation, Docker/STRUCTURE.md in lead prompt)
+- [x] v1.0.2-pre: setup.sh auto-fix — interactive prompt installs uv, Claude CLI, global settings (bash 3.2 compatible)
+- [x] v1.0.2-pre: Claude CLI install updated to official curl method (replaced deprecated npm install)
+- [x] v1.0.2-pre: setup.sh verifies zo CLI callable on PATH (check #11), auto-fixes via symlink to ~/.local/bin/
+- [x] v1.0.2-pre: setup.sh deps check upgraded from dry-run to actual `uv sync`
 
 ## Known Issues
 
@@ -53,7 +57,7 @@ ZO v1.0.2-pre — **pre-IVL F5 hardening complete**. Phase persistence fixed, de
 
 ## What's Next
 
-1. **CIFAR-10 demo** — smoke test full pipeline on new machine, then IVL F5
+1. **CIFAR-10 demo** — environment ready, run `zo build plans/cifar10.md` next
 2. Phase completion snapshots (C1) — capture context at phase boundaries for reports
 3. Phase summary reports (B3) — markdown reports per phase with embedded plots
 4. Domain evaluator refactor — make project-specific via plan.md domain priors
@@ -62,9 +66,10 @@ ZO v1.0.2-pre — **pre-IVL F5 hardening complete**. Phase persistence fixed, de
 
 ## Session Metadata
 
-last_checkpoint: 2026-04-12T12:30:00Z
-last_session: session-010
-branch: claude/mystifying-chatterjee (worktree)
+last_checkpoint: 2026-04-12T20:00:00Z
+last_session: session-011
+branch: claude/eloquent-poincare (worktree)
 test_count: 338 passed, 7 skipped
 lint: ruff clean (src/zo/)
 validation: scripts/validate-docs.sh 9/9 passed, 1 warning (test badge)
+pr: #22 (feat: setup auto-fix)

--- a/memory/zo-platform/sessions/session-011-2026-04-12.md
+++ b/memory/zo-platform/sessions/session-011-2026-04-12.md
@@ -1,0 +1,53 @@
+# Session Summary: 2026-04-12 (evening)
+**Date**: 2026-04-12
+**Duration**: ~45 minutes
+**Mode**: maintain
+**Agent**: orchestrator
+
+## Accomplished
+- Full project audit: read STATE.md, DECISION_LOG.md, PRIORS.md, plan, specs, codebase structure via parallel agents
+- Provided comprehensive "where we are" summary to user starting CIFAR-10 demo on new machine
+- setup.sh auto-fix feature: detects fixable failures and prompts "Install now? [Y/n]"
+  - Supports: uv (curl install), Claude CLI (curl install), global settings (create/merge JSON)
+  - Bash 3.2 compatible (string counters, not arrays) for stock macOS
+  - Re-execs itself after fixing to re-validate
+- Updated Claude CLI install from deprecated `npm install -g @anthropic-ai/claude-code` to `curl -fsSL https://claude.ai/install.sh | bash`
+- Fixed bash 3.2 empty array bug that silently killed auto-fix block under `set -u`
+- Tested setup.sh: syntax check, normal run (shows tip), --fix run (installs uv 0.11.6 + Claude 2.1.104), stripped PATH test, clean re-validation (11/11 pass)
+- PR #22 created and pushed: feat(setup): auto-fix missing dependencies
+- Configured gh CLI auth on new machine (SamPlvs account, keyring)
+- Fixed `zo: command not found` after `uv sync` — added check #11 (zo CLI on PATH), auto-fix symlinks `.venv/bin/zo` → `~/.local/bin/zo`
+- Upgraded deps check from dry-run to actual `uv sync --quiet`
+- setup.sh now passes 12/12 checks on clean machine
+
+## Decisions Made
+- Interactive prompt > --fix flag for setup auto-fix (zero-friction UX)
+- String + counter > bash arrays for macOS 3.2 compatibility
+- Claude CLI install via curl (official) > npm (deprecated)
+- Global settings auto-creation includes only env block (not full permissions — those live in project settings)
+
+## Blockers Hit
+- git push failed initially: HTTPS remote without credentials. Resolved by user running `gh auth login`.
+
+## Priors Added
+- PR-010: macOS bash 3.2 breaks empty array checks under `set -u`
+- PR-011: Setup scripts should auto-fix, not just report
+- PR-012: uv sync does not put CLI entry points on PATH — symlink to ~/.local/bin/
+
+## Next Steps
+- CIFAR-10 demo: environment ready, run `zo build plans/cifar10.md`
+- Phase completion snapshots (C1)
+- Phase summary reports (B3)
+- Domain evaluator refactor for IVL F5
+
+## Files Changed
+- setup.sh (auto-fix feature, bash 3.2 compat, Claude CLI install update)
+- memory/zo-platform/STATE.md (updated position, completed items, session metadata)
+- memory/zo-platform/DECISION_LOG.md (+3 decisions: auto-fix UX, Claude CLI update, bash 3.2 fix)
+- memory/zo-platform/PRIORS.md (+2 priors: PR-010 bash 3.2, PR-011 auto-fix UX)
+- memory/zo-platform/sessions/session-011-2026-04-12.md (NEW)
+
+## Context Handoff
+- Estimated completion: Setup hardening complete, CIFAR-10 environment ready
+- Open questions: device detection (Linux vs Mac), directory paths in plan schema
+- Recommended next action: create CIFAR-10 plan and run `zo build`

--- a/memory/zo-platform/sessions/session-011-2026-04-12.md
+++ b/memory/zo-platform/sessions/session-011-2026-04-12.md
@@ -19,6 +19,9 @@
 - Fixed `zo: command not found` after `uv sync` — added check #11 (zo CLI on PATH), auto-fix symlinks `.venv/bin/zo` → `~/.local/bin/zo`
 - Upgraded deps check from dry-run to actual `uv sync --quiet`
 - setup.sh now passes 12/12 checks on clean machine
+- Hardened zo-cli fix: uses `uv run python3` to find venv (handles worktrees, conda, any cwd)
+- Added stale symlink detection: `zo` on PATH but broken triggers reinstall
+- Tested: clean pass, auto-fix from scratch, stale symlink, stripped PATH with decline, idempotency
 
 ## Decisions Made
 - Interactive prompt > --fix flag for setup auto-fix (zero-friction UX)

--- a/setup.sh
+++ b/setup.sh
@@ -132,19 +132,28 @@ else
     warn "ruff not found — install: uv tool install ruff"
 fi
 
-# 9. Dependencies synced
+# 9. Dependencies synced + zo CLI available
 echo -e "${DIM}Checking dependencies...${RESET}"
 if [[ -f "pyproject.toml" ]]; then
     pass "pyproject.toml exists"
     if command -v uv &>/dev/null; then
-        if uv sync --dry-run &>/dev/null 2>&1; then
-            pass "Dependencies resolvable"
+        if uv sync --quiet 2>/dev/null; then
+            pass "Dependencies installed"
         else
-            warn "uv sync --dry-run failed — run: uv sync"
+            warn "uv sync failed — run: uv sync"
         fi
     fi
 else
     fail "pyproject.toml missing"
+fi
+
+echo -e "${DIM}Checking zo CLI...${RESET}"
+if command -v zo &>/dev/null; then
+    ZO_VERSION=$(zo --version 2>/dev/null || echo "available")
+    pass "zo CLI ($ZO_VERSION)"
+else
+    fail "zo CLI not found on PATH"
+    fixable "zo-cli"
 fi
 
 # 10. Directory structure
@@ -205,6 +214,35 @@ fix_item() {
 SETTINGS_EOF
             echo -e "  ${GREEN}✓${RESET} Global settings created with agent teams enabled"
             return 0
+            ;;
+        zo-cli)
+            echo -e "  ${AMBER}→${RESET} Installing zo CLI..."
+            if command -v uv &>/dev/null; then
+                # Ensure .venv exists with deps
+                uv sync 2>/dev/null
+                # Find the zo binary in the project venv
+                ZO_VENV_BIN="$(pwd)/.venv/bin/zo"
+                if [[ ! -f "$ZO_VENV_BIN" ]]; then
+                    # Fallback: check main repo .venv (worktree case)
+                    REPO_ROOT=$(git rev-parse --show-superproject-working-tree 2>/dev/null || git rev-parse --show-toplevel 2>/dev/null)
+                    if [[ -n "$REPO_ROOT" ]]; then
+                        uv sync --project "$REPO_ROOT" 2>/dev/null
+                        ZO_VENV_BIN="$REPO_ROOT/.venv/bin/zo"
+                    fi
+                fi
+                if [[ -f "$ZO_VENV_BIN" ]]; then
+                    # Symlink into ~/.local/bin (already on PATH from uv install)
+                    mkdir -p "$HOME/.local/bin"
+                    ln -sf "$ZO_VENV_BIN" "$HOME/.local/bin/zo"
+                    export PATH="$HOME/.local/bin:$PATH"
+                    if command -v zo &>/dev/null; then
+                        echo -e "  ${GREEN}✓${RESET} zo CLI installed (symlinked to ~/.local/bin/zo)"
+                        return 0
+                    fi
+                fi
+            fi
+            echo -e "  ${RED}✗${RESET} zo install failed — try: uv sync && source .venv/bin/activate"
+            return 1
             ;;
         agent-teams-env)
             echo -e "  ${AMBER}→${RESET} Adding agent teams env to $SETTINGS_FILE..."

--- a/setup.sh
+++ b/setup.sh
@@ -142,17 +142,23 @@ if [[ -f "pyproject.toml" ]]; then
         else
             warn "uv sync failed — run: uv sync"
         fi
+    else
+        warn "uv not available yet — dependencies not synced"
     fi
 else
     fail "pyproject.toml missing"
 fi
 
 echo -e "${DIM}Checking zo CLI...${RESET}"
-if command -v zo &>/dev/null; then
+if command -v zo &>/dev/null && zo --version &>/dev/null 2>&1; then
     ZO_VERSION=$(zo --version 2>/dev/null || echo "available")
     pass "zo CLI ($ZO_VERSION)"
 else
-    fail "zo CLI not found on PATH"
+    if command -v zo &>/dev/null; then
+        fail "zo CLI found but broken (stale symlink?) — will reinstall"
+    else
+        fail "zo CLI not found on PATH"
+    fi
     fixable "zo-cli"
 fi
 
@@ -217,31 +223,28 @@ SETTINGS_EOF
             ;;
         zo-cli)
             echo -e "  ${AMBER}→${RESET} Installing zo CLI..."
-            if command -v uv &>/dev/null; then
-                # Ensure .venv exists with deps
-                uv sync 2>/dev/null
-                # Find the zo binary in the project venv
-                ZO_VENV_BIN="$(pwd)/.venv/bin/zo"
-                if [[ ! -f "$ZO_VENV_BIN" ]]; then
-                    # Fallback: check main repo .venv (worktree case)
-                    REPO_ROOT=$(git rev-parse --show-superproject-working-tree 2>/dev/null || git rev-parse --show-toplevel 2>/dev/null)
-                    if [[ -n "$REPO_ROOT" ]]; then
-                        uv sync --project "$REPO_ROOT" 2>/dev/null
-                        ZO_VENV_BIN="$REPO_ROOT/.venv/bin/zo"
-                    fi
-                fi
-                if [[ -f "$ZO_VENV_BIN" ]]; then
-                    # Symlink into ~/.local/bin (already on PATH from uv install)
-                    mkdir -p "$HOME/.local/bin"
-                    ln -sf "$ZO_VENV_BIN" "$HOME/.local/bin/zo"
-                    export PATH="$HOME/.local/bin:$PATH"
-                    if command -v zo &>/dev/null; then
-                        echo -e "  ${GREEN}✓${RESET} zo CLI installed (symlinked to ~/.local/bin/zo)"
-                        return 0
-                    fi
-                fi
+            if ! command -v uv &>/dev/null; then
+                echo -e "  ${RED}✗${RESET} uv required to install zo — fix uv first"
+                return 1
             fi
-            echo -e "  ${RED}✗${RESET} zo install failed — try: uv sync && source .venv/bin/activate"
+            # Sync deps — uv finds the project root automatically
+            # (handles worktrees, nested dirs, any cwd)
+            uv sync --quiet 2>/dev/null
+            # Ask uv where the venv actually is (don't guess paths)
+            ZO_VENV_BIN=$(uv run python3 -c "import sys, os; print(os.path.join(sys.prefix, 'bin', 'zo'))" 2>/dev/null)
+            if [[ -z "$ZO_VENV_BIN" || ! -f "$ZO_VENV_BIN" ]]; then
+                echo -e "  ${RED}✗${RESET} zo binary not found after uv sync — try: uv sync && source .venv/bin/activate"
+                return 1
+            fi
+            # Symlink into ~/.local/bin (already on PATH from uv install)
+            mkdir -p "$HOME/.local/bin"
+            ln -sf "$ZO_VENV_BIN" "$HOME/.local/bin/zo"
+            export PATH="$HOME/.local/bin:$PATH"
+            if command -v zo &>/dev/null && zo --version &>/dev/null 2>&1; then
+                echo -e "  ${GREEN}✓${RESET} zo CLI installed (symlinked to ~/.local/bin/zo)"
+                return 0
+            fi
+            echo -e "  ${RED}✗${RESET} zo symlink created but not working — check PATH includes ~/.local/bin"
             return 1
             ;;
         agent-teams-env)


### PR DESCRIPTION
## Summary
- `setup.sh` now verifies `zo` CLI is actually callable (not just installed), auto-fixes via symlink to `~/.local/bin/`
- Uses `uv run python3` to locate venv — handles worktrees, conda, pyenv, bare servers
- Detects stale symlinks (`zo` on PATH but broken) and reinstalls
- Deps check warns gracefully when uv isn't available yet

## Test results
| Scenario | Result |
|----------|--------|
| Clean pass (all deps) | 12/12, no prompt |
| Auto-fix from scratch | Installs uv + claude + zo, re-validates 12/12 |
| Stale symlink | Detects broken zo, reinstalls |
| Stripped PATH + decline | 4 failures reported, exits cleanly |
| Idempotent re-run | Clean pass, no prompt |

## Prior added
- **PR-012**: `uv sync` does not put CLI entry points on PATH — checking ≠ installing ≠ callable

🤖 Generated with [Claude Code](https://claude.com/claude-code)