### PR TITLE
feat(draft): conversational plan drafting without source documents

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ You stay in the loop at human checkpoints. ZO remembers everything across sessio
   You                          ZO                           Delivery Repo
   ───                          ──                           ─────────────
 
-  1. Provide source docs ────► zo draft ──► plan.md
+  1. Draft a plan ───────────► zo draft ──► plan.md
                                               │
   2. Review & edit plan  ◄─────────────────────┘
                                               │
@@ -74,7 +74,7 @@ You stay in the loop at human checkpoints. ZO remembers everything across sessio
 
 **Step by step:**
 
-1. **Feed source docs** — `zo draft ~/docs/req.md ~/data/ --project my-project` indexes your documents and generates a `plan.md`, then opens an interactive Claude session to refine it
+1. **Draft a plan** — `zo draft --project my-project` opens an interactive Claude session that drafts a `plan.md` conversationally. Optionally provide source docs or a description (`-d`)
 2. **Review the plan** — edit `plans/my-project.md` to sharpen the objective, set oracle thresholds, add domain knowledge
 3. **Launch** — `zo build plans/my-project.md` shows a phase review (subtasks, agents, oracle criteria), prompts for additional instructions, then spawns the agent team in tmux
 4. **Approve at gates** — in supervised mode (default), every phase transition pauses for your review. You can also type directly into the Lead Orchestrator's Claude Code session
@@ -107,13 +107,15 @@ zo continue my-project
 
 Finds `plans/{project}.md` and runs `zo build` on it. Shorthand for when you don't want to type the plan path.
 
-### `zo draft` — Generate a plan from documents
+### `zo draft` — Generate a plan conversationally
 
 ```bash
-zo draft ~/docs/requirements.md ~/data/notes/ /path/to/specs.txt --project my-project
+zo draft ~/docs/requirements.md ~/data/notes/ --project my-project   # from source docs
+zo draft --project cifar10 -d "CIFAR-10 CNN, PyTorch, 90%+ accuracy" # from description
+zo draft --project my-project                                         # interactive prompt
 ```
 
-Accepts **multiple file and directory paths**. Indexes all source documents, generates a compliant `plan.md`, then opens an interactive Claude Code session to refine it with you. Use `--no-tmux` to skip the interactive session.
+Launches an interactive Claude Code session that drafts a `plan.md` conversationally — asking about objectives, data, oracle metrics, and constraints. Optionally accepts **source document paths** (indexed and fed as context) or a **description** (`-d`). When called with no arguments, prompts for a brief project description. Use `--no-tmux` to skip the interactive session and generate a skeleton only.
 
 ### `zo init` — Scaffold a new project
 
@@ -360,7 +362,7 @@ Over time, `PRIORS.md` accumulates domain knowledge. The same mistake never happ
 zero-operators/
 ├── src/zo/                     # Platform code (10 modules)
 │   ├── cli.py                  # CLI: zo build/continue/init/status/draft
-│   ├── draft.py                # Agentic plan generation from source docs
+│   ├── draft.py                # Conversational plan generation (with or without source docs)
 │   ├── plan.py                 # Plan parser and validator (8 sections)
 │   ├── target.py               # Target file parser, isolation enforcer
 │   ├── orchestrator.py         # Phase decomposition, gate management, lead prompt

--- a/src/zo/cli.py
+++ b/src/zo/cli.py
@@ -589,57 +589,96 @@ def preflight(plan_file: Path, target_repo: Path | None) -> None:
 
 
 @cli.command()
-@click.argument("source_paths", nargs=-1, type=click.Path(exists=True, path_type=Path))
+@click.argument("source_paths", nargs=-1, type=click.Path(path_type=Path))
 @click.option("--project", "-p", required=True, help="Project name for the generated plan")
-@click.option("--no-tmux", is_flag=True, help="Skip interactive refinement session")
-def draft(source_paths: tuple[Path, ...], project: str, no_tmux: bool) -> None:
-    """Generate a plan.md from source documents.
+@click.option("--description", "-d", default=None, help="Project description (when no source docs)")
+@click.option("--no-tmux", is_flag=True, help="Skip interactive drafting session")
+def draft(
+    source_paths: tuple[Path, ...], project: str,
+    description: str | None, no_tmux: bool,
+) -> None:
+    """Generate a plan.md conversationally or from source documents.
 
-    Accepts multiple file and/or directory paths. Indexes all documents,
-    generates a compliant plan.md, then optionally launches an interactive
-    Claude Code session to refine it with you.
+    When source paths are provided, indexes documents and generates a
+    plan template seeded with their content. When no source paths are
+    given, prompts for a project description (or uses --description).
+
+    In both cases, launches an interactive Claude Code session that
+    drafts the plan conversationally — asking about objectives, data,
+    oracle metrics, and constraints.
 
     Usage::
 
-        zo draft ~/docs/requirements.md ~/data/notes/ --project my-project
-        zo draft ./specs --project alpha --no-tmux
+        zo draft ~/docs/spec.md --project my-project
+        zo draft --project cifar10 -d "CIFAR-10 CNN, PyTorch, 90%+ accuracy"
+        zo draft --project my-project
     """
     from zo.draft import PlanDrafter
 
-    if not source_paths:
-        console.print("[red bold]No source paths provided.[/]")
-        raise SystemExit(1)
-
     zo_root = _zo_root()
-    drafter = PlanDrafter(
-        source_paths=list(source_paths), project_name=project, zo_root=zo_root,
-    )
+    desc = description or ""
+    doc_context = ""
 
-    console.print(f"[{_AMBER}]Indexing documents from {len(source_paths)} path(s):[/]")
-    for sp in source_paths:
-        console.print(f"  [{_DIM}]{sp}[/]")
-    count = drafter.index_documents()
-    console.print(f"[green]Indexed {count} documents.[/]")
+    if source_paths:
+        # --- Branch A: source documents provided ---
+        for sp in source_paths:
+            if not sp.exists():
+                console.print(f"[red bold]Path not found: {sp}[/]")
+                raise SystemExit(1)
 
-    console.print(f"[{_AMBER}]Generating plan...[/]")
-    plan_path = drafter.generate_plan()
+        drafter = PlanDrafter(
+            source_paths=list(source_paths), project_name=project, zo_root=zo_root,
+        )
+
+        console.print(f"[{_AMBER}]Indexing documents from {len(source_paths)} path(s):[/]")
+        for sp in source_paths:
+            console.print(f"  [{_DIM}]{sp}[/]")
+        count = drafter.index_documents()
+        console.print(f"[green]Indexed {count} documents.[/]")
+
+        console.print(f"[{_AMBER}]Generating plan from documents...[/]")
+        plan_path = drafter.generate_plan()
+        doc_context = drafter.get_document_summaries()
+
+    else:
+        # --- Branch B: no source documents ---
+        if not desc:
+            console.print(
+                f"[{_AMBER}]No source documents provided.[/]\n"
+                f"  [{_DIM}]Describe your project briefly "
+                f"(goal, domain, method, target metric):[/]"
+            )
+            console.print()
+            desc = console.input(f"  [{_AMBER}]>[/] ").strip()
+            if not desc:
+                console.print("[red bold]No description provided. Aborting.[/]")
+                raise SystemExit(1)
+
+        drafter = PlanDrafter(project_name=project, zo_root=zo_root)
+
+        console.print(f"\n[{_AMBER}]Drafting plan for:[/] {project}")
+        console.print(f"  [{_DIM}]Description:[/] {desc}")
+
+        console.print(f"[{_AMBER}]Generating plan skeleton...[/]")
+        plan_path = drafter.generate_plan_from_description(desc)
+
     console.print(f"[green]Plan generated:[/] {plan_path}")
 
     valid = drafter.validate_draft(plan_path)
     if valid:
-        console.print("[green bold]Plan passes validation.[/]")
+        console.print("[green bold]Plan passes schema validation.[/]")
     else:
         console.print(
-            f"[yellow bold]Plan has validation issues.[/] "
-            f"Edit {plan_path} to fix them."
+            "[yellow bold]Plan has validation issues.[/] "
+            "The drafting session will address them."
         )
 
-    # Interactive refinement session
+    # Interactive drafting session
     if not no_tmux:
         from zo.wrapper import LifecycleWrapper
 
         console.print(
-            f"\n[{_AMBER}]Opening interactive session to refine the plan...[/]"
+            f"\n[{_AMBER}]Opening interactive drafting session...[/]"
         )
         from zo.comms import CommsLogger
 
@@ -650,19 +689,36 @@ def draft(source_paths: tuple[Path, ...], project: str, no_tmux: bool) -> None:
         )
         wrapper = LifecycleWrapper(comms=comms, log_dir=zo_root / "logs" / "wrapper")
 
-        refine_prompt = (
-            f"I've drafted a plan.md at {plan_path} for project '{project}'.\n\n"
-            f"The plan was generated from {count} source documents.\n"
-            f"Please review it, suggest improvements, and help me refine the "
-            f"oracle definition, constraints, and agent configuration.\n\n"
-            f"The plan schema is defined in specs/plan.md — ensure compliance."
+        # Build context-aware prompt
+        context_block = ""
+        if doc_context:
+            context_block = f"\n\n{doc_context}\n"
+        elif desc:
+            context_block = f"\n\nUser's project description: {desc}\n"
+
+        draft_prompt = (
+            f"You are drafting a plan.md for project '{project}' at {plan_path}.\n"
+            f"{context_block}\n"
+            f"A skeleton plan already exists at that path. Read it, then work with "
+            f"the user conversationally to complete it:\n\n"
+            f"1. Review what's there and summarise what you understand\n"
+            f"2. Ask about the objective — what exactly are we building?\n"
+            f"3. Ask about data sources — where does the data come from?\n"
+            f"4. Ask about oracle metrics — how do we measure success?\n"
+            f"5. Ask about constraints — time, compute, regulatory limits?\n"
+            f"6. Fill in each section as you get answers\n"
+            f"7. Validate the final plan against specs/plan.md schema\n\n"
+            f"Write the completed plan to {plan_path}. "
+            f"The plan schema is defined in specs/plan.md — ensure compliance.\n"
+            f"After the plan is complete, tell the user to run: "
+            f"zo build {plan_path}"
         )
 
         prompt_file = zo_root / "logs" / "wrapper" / f"zo-draft-{project}-prompt.txt"
         prompt_file.parent.mkdir(parents=True, exist_ok=True)
-        prompt_file.write_text(refine_prompt, encoding="utf-8")
+        prompt_file.write_text(draft_prompt, encoding="utf-8")
 
-        # Launch interactive claude to refine the plan
+        # Launch interactive claude session
         result = __import__("subprocess").run(
             ["tmux", "new-window", "-d", "-n", f"draft-{project}",
              "-P", "-F", "#{pane_id}"],
@@ -699,7 +755,7 @@ def draft(source_paths: tuple[Path, ...], project: str, no_tmux: bool) -> None:
         )
 
         console.print(
-            f"[{_AMBER}]Refinement session opened.[/] "
+            f"[{_AMBER}]Drafting session opened.[/] "
             f"[{_DIM}]Ctrl-b n to switch to it.[/]"
         )
 

--- a/src/zo/draft.py
+++ b/src/zo/draft.py
@@ -162,6 +162,129 @@ class PlanDrafter:
         plan_path.write_text("\n".join(sections), encoding="utf-8")
         return plan_path
 
+    def generate_plan_from_description(self, description: str) -> Path:
+        """Generate a plan.md from a free-text project description.
+
+        Produces a structurally valid skeleton with the description seeded
+        into appropriate sections. Designed to be fleshed out by the
+        interactive Claude session.
+
+        Args:
+            description: Free-text project description from the user.
+
+        Returns:
+            Path to generated plan file.
+        """
+        plans_dir = self._zo_root / "plans"
+        plans_dir.mkdir(parents=True, exist_ok=True)
+        plan_path = plans_dir / f"{self._project_name}.md"
+
+        now = datetime.now(UTC).strftime("%Y-%m-%d")
+        desc_lower = description.lower()
+
+        # Infer workflow mode from description keywords
+        dl_keywords = ("cnn", "neural", "deep learning", "transformer",
+                       "lstm", "resnet", "pytorch", "tensorflow", "vit",
+                       "diffusion", "gan", "autoencoder", "bert", "gpt")
+        research_keywords = ("research", "experiment", "explore", "survey",
+                             "literature", "hypothesis")
+        if any(kw in desc_lower for kw in dl_keywords):
+            workflow_mode = "deep_learning"
+        elif any(kw in desc_lower for kw in research_keywords):
+            workflow_mode = "research"
+        else:
+            workflow_mode = "classical_ml"
+
+        # Extract metric hint if mentioned
+        metric_hint = "TODO"
+        for kw in ("accuracy", "rmse", "mae", "f1", "auc", "loss",
+                    "precision", "recall", "bleu", "rouge", "mse",
+                    "r2", "perplexity", "iou"):
+            if kw in desc_lower:
+                metric_hint = kw.upper() if len(kw) <= 4 else kw.capitalize()
+                break
+
+        sections = [
+            "---",
+            f"project_name: {self._project_name}",
+            'version: "0.1.0"',
+            f'created: "{now}"',
+            f'last_modified: "{now}"',
+            "status: active",
+            'owner: "TODO"',
+            "---",
+            "",
+            "## Objective",
+            "",
+            description,
+            "",
+            "TODO: Expand into full objective with concrete deliverables.",
+            "",
+            "## Oracle Definition",
+            "",
+            f"**Primary metric:** {metric_hint}",
+            "**Ground truth source:** TODO",
+            "**Evaluation method:** TODO",
+            "**Target threshold:** TODO",
+            "**Evaluation frequency:** TODO",
+            "",
+            "## Workflow Configuration",
+            "",
+            f"**Mode:** {workflow_mode}",
+            "",
+            "## Data Sources",
+            "",
+            "### Primary",
+            "",
+            "TODO: Describe your primary data source.",
+            "",
+            "## Domain Context and Priors",
+            "",
+            f"- Project context: {description}",
+            "",
+            "TODO: Add domain knowledge and assumptions.",
+            "",
+            "## Agent Configuration",
+            "",
+            "**Active agents:** data-engineer, model-builder, oracle-qa, test-engineer",
+            "",
+            "## Constraints",
+            "",
+            "TODO: Define constraints (time, compute, data, regulatory).",
+            "",
+            "## Milestones and Timeline",
+            "",
+            "TODO: Define milestones.",
+            "",
+        ]
+
+        plan_path.write_text("\n".join(sections), encoding="utf-8")
+        return plan_path
+
+    def get_document_summaries(self, max_entries: int = 10) -> str:
+        """Return formatted summaries of indexed documents.
+
+        Used to inject document context into the Claude session prompt.
+
+        Args:
+            max_entries: Maximum number of summaries to return.
+
+        Returns:
+            Formatted string of document summaries, or empty string.
+        """
+        hits = self._index.query("project objective data domain", top_k=max_entries)
+        if not hits:
+            return ""
+        lines = ["Indexed document summaries:"]
+        for hit in hits:
+            summary = hit.entry.summary
+            if summary.startswith("["):
+                idx = summary.find("]")
+                if idx != -1:
+                    summary = summary[idx + 2:]
+            lines.append(f"  - {summary}")
+        return "\n".join(lines)
+
     def validate_draft(self, plan_path: Path) -> bool:
         """Validate the generated plan against the schema.
 

--- a/tests/unit/test_cli.py
+++ b/tests/unit/test_cli.py
@@ -402,6 +402,64 @@ class TestDraftCommand:
         plan_path = zo_root / "plans" / "test-draft.md"
         assert plan_path.exists()
 
+    def test_draft_from_description(
+        self, runner: click.testing.CliRunner, tmp_path: Path
+    ) -> None:
+        zo_root = tmp_path / "zo"
+        zo_root.mkdir()
+
+        with patch("zo.cli._zo_root", return_value=zo_root):
+            result = runner.invoke(
+                cli,
+                ["draft", "--project", "test-desc", "-d",
+                 "CIFAR-10 image classification with PyTorch CNN, target 90% accuracy"],
+            )
+
+        assert result.exit_code == 0
+        assert "Drafting plan for" in result.output
+        plan_path = zo_root / "plans" / "test-desc.md"
+        assert plan_path.exists()
+        content = plan_path.read_text()
+        assert "deep_learning" in content
+        assert "Accuracy" in content
+        assert "CIFAR-10" in content
+
+    def test_draft_interactive_prompt(
+        self, runner: click.testing.CliRunner, tmp_path: Path
+    ) -> None:
+        zo_root = tmp_path / "zo"
+        zo_root.mkdir()
+
+        with patch("zo.cli._zo_root", return_value=zo_root):
+            result = runner.invoke(
+                cli,
+                ["draft", "--project", "test-interactive", "--no-tmux"],
+                input="Random forest classifier for tabular sales data, target RMSE < 0.1\n",
+            )
+
+        assert result.exit_code == 0
+        plan_path = zo_root / "plans" / "test-interactive.md"
+        assert plan_path.exists()
+        content = plan_path.read_text()
+        assert "classical_ml" in content
+        assert "RMSE" in content
+
+    def test_draft_empty_input_aborts(
+        self, runner: click.testing.CliRunner, tmp_path: Path
+    ) -> None:
+        zo_root = tmp_path / "zo"
+        zo_root.mkdir()
+
+        with patch("zo.cli._zo_root", return_value=zo_root):
+            result = runner.invoke(
+                cli,
+                ["draft", "--project", "test-empty", "--no-tmux"],
+                input="\n",
+            )
+
+        assert result.exit_code == 1
+        assert "No description provided" in result.output
+
 
 # ---------------------------------------------------------------------------
 # gate-mode mapping


### PR DESCRIPTION
## Summary
- `zo draft` now works **with or without source documents**
- No args → prompts for description interactively
- `-d "description"` → seeds plan from description
- Source paths → indexes docs and feeds context (existing behavior preserved)
- All paths launch an interactive Claude session that drafts conversationally
- Adds keyword inference: CNN/PyTorch → `deep_learning` mode, accuracy → metric hint

## Usage
```bash
zo draft --project cifar10 -d "CIFAR-10 CNN, PyTorch, 90%+ accuracy"
zo draft ~/docs/spec.md --project my-project
zo draft --project my-project  # interactive prompt
```

## Test plan
- [x] `test_draft_requires_project` — existing test passes
- [x] `test_draft_indexes_and_generates` — existing source-docs flow passes
- [x] `test_draft_from_description` — `-d` flag generates plan with deep_learning mode + Accuracy hint
- [x] `test_draft_interactive_prompt` — simulated input generates plan with classical_ml + RMSE
- [x] `test_draft_empty_input_aborts` — empty input exits cleanly
- [x] 341 tests pass, ruff clean, validate-docs 9/9

🤖 Generated with [Claude Code](https://claude.com/claude-code)