### PR TITLE
feat: brand banner everywhere + production phase definitions + worktree-aware draft

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@
 <br/>
 
 [![Status](https://img.shields.io/badge/status-validated-F0C040?style=flat-square&labelColor=080808)](#status)
-[![Tests](https://img.shields.io/badge/tests-338_passing-F0C040?style=flat-square&labelColor=080808)](#status)
+[![Tests](https://img.shields.io/badge/tests-347_passing-F0C040?style=flat-square&labelColor=080808)](#status)
 [![Agents](https://img.shields.io/badge/agents-17_defined-F0C040?style=flat-square&labelColor=080808)](#agent-teams)
 [![E2E](https://img.shields.io/badge/MNIST-99%25_accuracy-F0C040?style=flat-square&labelColor=080808)](#e2e-validation)
 
@@ -165,6 +165,10 @@ zo gates set full-auto -p my-project
 
 Writes the new mode to `memory/{project}/gate_mode`. The running orchestrator and wrapper pick it up on the next poll cycle — no restart needed.
 
+### Live Status & Haiku Headlines
+
+During `zo build`, the main terminal shows a live activity feed: tasks, agent progress, comms events. Every 60 seconds, Claude Haiku generates a 1-line headline summarising recent activity — like news ticker for your build.
+
 ---
 
 ## Quick Start
@@ -173,7 +177,7 @@ Writes the new mode to `memory/{project}/gate_mode`. The running orchestrator an
 # 1. Clone and setup
 git clone https://github.com/SamPlvs/zero-operators.git
 cd zero-operators
-./setup.sh                    # validates Python 3.11+, uv, Claude CLI, agent teams
+./setup.sh                    # validates deps, auto-fixes missing ones interactively
 
 # 2. Install
 uv sync --extra dev
@@ -251,7 +255,7 @@ ZO follows a structured pipeline defined in `specs/workflow.md`. Three modes ava
 
 ```
 Phase 1: Data Review & Pipeline     → Gate (automated)
-  Data audit, hygiene, EDA, versioning, DataLoader
+  13 subtasks covering schema validation, outlier detection, class imbalance, split strategy, and more
 
 Phase 2: Feature Engineering        → Gate (BLOCKING — human approves features)
   Feature creation, statistical filtering, multicollinearity pruning
@@ -331,7 +335,7 @@ Adds **Phase 0: Literature Review** (prior art survey, baseline definition). Pha
 | Agent | Model | When Active | What They Do |
 |-------|-------|-------------|-------------|
 | Lead Orchestrator | Opus | Always | Creates team, decomposes phases, manages gates, coordinates |
-| Research Scout | Opus | Phase 0 | Literature survey, SOTA, open-source code, experiment plan |
+| Research Scout | Opus | All phases | Literature survey, SOTA, open-source code, experiment plan |
 | Data Engineer | Sonnet | Phases 1-2 | Data pipeline, cleaning, EDA, DataLoaders |
 | Model Builder | Opus | Phases 3-5 | Architecture selection, training, iteration |
 | Oracle / QA | Sonnet | Phases 3-5 | Hard metric evaluation, pass/fail gating |
@@ -341,6 +345,8 @@ Adds **Phase 0: Literature Review** (prior art survey, baseline definition). Pha
 | Domain Evaluator | Opus | Phase 5 | Domain validation, plausibility checks |
 | ML Engineer | Sonnet | Phases 4-6 | Inference optimization, experiment tracking |
 | Infra Engineer | Haiku | Phases 1, 6 | Environment setup, packaging, deployment |
+
+Code Reviewer and Research Scout are cross-cutting agents present in all phases by default.
 
 **Dynamic agents** — if your project needs expertise not covered (NLP, time-series, security), the Lead Orchestrator creates a new agent definition on the fly.
 
@@ -386,7 +392,7 @@ zero-operators/
 ├── memory/                     # Per-project state (STATE.md, DECISION_LOG, PRIORS)
 ├── logs/                       # JSONL audit trails
 ├── targets/                    # Delivery repo configuration
-├── tests/                      # 338 tests (unit + integration)
+├── tests/                      # 347 tests (unit + integration)
 ├── setup.sh                    # Environment validation (10 checks)
 └── pyproject.toml              # Python package config
 ```
@@ -439,7 +445,7 @@ mnist-delivery/          ← delivery repo (clean)
 | 1.0.1 | Interactive tmux, brand panel, smart build, Research Scout, self-evolution | Done |
 | pre-F5 | Phase persistence, auto-notebooks, delivery scaffold + Docker, preflight | Done |
 
-338 platform tests. ruff clean. 17 agents. 24 slash commands.
+347 platform tests. ruff clean. 17 agents. 24 slash commands.
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -156,6 +156,15 @@ Control how much autonomy ZO has at phase transitions.
 
 You can switch modes at runtime — start supervised, watch the first few phases, then switch to auto once you trust the flow.
 
+### `zo gates set` — Change gate mode mid-session
+
+```bash
+zo gates set auto --project my-project
+zo gates set full-auto -p my-project
+```
+
+Writes the new mode to `memory/{project}/gate_mode`. The running orchestrator and wrapper pick it up on the next poll cycle — no restart needed.
+
 ---
 
 ## Quick Start
@@ -361,7 +370,7 @@ Over time, `PRIORS.md` accumulates domain knowledge. The same mistake never happ
 ```
 zero-operators/
 ├── src/zo/                     # Platform code (10 modules)
-│   ├── cli.py                  # CLI: zo build/continue/init/status/draft
+│   ├── cli.py                  # CLI: zo build/continue/init/status/draft/gates
 │   ├── draft.py                # Conversational plan generation (with or without source docs)
 │   ├── plan.py                 # Plan parser and validator (8 sections)
 │   ├── target.py               # Target file parser, isolation enforcer

--- a/docs/COMMANDS.md
+++ b/docs/COMMANDS.md
@@ -8,6 +8,76 @@ All commands are defined in `.claude/commands/` and invoked as `/category/comman
 
 ---
 
+## CLI Commands
+
+These are terminal commands provided by the `zo` CLI (installed via `uv`). They are distinct from the slash commands used inside Claude Code sessions.
+
+### zo build
+
+Launch an agent team to execute a plan. Parses the plan, shows a phase review, and spawns agents in a tmux session for parallel execution.
+
+```
+zo build plans/project.md [--gate-mode supervised|auto|full-auto] [--no-tmux]
+```
+
+### zo continue
+
+Resume a paused project. Shorthand for `zo build` with an existing plan -- finds the plan by project name and picks up from the current phase.
+
+```
+zo continue project-name [--gate-mode supervised|auto|full-auto]
+```
+
+### zo draft
+
+Draft a plan conversationally. Accepts source documents, a description, or launches an interactive prompt. Starts a Claude session to refine the plan collaboratively.
+
+```
+zo draft [SOURCE_PATHS...] --project NAME [-d DESC] [--no-tmux]
+```
+
+### zo init
+
+Initialize a project scaffold including memory directory, targets, plans, and delivery repo. Auto-scaffolds the delivery repo if `--scaffold-delivery` is provided.
+
+```
+zo init project-name [--scaffold-delivery PATH]
+```
+
+### zo status
+
+Show the current project status by reading `STATE.md`. Displays phase, blockers, recent activity, and next steps.
+
+```
+zo status project-name
+```
+
+### zo preflight
+
+Validate the environment before building. Checks CLI tools, plan structure, agent definitions, Docker availability, and GPU access.
+
+```
+zo preflight plans/project.md [-t TARGET_REPO]
+```
+
+### zo gates set
+
+Change the gate mode for a running project. The active build session picks up the change within 10 seconds.
+
+```
+zo gates set MODE --project NAME
+```
+
+`MODE` is one of: `supervised` (human approves every gate), `auto` (orchestrator approves unless ambiguous), `full-auto` (all gates auto-approved).
+
+---
+
+## Slash Commands
+
+The following slash commands are available inside Claude Code sessions.
+
+---
+
 ## Project Lifecycle
 
 ### /project/import \<github-url\>

--- a/docs/SAMPLE_PROJECT.md
+++ b/docs/SAMPLE_PROJECT.md
@@ -6,6 +6,28 @@ A step-by-step guide to running Zero Operators on a CIFAR-10 image classifier. U
 
 ---
 
+## Quick Start Flow
+
+```bash
+# 1. Setup (auto-fixes missing deps interactively)
+cd /path/to/zero-operators
+./setup.sh
+
+# 2. Initialize (auto-scaffolds delivery repo)
+zo init cifar10-demo
+zo init cifar10-demo --scaffold-delivery ~/projects/cifar10-delivery
+
+# 3. Draft a plan (or write one manually — see Step 2 below)
+zo draft --project cifar10-demo              # interactive prompt
+zo draft --project cifar10-demo -d "CIFAR-10 CNN, PyTorch, 85%+ accuracy"
+
+# 4. Launch
+tmux new -s zo
+zo build plans/cifar10-demo.md
+```
+
+---
+
 ## Prerequisites
 
 ```bash
@@ -13,12 +35,12 @@ A step-by-step guide to running Zero Operators on a CIFAR-10 image classifier. U
 ssh your-server
 tmux new -s zo
 
-# Verify ZO environment
+# Verify ZO environment — auto-fixes missing dependencies
 cd /path/to/zero-operators
-bash setup.sh
+./setup.sh
 ```
 
-All 10 checks should pass.
+All 10 checks should pass. `setup.sh` will offer to install missing tools (uv, Claude CLI, etc.) interactively.
 
 ---
 
@@ -55,7 +77,7 @@ See `STRUCTURE.md` inside the delivery repo or [Delivery Repo Structure](DELIVER
 
 ## Step 2: Write the Plan
 
-Edit `plans/cifar10-demo.md`:
+Use `zo draft --project cifar10-demo` to generate a plan conversationally, or edit `plans/cifar10-demo.md` manually:
 
 ```markdown
 ---
@@ -237,6 +259,13 @@ Expected output:
 # Supervised mode -- approve every gate (recommended for first run)
 zo build plans/cifar10-demo.md --gate-mode supervised
 ```
+
+> **Tip:** You can switch gate modes mid-session without restarting:
+> ```bash
+> zo gates set auto --project cifar10-demo
+> zo gates set full-auto -p cifar10-demo
+> ```
+> The running orchestrator picks up the change on the next poll cycle.
 
 **What happens:**
 

--- a/docs/demo.html
+++ b/docs/demo.html
@@ -1550,7 +1550,7 @@
 <div class="panel" id="panel-commands">
 
   <h1>COMMANDS</h1>
-  <div class="subtitle">24 slash commands for Claude Code</div>
+  <div class="subtitle">7 CLI commands + 24 slash commands for Claude Code</div>
 
   <input type="text" class="cmd-search" id="cmd-search" placeholder="Type to filter commands..." oninput="filterCommands()">
 
@@ -1832,13 +1832,14 @@
 
   <div class="section-label">Quick Start</div>
 
-  <h3>1. Initialize</h3>
-  <pre class="code-block"><code>zo init cifar10-demo
-mkdir -p ~/projects/cifar10-delivery && cd ~/projects/cifar10-delivery && git init && cd -
-zo init cifar10-demo --scaffold-delivery ~/projects/cifar10-delivery</code></pre>
+  <h3>1. Setup &amp; Initialize</h3>
+  <pre class="code-block"><code>./setup.sh                    # auto-fixes missing deps (uv, Claude CLI, zo)
+zo init cifar10-demo          # scaffolds memory, targets, plans, delivery repo</code></pre>
 
-  <h3>2. Write Plan</h3>
-  <p>Edit <code>plans/cifar10-demo.md</code> with CIFAR-10 config. Key fields:</p>
+  <h3>2. Draft Plan</h3>
+  <pre class="code-block"><code>zo draft --project cifar10-demo -d "CIFAR-10 image classification, PyTorch CNN, 90%+ accuracy"
+# Or interactively: zo draft --project cifar10-demo</code></pre>
+  <p>Claude drafts the plan conversationally. Key fields:</p>
   <div style="display:grid; grid-template-columns: 1fr 1fr; gap: 2px; margin-bottom: 24px;">
     <div class="stat-item scanlines" style="padding: 12px 16px;">
       <div style="color: var(--amber); font-size: 13px; margin-bottom: 4px;">Oracle</div>
@@ -1858,15 +1859,14 @@ zo init cifar10-demo --scaffold-delivery ~/projects/cifar10-delivery</code></pre
     </div>
   </div>
 
-  <h3>3. Build Docker + Preflight</h3>
-  <pre class="code-block"><code># Build delivery container
-cd ~/projects/cifar10-delivery && docker compose -f docker/docker-compose.yml build && cd -
+  <h3>3. Preflight + Launch</h3>
+  <pre class="code-block"><code>zo preflight plans/cifar10-demo.md    # validate environment
+zo build plans/cifar10-demo.md        # launch agent team</code></pre>
 
-# Validate everything
-zo preflight plans/cifar10-demo.md --target-repo ~/projects/cifar10-delivery</code></pre>
-
-  <h3>4. Launch</h3>
-  <pre class="code-block"><code>zo build plans/cifar10-demo.md --gate-mode supervised</code></pre>
+  <h3>4. Toggle Gates Mid-Session</h3>
+  <pre class="code-block"><code># Start supervised, then switch once confident:
+zo gates set auto --project cifar10-demo
+zo gates set full-auto --project cifar10-demo   # full autonomy</code></pre>
 
   <div class="section-label">What Happens</div>
 
@@ -2056,17 +2056,16 @@ function toggleStep(el) {
 // ── Agent cards ──
 const agentData = {
   'lead-orchestrator': { model: 'Opus', team: 'Project Delivery', role: 'Creates the agent team, decomposes the plan into phases, manages gate transitions, coordinates all agent communication. The central hub.', owns: 'Orchestration, phase management, gate coordination', when: 'Always active -- present in every phase' },
-  'research-scout': { model: 'Opus', team: 'Project Delivery', role: 'Surveys literature for relevant approaches, identifies SOTA and analogous benchmarks, catalogs open-source implementations, designs experiment plans with baselines. Handles customer projects with no published benchmarks.', owns: 'research/', when: 'Phase 0 (Literature Review) and Phase 3 (Model Design)' },
+  'research-scout': { model: 'Opus', team: 'Project Delivery', role: 'Surveys literature for relevant approaches, identifies SOTA and analogous benchmarks, catalogs open-source implementations, designs experiment plans with baselines. Cross-cutting agent present in all phases.', owns: 'research/', when: 'All phases (cross-cutting -- domain context informs every phase)' },
   'data-engineer': { model: 'Sonnet', team: 'Project Delivery', role: 'Builds and validates the data pipeline. Handles data cleaning, EDA, profiling, DataLoader construction, train/val/test splits, and data versioning.', owns: 'data/, DataLoaders, data tests', when: 'Phases 1-2 (Data Review, Feature Engineering)' },
   'model-builder': { model: 'Opus', team: 'Project Delivery', role: 'Designs model architecture, writes training loops, runs the iteration protocol (train, evaluate, adjust). Handles architecture selection, loss function design, and hyperparameter strategy.', owns: 'src/model.py, src/train.py, models/', when: 'Phases 3-5 (Model Design through Validation)' },
   'oracle-qa': { model: 'Sonnet', team: 'Project Delivery', role: 'The hard evaluator. Runs tiered metric evaluation (Tier 1 core, Tier 2 operational, Tier 3 robustness). Enforces pass/fail gating with no negotiation on thresholds.', owns: 'oracle/, reports/validation_report.md', when: 'Phases 3-5 (every evaluation cycle)' },
   'code-reviewer': { model: 'Sonnet', team: 'Project Delivery', role: 'Reviews all code changes for PEP8 compliance, security issues, convention enforcement, and overall quality. Acts as the code quality gate.', owns: 'Code review reports', when: 'All phases -- reviews every code change' },
   'test-engineer': { model: 'Sonnet', team: 'Project Delivery', role: 'Writes and maintains unit, integration, and regression test suites. Ensures test coverage meets targets and all tests pass before gate transitions.', owns: 'tests/', when: 'All phases -- tests accompany every deliverable' },
   'xai-agent': { model: 'Sonnet', team: 'Project Delivery (Phase-in)', role: 'Produces explainability analysis: SHAP values, feature importance rankings, GradCAM visualizations, and interpretability reports.', owns: 'xai/, experiments/explainability/', when: 'Phase 5 (Analysis & Validation)' },
-  'domain-evaluator': { model: 'Opus', team: 'Project Delivery (Phase-in)', role: 'Validates model outputs against domain knowledge. Checks plausibility, extracts domain priors, and flags results that are statistically valid but domain-implausible.', owns: 'PRIORS.md updates, domain validation reports', when: 'Phase 5 (domain-specific validation)' },
+  'domain-evaluator': { model: 'Opus', team: 'Project Delivery', role: 'Validates data and model outputs against domain knowledge. Checks plausibility, extracts domain priors, and flags results that are statistically valid but domain-implausible.', owns: 'PRIORS.md updates, domain validation reports', when: 'Phases 1, 5 (data validation and final domain review)' },
   'ml-engineer': { model: 'Sonnet', team: 'Project Delivery (Phase-in)', role: 'Optimizes the inference pipeline, manages experiment tracking, handles model serving configuration, and ensures production readiness.', owns: 'src/inference.py, experiments/', when: 'Phases 4-6 (Training through Packaging)' },
-  'infra-engineer': { model: 'Haiku', team: 'Project Delivery (Phase-in)', role: 'Handles environment setup, dependency management, packaging (pyproject.toml), deployment configs, and CI/CD pipeline setup.', owns: 'pyproject.toml, setup.sh, CI configs', when: 'Phases 1, 6 (initial setup, final packaging)' },
-  'research-scout': { model: 'Opus', team: 'Project Delivery', role: 'Surveys literature, finds state-of-the-art methods, designs experiment plans. Owns the Phase 0 literature review and baseline definition.', owns: 'Literature surveys, experiment design docs, PRIORS.md contributions', when: 'Phase 0 (Literature Review)' }
+  'infra-engineer': { model: 'Haiku', team: 'Project Delivery (Phase-in)', role: 'Handles environment setup, dependency management, packaging (pyproject.toml), deployment configs, and CI/CD pipeline setup.', owns: 'pyproject.toml, setup.sh, CI configs', when: 'Phases 1, 6 (initial setup, final packaging)' }
 };
 
 function selectAgent(el, name) {

--- a/memory/zo-platform/DECISION_LOG.md
+++ b/memory/zo-platform/DECISION_LOG.md
@@ -423,3 +423,33 @@ Append-only. Every orchestration decision with timestamp, rationale, and outcome
 **Rationale:** User ran `zo init --scaffold-delivery ~/projects/cifar10-delivery`, then `zo build` looked for `/code/target-cifar10-demo` — a completely different path. The target template hardcoded a relative path that never matched the scaffold. The init → draft → build pipeline must carry its own context autonomously through the target file.
 **Alternatives considered:** (1) Ask user to pass path at every step — breaks autonomous promise. (2) Store path in STATE.md — wrong abstraction, target file already exists for this. (3) Target file as single source of truth with absolute paths (chosen) — deterministic, no user input between commands.
 **Outcome:** PR #25. Target file always has absolute paths. init auto-scaffolds. build reads target file. Full pipeline works without user passing paths.
+
+---
+
+## Decision: 2026-04-12T23:30:00Z
+**Type:** FEATURE
+**Title:** Haiku headline summaries in live build status feed
+**Decision:** Buffer comms events (decisions, gates, checkpoints, errors) during `zo build` status polling. Every 60 seconds, send the last 15 buffered events to Claude Haiku with a prompt to generate a 1-line headline (80 chars max). Print with `▸` prefix in amber. Non-blocking — fails silently if Haiku unavailable.
+**Rationale:** The raw event feed (decisions, checkpoints, errors) is useful but verbose. A periodic natural language summary gives the user a quick "what's happening" without reading every line. Like a news ticker for their build.
+**Alternatives considered:** (1) No summaries — raw events only. (2) Python-based summariser — brittle, can't handle diverse events. (3) Haiku API call (chosen) — fast, cheap, high quality, graceful degradation.
+**Outcome:** PR #25. 60s interval, 15-event batch, 80-char headline.
+
+---
+
+## Decision: 2026-04-12T23:30:00Z
+**Type:** FEATURE
+**Title:** zo gates set — toggle gate mode mid-session
+**Decision:** New CLI command `zo gates set MODE --project NAME` writes the mode to `memory/{project}/gate_mode`. The orchestrator calls `_refresh_gate_mode()` at the top of `advance_phase()` to re-read the file before each gate decision. The wrapper calls `_check_gate_mode_change()` each poll cycle. Changes take effect within 10 seconds — no restart needed.
+**Rationale:** In supervised mode, every agent tool call needs approval. User wants to start supervised (to verify things work), then switch to auto once confident. Previously required killing the session and restarting with a different flag.
+**Alternatives considered:** (1) Restart with different flag — loses session context. (2) Signal-based (SIGUSR1) — fragile, platform-specific. (3) File-based with polling (chosen) — simple, reliable, works from any terminal.
+**Outcome:** PR #25. 6 new tests, 347 total. MemoryManager.read_gate_mode() / write_gate_mode().
+
+---
+
+## Decision: 2026-04-13T00:00:00Z
+**Type:** DOCUMENTATION
+**Title:** Full documentation audit and consistency sweep
+**Decision:** Audited README, COMMANDS.md, SAMPLE_PROJECT.md, workflow.md, DELIVERY_STRUCTURE.md for consistency with session 011 features. Found: (1) COMMANDS.md missing all CLI commands (only had slash commands). (2) specs/workflow.md Phase 1 still had 7 subtasks (should be 13). (3) README agent table showed Research Scout as "Phase 0" (should be "All phases"). (4) Test counts stale (338 → 347). (5) New features (Haiku headlines, zo gates set, tmux orphan prevention) not documented. Fixed all issues.
+**Rationale:** PR-005 prior: aspirational docs without enforcement degrade. This session added 10+ features but only partially updated docs. Full sweep ensures any user reading any doc gets consistent, current information.
+**Alternatives considered:** None — mandatory per CLAUDE.md protocol.
+**Outcome:** All user-facing docs updated and cross-referenced.

--- a/memory/zo-platform/DECISION_LOG.md
+++ b/memory/zo-platform/DECISION_LOG.md
@@ -413,3 +413,13 @@ Append-only. Every orchestration decision with timestamp, rationale, and outcome
 **Rationale:** Phase 1 with only data-engineer + test-engineer and 7 subtasks was adequate for CIFAR-10 but not for production data (messy, large-scale, domain-specific). The 6 new subtasks cover real-world essentials that were missing. Code review and research are cross-cutting concerns — code quality degrades silently and domain understanding should inform every phase, not just Phase 0.
 **Alternatives considered:** (1) Keep minimal, let plan.md override — misses the "good defaults" principle. (2) Add agents to Phase 1 only — leaves other phases thin on review/research. (3) Cross-cutting defaults + enriched Phase 1 (chosen) — good defaults everywhere, plan.md can still override.
 **Outcome:** PR #25. Phase 1: 13 subtasks, 5 agents. All phases: code-reviewer + research-scout default.
+
+---
+
+## Decision: 2026-04-12T23:00:00Z
+**Type:** ARCHITECTURE
+**Title:** Autonomous path handoff — target file as single source of truth for delivery repo
+**Decision:** (1) `zo init` now always writes an absolute delivery path to `targets/{project}.target.md`. If `--scaffold-delivery PATH` given, uses that resolved path. If not, defaults to `../{project}-delivery/` resolved to absolute. (2) `zo init` always scaffolds the delivery repo (not just with `--scaffold-delivery`). (3) Target template uses `{target_repo}` placeholder instead of hardcoded `../target-{project}`. (4) `zo build` reads the absolute path from the target file — no path guessing. The user never needs to pass paths between commands.
+**Rationale:** User ran `zo init --scaffold-delivery ~/projects/cifar10-delivery`, then `zo build` looked for `/code/target-cifar10-demo` — a completely different path. The target template hardcoded a relative path that never matched the scaffold. The init → draft → build pipeline must carry its own context autonomously through the target file.
+**Alternatives considered:** (1) Ask user to pass path at every step — breaks autonomous promise. (2) Store path in STATE.md — wrong abstraction, target file already exists for this. (3) Target file as single source of truth with absolute paths (chosen) — deterministic, no user input between commands.
+**Outcome:** PR #25. Target file always has absolute paths. init auto-scaffolds. build reads target file. Full pipeline works without user passing paths.

--- a/memory/zo-platform/DECISION_LOG.md
+++ b/memory/zo-platform/DECISION_LOG.md
@@ -373,3 +373,43 @@ Append-only. Every orchestration decision with timestamp, rationale, and outcome
 **Rationale:** User ran `uv sync` then `zo init` → "command not found". `uv sync` installs into `.venv/bin/` which isn't on PATH when conda/pyenv/system Python is active. setup.sh only checked deps *resolve* (dry-run), never verified the CLI was *callable*. This is the difference between "package manager happy" and "user can type the command".
 **Alternatives considered:** (1) Tell user to `source .venv/bin/activate` — adds manual step, breaks "just run setup.sh" promise. (2) `uv pip install -e .` into active env — fragile with conda, pollutes base env. (3) Symlink to `~/.local/bin/` (chosen) — clean, already on PATH, works with any Python env manager.
 **Outcome:** setup.sh now passes 12/12 checks. `zo, version 1.0.1` callable after setup. PR-012 prior added.
+
+---
+
+## Decision: 2026-04-12T21:00:00Z
+**Type:** FEATURE
+**Title:** Conversational zo draft — source documents optional
+**Decision:** Reworked `zo draft` so source paths are optional. Three usage modes: (1) source docs → index + template + tmux session, (2) `-d "description"` → skeleton from keywords + tmux session, (3) no args → interactive prompt for description + tmux session. All paths converge at a Claude session that drafts the plan conversationally. Added `generate_plan_from_description()` with workflow mode inference (CNN/PyTorch → deep_learning) and metric hint extraction.
+**Rationale:** User ran `zo draft plans/cifar10-demo.md` expecting it to work — but the command required source document paths. CIFAR-10 is a well-known domain with no source docs needed. The rigid template-filling approach produced plans full of TODOs. Making the tmux Claude session the primary drafter (not a refinement afterthought) gives much better results.
+**Alternatives considered:** (1) Require source docs always — breaks well-known-domain use case. (2) Generate smarter template without Claude — still static, can't ask questions. (3) Conversational agent-driven (chosen) — Claude asks about objectives, data, metrics, constraints.
+**Outcome:** PR #24. 3 new tests, 341 total. zo draft works in all three modes.
+
+---
+
+## Decision: 2026-04-12T21:30:00Z
+**Type:** ARCHITECTURE
+**Title:** Plans write to main repo, not worktrees — _main_repo_root() helper
+**Decision:** Added `_main_repo_root()` to cli.py that detects git worktrees via `git worktree list --porcelain` and returns the main repo path. `zo draft` uses this to write plans to the main repo's `plans/` directory. Draft session prompt references `zo build plans/{project}.md` with main-repo relative path.
+**Rationale:** User ran `zo draft` from a worktree. Plan landed in worktree's `plans/` dir. Then `zo build` from main repo couldn't find it. ZO artifacts (plans, memory, state) should always live in the main repo — worktrees are for ZO development, not ZO usage.
+**Alternatives considered:** (1) Tell user to copy manually — bad UX. (2) Always run from main repo — doesn't help when you're already in a worktree. (3) Auto-detect and write to main repo (chosen) — transparent, no user action needed.
+**Outcome:** PR #25. Plans always land in main repo regardless of cwd.
+
+---
+
+## Decision: 2026-04-12T22:00:00Z
+**Type:** UX
+**Title:** Brand banner on all CLI commands via shared _show_banner()
+**Decision:** Extracted the ZO brand panel (orbital mark, version, project/mode/phase/gates) into a shared `_show_banner()` function. Called at the top of all 6 CLI commands: build, draft, init, status, preflight, continue. Fields are optional — commands that don't have a phase or gates simply omit those lines.
+**Rationale:** The brand panel was only in `zo build`. User noted it should appear everywhere — it establishes identity and shows current context at a glance. Professional tooling has consistent branding across all entry points.
+**Alternatives considered:** None — clearly the right move.
+**Outcome:** PR #25. All commands show the banner.
+
+---
+
+## Decision: 2026-04-12T22:00:00Z
+**Type:** ARCHITECTURE
+**Title:** Production-grade phase definitions — enriched Phase 1, cross-cutting agents
+**Decision:** (1) Phase 1 (Data Review) expanded from 7 to 13 subtasks: added data schema validation, missing value analysis, outlier detection, class imbalance analysis, train/val/test split strategy, data drift baseline. Added research-scout, code-reviewer, domain-evaluator to Phase 1 agents (5 total, was 2). (2) Made code-reviewer and research-scout default on ALL phases across all 3 workflow modes (classical_ml, deep_learning, research).
+**Rationale:** Phase 1 with only data-engineer + test-engineer and 7 subtasks was adequate for CIFAR-10 but not for production data (messy, large-scale, domain-specific). The 6 new subtasks cover real-world essentials that were missing. Code review and research are cross-cutting concerns — code quality degrades silently and domain understanding should inform every phase, not just Phase 0.
+**Alternatives considered:** (1) Keep minimal, let plan.md override — misses the "good defaults" principle. (2) Add agents to Phase 1 only — leaves other phases thin on review/research. (3) Cross-cutting defaults + enriched Phase 1 (chosen) — good defaults everywhere, plan.md can still override.
+**Outcome:** PR #25. Phase 1: 13 subtasks, 5 agents. All phases: code-reviewer + research-scout default.

--- a/memory/zo-platform/PRIORS.md
+++ b/memory/zo-platform/PRIORS.md
@@ -353,3 +353,68 @@ pip one-at-a-time installs, source builds in single stage, 80+ apt packages.
    The success criterion for setup is "can the user type `zo build` and have
    it work?" — not "are dependencies resolved?". Test from the user's
    perspective, not the package manager's.
+
+---
+
+## PR-013: ZO Artifacts Must Always Write to Main Repo, Not Worktrees
+**Source:** Session 011 (2026-04-12), zo draft wrote plan to worktree
+**Root cause category:** missing_rule
+**Failure:** User ran `zo draft` from a worktree. Plan was written to worktree's `plans/` dir. Then `zo build` from main repo couldn't find it. User had to manually copy the file.
+
+### Rules
+
+1. **Plans, memory, and state always live in the main repo.**
+   Worktrees are for ZO development, not ZO usage. Use
+   `_main_repo_root()` (git worktree list --porcelain) to find the
+   main repo when writing artifacts that need to persist.
+
+2. **Any zo command that writes artifacts must be worktree-aware.**
+   Check if cwd is a worktree. If so, write to main repo and inform
+   the user: "Written to main repo (not worktree)".
+
+3. **Test from the user's perspective: where would they look?**
+   Users expect `plans/project.md` in the repo they cloned, not in a
+   hidden `.claude/worktrees/` subdirectory.
+
+---
+
+## PR-014: CLI Commands Need Consistent Branding and Context Display
+**Source:** Session 011 (2026-04-12), user noted brand panel only in zo build
+**Root cause category:** missing_rule
+**Failure:** Not a failure — a UX gap. The brand panel (project, mode, phase, gates) only appeared in `zo build`. All other commands showed raw output with no context.
+
+### Rules
+
+1. **Every CLI entry point shows the brand banner.**
+   Extract into shared `_show_banner()`. Establishes identity and
+   shows current context (project, mode). Professional tooling has
+   consistent branding across all entry points.
+
+2. **Banner fields are contextual, not forced.**
+   Only show fields relevant to the command. `zo preflight` has no
+   project — skip that line. `zo draft` has no phase — skip it.
+   Don't show empty fields.
+
+---
+
+## PR-015: Phase Definitions Must Be Production-Ready by Default
+**Source:** Session 011 (2026-04-12), CIFAR-10 Phase 1 review
+**Root cause category:** missing_rule
+**Failure:** Not a failure — a gap. Phase 1 (Data Review) had only 2 agents and 7 subtasks. Sufficient for CIFAR-10 demo but would miss critical steps on messy production data (no schema validation, no outlier detection, no class imbalance analysis, no split strategy).
+
+### Rules
+
+1. **Phase defaults must handle the hardest case, not the easiest.**
+   CIFAR-10 is clean, balanced, well-known. IVL F5 data is messy,
+   domain-specific, potentially imbalanced. Defaults should be
+   production-grade — users can simplify via plan.md overrides.
+
+2. **Code review and research are cross-cutting — always present.**
+   `code-reviewer` catches quality issues before they compound.
+   `research-scout` ensures domain context informs every phase.
+   These shouldn't be opt-in. Add to all phases by default.
+
+3. **Data workflow subtasks must cover the full production checklist.**
+   Schema validation, missing values, outliers, class imbalance,
+   split strategy, drift baselines — all essential before training.
+   Missing any one can silently corrupt downstream results.

--- a/memory/zo-platform/PRIORS.md
+++ b/memory/zo-platform/PRIORS.md
@@ -418,3 +418,33 @@ pip one-at-a-time installs, source builds in single stage, 80+ apt packages.
    Schema validation, missing values, outliers, class imbalance,
    split strategy, drift baselines — all essential before training.
    Missing any one can silently corrupt downstream results.
+
+---
+
+## PR-016: Pipeline Commands Must Carry Context Autonomously
+**Source:** Session 011 (2026-04-12), CIFAR-10 init → build path mismatch
+**Root cause category:** missing_rule
+**Failure:** User ran `zo init --scaffold-delivery ~/projects/cifar10-delivery`, then `zo build` looked for `/code/target-cifar10-demo`. Target template hardcoded `../target-{project}` — a relative path that never matched the scaffold location. User had to manually create the directory and re-init.
+
+### Rules
+
+1. **The user is not a message bus between commands.**
+   init → draft → build must carry context through artifacts (target
+   file, plan, STATE.md). If a path is set in init, every downstream
+   command must read it from the same source — never guess or compute
+   independently.
+
+2. **Always write absolute paths to config files.**
+   Relative paths resolve differently depending on cwd, worktree,
+   tmux session, or agent working directory. Absolute paths are
+   deterministic. Resolve at write time, not read time.
+
+3. **The target file is the single source of truth for delivery repo.**
+   `target_repo` in `targets/{project}.target.md` is THE path. init
+   writes it, build reads it, preflight validates it. No other source.
+
+4. **Default behavior should be autonomous — flags are for overrides.**
+   `zo init project` should scaffold everything (including delivery
+   repo at a default location) without flags. `--scaffold-delivery`
+   is an override for non-default paths, not the only way to get a
+   delivery repo.

--- a/memory/zo-platform/STATE.md
+++ b/memory/zo-platform/STATE.md
@@ -54,6 +54,11 @@ ZO v1.0.2-pre — **CIFAR-10 demo running**. Full UX overhaul: setup.sh auto-fix
 - [x] v1.0.2-pre: README updated — zo draft docs reflect conversational flow + new usage patterns
 - [x] v1.0.2-pre: Autonomous path handoff — zo init writes absolute delivery path to target file, auto-scaffolds delivery repo
 - [x] v1.0.2-pre: init → draft → build pipeline carries context via target file (no user path passing)
+- [x] v1.0.2-pre: Haiku headline summaries — live 1-line status every 60s during zo build
+- [x] v1.0.2-pre: tmux orphan prevention — draft kills existing window before creating new one
+- [x] v1.0.2-pre: Draft tests fixed — all use --no-tmux (was spawning real tmux windows)
+- [x] v1.0.2-pre: zo gates set — toggle gate mode mid-session (supervised/auto/full-auto)
+- [x] v1.0.2-pre: Full doc audit — COMMANDS.md, workflow.md, README, SAMPLE_PROJECT updated for consistency
 
 ## Known Issues
 
@@ -78,7 +83,7 @@ ZO v1.0.2-pre — **CIFAR-10 demo running**. Full UX overhaul: setup.sh auto-fix
 last_checkpoint: 2026-04-12T22:00:00Z
 last_session: session-011
 branch: claude/eloquent-poincare (worktree)
-test_count: 341 passed, 7 skipped
+test_count: 347 passed, 7 skipped
 lint: ruff clean (src/zo/)
 validation: scripts/validate-docs.sh 9/9 passed, 1 warning (test badge)
 prs: #22 (setup auto-fix), #23 (zo CLI install), #24 (conversational draft), #25 (banner + phases + worktree draft)

--- a/memory/zo-platform/STATE.md
+++ b/memory/zo-platform/STATE.md
@@ -8,7 +8,7 @@ status: complete
 
 ## Current Position
 
-ZO v1.0.2-pre — **CIFAR-10 demo setup in progress on new machine**. setup.sh now auto-fixes missing deps (uv, Claude CLI, global settings) with interactive prompt. Environment bootstrapped successfully. 338 tests, ruff clean, validate-docs 9/9. PR #22 merged for setup auto-fix.
+ZO v1.0.2-pre — **CIFAR-10 demo running**. Full UX overhaul: setup.sh auto-fixes deps, zo draft works without source docs (conversational), brand banner on all commands, production-grade phase definitions with cross-cutting agents. 341 tests, ruff clean, validate-docs 9/9. PRs #22-#25.
 
 ## Completed
 
@@ -45,6 +45,13 @@ ZO v1.0.2-pre — **CIFAR-10 demo setup in progress on new machine**. setup.sh n
 - [x] v1.0.2-pre: Claude CLI install updated to official curl method (replaced deprecated npm install)
 - [x] v1.0.2-pre: setup.sh verifies zo CLI callable on PATH (check #11), auto-fixes via symlink to ~/.local/bin/
 - [x] v1.0.2-pre: setup.sh deps check upgraded from dry-run to actual `uv sync`
+- [x] v1.0.2-pre: zo draft works without source docs — conversational, description-based, or interactive prompt
+- [x] v1.0.2-pre: Draft plans write to main repo (not worktrees) via _main_repo_root()
+- [x] v1.0.2-pre: Draft session wrap-up — Claude asks "anything else?" then tells user to /exit and run zo build
+- [x] v1.0.2-pre: Brand banner (_show_banner) on all 6 CLI commands (build, draft, init, status, preflight, continue)
+- [x] v1.0.2-pre: Phase 1 enriched — 13 subtasks (was 7), 5 agents (was 2) for production data workflows
+- [x] v1.0.2-pre: Cross-cutting agents — code-reviewer + research-scout default on ALL phases, all workflow modes
+- [x] v1.0.2-pre: README updated — zo draft docs reflect conversational flow + new usage patterns
 
 ## Known Issues
 
@@ -57,7 +64,7 @@ ZO v1.0.2-pre — **CIFAR-10 demo setup in progress on new machine**. setup.sh n
 
 ## What's Next
 
-1. **CIFAR-10 demo** — environment ready, run `zo build plans/cifar10.md` next
+1. **CIFAR-10 demo** — running, plan drafted, zo build in progress
 2. Phase completion snapshots (C1) — capture context at phase boundaries for reports
 3. Phase summary reports (B3) — markdown reports per phase with embedded plots
 4. Domain evaluator refactor — make project-specific via plan.md domain priors
@@ -66,10 +73,10 @@ ZO v1.0.2-pre — **CIFAR-10 demo setup in progress on new machine**. setup.sh n
 
 ## Session Metadata
 
-last_checkpoint: 2026-04-12T20:00:00Z
+last_checkpoint: 2026-04-12T22:00:00Z
 last_session: session-011
 branch: claude/eloquent-poincare (worktree)
-test_count: 338 passed, 7 skipped
+test_count: 341 passed, 7 skipped
 lint: ruff clean (src/zo/)
 validation: scripts/validate-docs.sh 9/9 passed, 1 warning (test badge)
-pr: #22 (feat: setup auto-fix)
+prs: #22 (setup auto-fix), #23 (zo CLI install), #24 (conversational draft), #25 (banner + phases + worktree draft)

--- a/memory/zo-platform/STATE.md
+++ b/memory/zo-platform/STATE.md
@@ -52,6 +52,8 @@ ZO v1.0.2-pre — **CIFAR-10 demo running**. Full UX overhaul: setup.sh auto-fix
 - [x] v1.0.2-pre: Phase 1 enriched — 13 subtasks (was 7), 5 agents (was 2) for production data workflows
 - [x] v1.0.2-pre: Cross-cutting agents — code-reviewer + research-scout default on ALL phases, all workflow modes
 - [x] v1.0.2-pre: README updated — zo draft docs reflect conversational flow + new usage patterns
+- [x] v1.0.2-pre: Autonomous path handoff — zo init writes absolute delivery path to target file, auto-scaffolds delivery repo
+- [x] v1.0.2-pre: init → draft → build pipeline carries context via target file (no user path passing)
 
 ## Known Issues
 

--- a/memory/zo-platform/sessions/session-011-2026-04-12.md
+++ b/memory/zo-platform/sessions/session-011-2026-04-12.md
@@ -42,9 +42,17 @@
 - PR-013: ZO artifacts must always write to main repo, not worktrees
 - PR-014: CLI commands need consistent branding and context display
 - PR-015: Phase definitions must be production-ready by default
+- PR-016: Pipeline commands must carry context autonomously
+
+### Haiku headlines + gate toggle + tmux fix + doc audit
+- Haiku headline summaries: buffers comms events, calls Haiku every 60s for 1-line summary
+- zo gates set: toggle supervised/auto/full-auto mid-session via file-based polling
+- tmux orphan prevention: draft kills existing window, tests use --no-tmux
+- Full doc audit: COMMANDS.md (CLI section), workflow.md (13 subtasks), README (agent table, test counts, Haiku), SAMPLE_PROJECT (consistency)
+- 347 tests (6 new for gates), ruff clean
 
 ## Next Steps
-- CIFAR-10 demo: environment ready, run `zo build plans/cifar10.md`
+- CIFAR-10 demo: running, plan drafted, build in progress
 - Phase completion snapshots (C1)
 - Phase summary reports (B3)
 - Domain evaluator refactor for IVL F5

--- a/memory/zo-platform/sessions/session-011-2026-04-12.md
+++ b/memory/zo-platform/sessions/session-011-2026-04-12.md
@@ -5,23 +5,26 @@
 **Agent**: orchestrator
 
 ## Accomplished
-- Full project audit: read STATE.md, DECISION_LOG.md, PRIORS.md, plan, specs, codebase structure via parallel agents
-- Provided comprehensive "where we are" summary to user starting CIFAR-10 demo on new machine
-- setup.sh auto-fix feature: detects fixable failures and prompts "Install now? [Y/n]"
-  - Supports: uv (curl install), Claude CLI (curl install), global settings (create/merge JSON)
-  - Bash 3.2 compatible (string counters, not arrays) for stock macOS
-  - Re-execs itself after fixing to re-validate
-- Updated Claude CLI install from deprecated `npm install -g @anthropic-ai/claude-code` to `curl -fsSL https://claude.ai/install.sh | bash`
-- Fixed bash 3.2 empty array bug that silently killed auto-fix block under `set -u`
-- Tested setup.sh: syntax check, normal run (shows tip), --fix run (installs uv 0.11.6 + Claude 2.1.104), stripped PATH test, clean re-validation (11/11 pass)
-- PR #22 created and pushed: feat(setup): auto-fix missing dependencies
-- Configured gh CLI auth on new machine (SamPlvs account, keyring)
-- Fixed `zo: command not found` after `uv sync` — added check #11 (zo CLI on PATH), auto-fix symlinks `.venv/bin/zo` → `~/.local/bin/zo`
-- Upgraded deps check from dry-run to actual `uv sync --quiet`
-- setup.sh now passes 12/12 checks on clean machine
-- Hardened zo-cli fix: uses `uv run python3` to find venv (handles worktrees, conda, any cwd)
-- Added stale symlink detection: `zo` on PATH but broken triggers reinstall
-- Tested: clean pass, auto-fix from scratch, stale symlink, stripped PATH with decline, idempotency
+
+### Setup hardening (PRs #22, #23)
+- setup.sh auto-fix: detects fixable failures, prompts "Install now? [Y/n]", bash 3.2 compatible
+- Claude CLI install updated to `curl -fsSL https://claude.ai/install.sh | bash`
+- zo CLI check #11: verifies callable on PATH, auto-fixes via symlink to ~/.local/bin/
+- Stale symlink detection, deps check upgraded to actual `uv sync`
+- Tested: clean pass, auto-fix, stale symlink, stripped PATH, idempotency
+
+### Conversational draft (PR #24)
+- zo draft works without source docs — 3 modes: source paths, -d description, interactive prompt
+- generate_plan_from_description() with workflow mode inference + metric hints
+- get_document_summaries() for injecting indexed doc context into session prompt
+- README updated with new usage patterns
+
+### Worktree awareness + brand + phases (PR #25)
+- Plans write to main repo via _main_repo_root() (not worktrees)
+- Draft session prompt wraps up cleanly: asks "anything else?", tells user to /exit
+- Brand banner (_show_banner) on all 6 CLI commands
+- Phase 1 enriched: 13 subtasks (was 7), 5 agents (was 2)
+- Cross-cutting agents: code-reviewer + research-scout default on ALL phases, all modes
 
 ## Decisions Made
 - Interactive prompt > --fix flag for setup auto-fix (zero-friction UX)
@@ -36,6 +39,9 @@
 - PR-010: macOS bash 3.2 breaks empty array checks under `set -u`
 - PR-011: Setup scripts should auto-fix, not just report
 - PR-012: uv sync does not put CLI entry points on PATH — symlink to ~/.local/bin/
+- PR-013: ZO artifacts must always write to main repo, not worktrees
+- PR-014: CLI commands need consistent branding and context display
+- PR-015: Phase definitions must be production-ready by default
 
 ## Next Steps
 - CIFAR-10 demo: environment ready, run `zo build plans/cifar10.md`

--- a/specs/workflow.md
+++ b/specs/workflow.md
@@ -98,8 +98,11 @@ Orchestrator confirms: Is the problem well-defined? Are baselines identified? Is
 **Gate:** Gate 1 (Orchestrator review)
 **Input:** Raw data sources, data source documentation
 **Output:** Data quality report, versioned data pipeline, correlation artifact
+**Agents:** data-engineer, test-engineer, research-scout, code-reviewer, domain-evaluator
 
 This phase validates and understands raw data. Each subtask feeds the next. Do not parallelize.
+
+> **Cross-cutting agents:** `code-reviewer` and `research-scout` are cross-cutting agents present in ALL phases. `code-reviewer` validates code quality, test coverage, and adherence to standards in every phase that produces code. `research-scout` monitors for relevant prior art, methodology updates, and domain-specific best practices throughout the project lifecycle.
 
 ### Subtask 1.1: Raw Data Audit
 
@@ -188,6 +191,63 @@ Build the training data pipeline:
 - Benchmark DataLoader throughput (samples/sec) to ensure it won't bottleneck training
 
 **Artifact:** `dataset.py`, `data_loader.py`, `transforms.py`, `loader_benchmark.md`.
+
+### Subtask 1.8: Data Schema Validation
+
+Enforce expected schema on the cleaned dataset:
+- Validate column names, data types, and value ranges against a schema definition
+- Flag columns with unexpected types (e.g., numeric stored as string) or out-of-range values
+- Produce a schema compliance report with pass/fail per column
+
+**Artifact:** `data_schema.yaml`, `schema_validation_report.md`.
+
+### Subtask 1.9: Missing Value Analysis and Strategy
+
+Analyze and document a strategy for handling missing data:
+- Quantify missingness per feature (MCAR, MAR, MNAR classification where feasible)
+- Evaluate imputation strategies (mean/median, forward-fill, model-based, drop) with impact analysis
+- Document chosen strategy per feature with justification
+
+**Artifact:** `missing_value_report.md`, `imputation_config.yaml`.
+
+### Subtask 1.10: Outlier Detection
+
+Identify outliers using statistical and domain-aware methods:
+- Statistical detection: z-score, IQR, isolation forest, or DBSCAN as appropriate
+- Domain-aware detection: flag values that violate physical or business constraints from `PRIORS.md`
+- Document each outlier category with count, severity, and recommended action (keep, cap, remove)
+
+**Artifact:** `outlier_report.md`, `outlier_flags.csv`.
+
+### Subtask 1.11: Class Imbalance Analysis
+
+Assess target variable distribution and plan mitigation:
+- Compute class frequencies and imbalance ratio
+- For regression: identify thin-tail regions with low sample density
+- Recommend mitigation strategy (oversampling, undersampling, class weights, focal loss, SMOTE) with rationale
+- If no imbalance detected, document confirmation
+
+**Artifact:** `imbalance_report.md`, `sampling_config.yaml` (if mitigation needed).
+
+### Subtask 1.12: Train/Val/Test Split Strategy
+
+Define and validate the data splitting approach:
+- Choose split method based on data type (temporal, stratified, grouped, domain-specific)
+- Validate no data leakage across splits (especially for time series and grouped data)
+- Document split ratios, boundaries, stratification keys, and purge gaps
+- Produce split statistics (class distributions, feature distributions per split)
+
+**Artifact:** `split_strategy.md`, `split_statistics.csv`.
+
+### Subtask 1.13: Data Drift Baseline
+
+Establish reference distributions for ongoing monitoring:
+- Compute reference statistics (mean, std, quantiles, histograms) for all features on the training set
+- Store reference distributions in a serializable format for future drift detection
+- Define drift thresholds (PSI, KS-test, or domain-specific) per feature
+- Document baseline assumptions and recommended monitoring cadence
+
+**Artifact:** `drift_baseline.yaml`, `reference_distributions.pkl`, `drift_monitoring_config.yaml`.
 
 ### Gate 1: Data Quality Review
 

--- a/src/zo/_orchestrator_phases.py
+++ b/src/zo/_orchestrator_phases.py
@@ -25,11 +25,14 @@ AGENT_PHASE_MAP: dict[str, list[str]] = {
     "code-reviewer": [
         "phase_1", "phase_2", "phase_3", "phase_4", "phase_5", "phase_6",
     ],
+    "research-scout": [
+        "phase_1", "phase_2", "phase_3", "phase_4", "phase_5", "phase_6",
+    ],
     "test-engineer": [
         "phase_1", "phase_2", "phase_3", "phase_4", "phase_5", "phase_6",
     ],
     "xai-agent": ["phase_5"],
-    "domain-evaluator": ["phase_5"],
+    "domain-evaluator": ["phase_1", "phase_5"],
     "ml-engineer": ["phase_4", "phase_5", "phase_6"],
     "infra-engineer": ["phase_1", "phase_6"],
     "lead-orchestrator": [],
@@ -51,6 +54,13 @@ def classical_ml_phases() -> list[PhaseDefinition]:
             subtasks=[
                 "Raw data audit", "Data hygiene", "Exclusion filters",
                 "Data alignment", "EDA", "Data versioning", "Data loader",
+                "Data schema validation", "Missing value analysis",
+                "Outlier detection", "Class imbalance analysis",
+                "Train/val/test split strategy", "Data drift baseline",
+            ],
+            assigned_agents=[
+                "data-engineer", "test-engineer", "research-scout",
+                "code-reviewer", "domain-evaluator",
             ],
             gate_type=GateType.AUTOMATED,
             depends_on=[],
@@ -68,6 +78,7 @@ def classical_ml_phases() -> list[PhaseDefinition]:
                 "Feature engineering", "Section filter", "Statistical filter",
                 "Multicollinearity pruning", "Domain validation", "Feature ranking",
             ],
+            assigned_agents=["code-reviewer", "research-scout"],
             gate_type=GateType.BLOCKING,
             depends_on=["phase_1"],
             required_artifacts=[
@@ -87,6 +98,7 @@ def classical_ml_phases() -> list[PhaseDefinition]:
                 "Training strategy", "Regime segmentation",
                 "Oracle setup", "Experiment tracking",
             ],
+            assigned_agents=["code-reviewer", "research-scout"],
             gate_type=GateType.AUTOMATED,
             depends_on=["phase_2"],
             required_artifacts=[
@@ -101,6 +113,7 @@ def classical_ml_phases() -> list[PhaseDefinition]:
                 "Baseline training", "Iteration protocol",
                 "Cross-validation", "Ensemble exploration",
             ],
+            assigned_agents=["code-reviewer", "research-scout"],
             gate_type=GateType.AUTOMATED,
             depends_on=["phase_3"],
             required_artifacts=[
@@ -123,6 +136,7 @@ def classical_ml_phases() -> list[PhaseDefinition]:
                 "Significance testing", "Reproducibility",
                 "Report assembly",
             ],
+            assigned_agents=["code-reviewer", "research-scout"],
             gate_type=GateType.BLOCKING,
             depends_on=["phase_4"],
             required_artifacts=[
@@ -138,6 +152,7 @@ def classical_ml_phases() -> list[PhaseDefinition]:
                 "Inference pipeline", "Model card",
                 "Validation report", "Drift detection", "Test suite",
             ],
+            assigned_agents=["code-reviewer", "research-scout"],
             gate_type=GateType.AUTOMATED,
             depends_on=["phase_5"],
             required_artifacts=[
@@ -164,6 +179,7 @@ def deep_learning_phases() -> list[PhaseDefinition]:
             "Input representation design", "Transfer learning assessment",
             "Augmentation strategy",
         ],
+        assigned_agents=["code-reviewer", "research-scout"],
         gate_type=GateType.BLOCKING,
         depends_on=["phase_1"],
     )
@@ -180,6 +196,7 @@ def deep_learning_phases() -> list[PhaseDefinition]:
             "Training strategy", "Gradient diagnostics plan",
             "Regime segmentation", "Oracle setup", "Experiment tracking",
         ],
+        assigned_agents=["code-reviewer", "research-scout"],
         gate_type=GateType.AUTOMATED,
         depends_on=["phase_2"],
     )
@@ -192,6 +209,7 @@ def deep_learning_phases() -> list[PhaseDefinition]:
             "Baseline training", "Training diagnostics",
             "Iteration protocol", "Cross-validation", "Ensemble exploration",
         ],
+        assigned_agents=["code-reviewer", "research-scout"],
         gate_type=GateType.AUTOMATED,
         depends_on=["phase_3"],
     )
@@ -205,6 +223,7 @@ def research_phases() -> list[PhaseDefinition]:
         name="Literature Review and Prior Art",
         description="Survey prior art, define baselines and evaluation protocol.",
         subtasks=["Prior art survey", "Baseline definition"],
+        assigned_agents=["code-reviewer", "research-scout"],
         gate_type=GateType.AUTOMATED,
         depends_on=[],
     )
@@ -226,6 +245,7 @@ def research_phases() -> list[PhaseDefinition]:
             "Significance testing", "Reproducibility",
             "Report assembly",
         ],
+        assigned_agents=["code-reviewer", "research-scout"],
         gate_type=GateType.BLOCKING,
         depends_on=["phase_4"],
     )
@@ -241,6 +261,7 @@ def research_phases() -> list[PhaseDefinition]:
             "Inference pipeline", "Model card", "Validation report",
             "Drift detection", "Test suite", "Research artifacts",
         ],
+        assigned_agents=["code-reviewer", "research-scout"],
         gate_type=GateType.AUTOMATED,
         depends_on=["phase_5"],
     )

--- a/src/zo/cli.py
+++ b/src/zo/cli.py
@@ -220,6 +220,40 @@ def _launch_and_monitor(
     console.print()
 
     _seen_events: set[str] = set()
+    _headline_buffer: list[str] = []
+    _last_headline_time: float = 0.0
+    _headline_interval = 60  # seconds between Haiku summaries
+
+    def _maybe_print_headline() -> None:
+        """Send buffered events to Haiku for a 1-line summary."""
+        import time as _time
+
+        nonlocal _last_headline_time
+        now = _time.monotonic()
+        if not _headline_buffer:
+            return
+        if now - _last_headline_time < _headline_interval:
+            return
+
+        events_text = "\n".join(_headline_buffer[-15:])
+        _headline_buffer.clear()
+        _last_headline_time = now
+
+        try:
+            result = __import__("subprocess").run(
+                ["claude", "-p", "--model", "haiku",
+                 f"Summarise these agent events in ONE short "
+                 f"headline (max 80 chars). No preamble, just "
+                 f"the headline:\n\n{events_text}"],
+                capture_output=True, text=True, timeout=15,
+            )
+            headline = result.stdout.strip().split("\n")[0][:80]
+            if headline:
+                console.print(
+                    f"  [{_AMBER}]▸ {headline}[/]"
+                )
+        except Exception:
+            pass  # Non-critical — skip if Haiku unavailable
 
     def _print_status(team_status, pane_snapshot=""):  # noqa: ANN001
         from datetime import UTC, datetime
@@ -286,23 +320,29 @@ def _launch_and_monitor(
                         console.print(
                             f"    [{_AMBER}]◆ DECISION[/] [{_DIM}]{agent}:[/] {title}"
                         )
+                        _headline_buffer.append(f"{agent} decided: {title}")
                     elif etype == "gate":
                         result = evt.get("result", "")
                         gphase = evt.get("phase_id", "")
                         console.print(
                             f"    [{_AMBER}]⊘ GATE[/] {gphase}: {result}"
                         )
+                        _headline_buffer.append(f"Gate {gphase}: {result}")
                     elif etype == "checkpoint":
                         progress = evt.get("progress", "")[:70]
                         console.print(f"    [{_DIM}]↳ {agent}: {progress}[/]")
+                        _headline_buffer.append(f"{agent}: {progress}")
                     elif etype == "error":
                         desc = evt.get("description", "")[:70]
                         console.print(
                             f"    [red]✗ ERROR[/] [{_DIM}]{agent}:[/] {desc}"
                         )
+                        _headline_buffer.append(f"ERROR {agent}: {desc}")
 
         if not tasks and not header_parts:
             console.print(f"  [{_DIM}][{elapsed}] Waiting for agents...[/]")
+
+        _maybe_print_headline()
         console.print()
 
     process = wrapper.wait_for_completion(process, on_status=_print_status)

--- a/src/zo/cli.py
+++ b/src/zo/cli.py
@@ -487,7 +487,13 @@ def init(project_name: str, scaffold_delivery: str | None) -> None:
     """
     _show_banner(project=project_name, mode="init")
 
-    zo_root = _zo_root()
+    zo_root = _main_repo_root()
+
+    # Resolve delivery repo path — absolute, deterministic
+    if scaffold_delivery is not None:
+        delivery_path = Path(scaffold_delivery).resolve()
+    else:
+        delivery_path = (zo_root.parent / f"{project_name}-delivery").resolve()
 
     # Initialize memory
     from zo.memory import MemoryManager
@@ -496,16 +502,22 @@ def init(project_name: str, scaffold_delivery: str | None) -> None:
     memory.initialize_project()
     console.print(f"[green]Memory initialized:[/] {memory.memory_root}")
 
-    # Create target template
+    # Create target file with absolute delivery path
     targets_dir = zo_root / "targets"
     targets_dir.mkdir(parents=True, exist_ok=True)
     target_path = targets_dir / f"{project_name}.target.md"
     if not target_path.exists():
         target_path.write_text(
-            _TARGET_TEMPLATE.format(project_name=project_name),
+            _TARGET_TEMPLATE.format(
+                project_name=project_name,
+                target_repo=str(delivery_path),
+            ),
             encoding="utf-8",
         )
-        console.print(f"[green]Target template created:[/] {target_path}")
+        console.print(f"[green]Target created:[/] {target_path}")
+        console.print(
+            f"  [{_DIM}]Delivery repo:[/] {delivery_path}"
+        )
     else:
         console.print(f"[{_DIM}]Target already exists:[/] {target_path}")
 
@@ -522,17 +534,29 @@ def init(project_name: str, scaffold_delivery: str | None) -> None:
     else:
         console.print(f"[{_DIM}]Plan already exists:[/] {plan_path}")
 
-    # Optional delivery repo scaffold
-    if scaffold_delivery is not None:
-        from zo.scaffold import scaffold_delivery as _scaffold
+    # Scaffold delivery repo
+    from zo.scaffold import scaffold_delivery as _scaffold
 
-        _scaffold(Path(scaffold_delivery), project_name)
+    if not delivery_path.exists():
+        _scaffold(delivery_path, project_name)
+        console.print(
+            f"[green]Delivery repo scaffolded:[/] {delivery_path}"
+        )
+    else:
+        console.print(
+            f"[{_DIM}]Delivery repo already exists:[/] "
+            f"{delivery_path}"
+        )
 
-    console.print(f"\n[{_AMBER}]Project '{project_name}' scaffolded.[/]")
+    console.print(f"\n[{_AMBER}]Project '{project_name}' ready.[/]")
     console.print("Next steps:")
-    console.print(f"  1. Edit [bold]{plan_path}[/]")
-    console.print(f"  2. Edit [bold]{target_path}[/]")
-    console.print(f"  3. Run [bold]zo build plans/{project_name}.md[/]")
+    console.print(
+        f"  1. Draft plan: [bold]zo draft --project "
+        f"{project_name}[/]"
+    )
+    console.print(
+        f"  2. Build: [bold]zo build plans/{project_name}.md[/]"
+    )
 
 
 @cli.command()
@@ -836,7 +860,7 @@ def draft(
 _TARGET_TEMPLATE = """\
 ---
 project: {project_name}
-target_repo: ../target-{project_name}
+target_repo: {target_repo}
 target_branch: main
 worktree_base: .worktrees
 git_author_name: ZO Agent

--- a/src/zo/cli.py
+++ b/src/zo/cli.py
@@ -196,6 +196,7 @@ def _launch_and_monitor(
     orchestrator,  # noqa: ANN001
     semantic,  # noqa: ANN001
     no_tmux: bool,
+    gate_mode_file: Path | None = None,
 ) -> None:
     """Shared launch → monitor → end-session flow for all modes."""
     use_tmux = not no_tmux
@@ -345,7 +346,9 @@ def _launch_and_monitor(
         _maybe_print_headline()
         console.print()
 
-    process = wrapper.wait_for_completion(process, on_status=_print_status)
+    process = wrapper.wait_for_completion(
+        process, on_status=_print_status, gate_mode_file=gate_mode_file,
+    )
 
     if process.status == "completed":
         console.print("[green bold]Session completed successfully.[/]")
@@ -433,6 +436,7 @@ def build(plan_path: Path, gate_mode: str, no_tmux: bool) -> None:
 
     # 6. Create Orchestrator
     gm = _gate_mode_from_str(gate_mode)
+    memory.write_gate_mode(gm.value)
     orchestrator = Orchestrator(
         plan=plan, target=target, memory=memory, comms=comms,
         semantic=semantic, zo_root=zo_root, gate_mode=gm,
@@ -473,6 +477,7 @@ def build(plan_path: Path, gate_mode: str, no_tmux: bool) -> None:
         orchestrator=orchestrator,
         semantic=semantic,
         no_tmux=no_tmux,
+        gate_mode_file=memory.memory_root / "gate_mode",
     )
 
 
@@ -642,6 +647,53 @@ def status(project_name: str) -> None:
         for s in recent:
             accomplished = ", ".join(s.accomplished[:3]) or "no summary"
             console.print(f"  {s.date} ({s.mode}): {accomplished}")
+
+
+@cli.group()
+def gates() -> None:
+    """Inspect and control gate modes for running projects."""
+
+
+@gates.command("set")
+@click.argument(
+    "mode",
+    type=click.Choice(["supervised", "auto", "full-auto"]),
+)
+@click.option(
+    "--project", "-p", required=True,
+    help="Project name whose gate mode to change.",
+)
+def gates_set(mode: str, project: str) -> None:
+    """Set the gate mode for a project mid-session.
+
+    Writes the mode to memory/{project}/gate_mode so that
+    the running orchestrator and wrapper pick it up dynamically.
+
+    Valid modes: supervised, auto, full-auto.
+
+    Usage::
+
+        zo gates set auto --project my-project
+        zo gates set full-auto -p my-project
+    """
+    from zo.memory import MemoryManager
+
+    zo_root = _zo_root()
+    memory = MemoryManager(project_dir=zo_root, project_name=project)
+
+    if not memory.memory_root.exists():
+        console.print(
+            f"[red bold]No memory found for '{project}'.[/] "
+            "Run [bold]zo init[/] or [bold]zo build[/] first."
+        )
+        raise SystemExit(1)
+
+    # Normalise CLI string to the GateMode enum value
+    gm = _gate_mode_from_str(mode)
+    memory.write_gate_mode(gm.value)
+
+    _show_banner(project=project, mode="gates", gate_mode=gm.value)
+    console.print(f"  Gate mode set to: [{_AMBER}]{gm.value}[/]")
 
 
 @cli.command()

--- a/src/zo/cli.py
+++ b/src/zo/cli.py
@@ -809,9 +809,16 @@ def draft(
         prompt_file.parent.mkdir(parents=True, exist_ok=True)
         prompt_file.write_text(draft_prompt, encoding="utf-8")
 
+        # Kill any existing draft window for this project (prevent orphans)
+        window_name = f"draft-{project}"
+        __import__("subprocess").run(
+            ["tmux", "kill-window", "-t", window_name],
+            capture_output=True, text=True, timeout=5,
+        )
+
         # Launch interactive claude session
         result = __import__("subprocess").run(
-            ["tmux", "new-window", "-d", "-n", f"draft-{project}",
+            ["tmux", "new-window", "-d", "-n", window_name,
              "-P", "-F", "#{pane_id}"],
             capture_output=True, text=True, timeout=10,
         )

--- a/src/zo/cli.py
+++ b/src/zo/cli.py
@@ -37,6 +37,31 @@ def _zo_root() -> Path:
     return Path(__file__).resolve().parent.parent.parent
 
 
+def _main_repo_root() -> Path:
+    """Return the main git repo root, even if running from a worktree.
+
+    ZO artifacts (plans, memory, state) should always live in the main
+    repo, not in worktrees. Worktrees are for ZO development.
+    """
+    import subprocess
+
+    zo_root = _zo_root()
+    try:
+        # git worktree list --porcelain: first line is the main repo
+        result = subprocess.run(
+            ["git", "worktree", "list", "--porcelain"],
+            capture_output=True, text=True, timeout=5, cwd=str(zo_root),
+        )
+        if result.returncode == 0:
+            for line in result.stdout.splitlines():
+                if line.startswith("worktree "):
+                    # First worktree entry is always the main repo
+                    return Path(line.split(" ", 1)[1])
+    except (subprocess.TimeoutExpired, FileNotFoundError):
+        pass
+    return zo_root
+
+
 def _gate_mode_from_str(value: str) -> GateMode:
     """Map CLI gate-mode string to GateMode enum."""
     mapping = {
@@ -616,8 +641,12 @@ def draft(
     from zo.draft import PlanDrafter
 
     zo_root = _zo_root()
+    main_root = _main_repo_root()
     desc = description or ""
     doc_context = ""
+
+    # Always write plans to main repo, not worktrees
+    plan_root = main_root if main_root != zo_root else zo_root
 
     if source_paths:
         # --- Branch A: source documents provided ---
@@ -627,10 +656,14 @@ def draft(
                 raise SystemExit(1)
 
         drafter = PlanDrafter(
-            source_paths=list(source_paths), project_name=project, zo_root=zo_root,
+            source_paths=list(source_paths), project_name=project,
+            zo_root=plan_root,
         )
 
-        console.print(f"[{_AMBER}]Indexing documents from {len(source_paths)} path(s):[/]")
+        console.print(
+            f"[{_AMBER}]Indexing documents from "
+            f"{len(source_paths)} path(s):[/]"
+        )
         for sp in source_paths:
             console.print(f"  [{_DIM}]{sp}[/]")
         count = drafter.index_documents()
@@ -651,10 +684,14 @@ def draft(
             console.print()
             desc = console.input(f"  [{_AMBER}]>[/] ").strip()
             if not desc:
-                console.print("[red bold]No description provided. Aborting.[/]")
+                console.print(
+                    "[red bold]No description provided. Aborting.[/]"
+                )
                 raise SystemExit(1)
 
-        drafter = PlanDrafter(project_name=project, zo_root=zo_root)
+        drafter = PlanDrafter(
+            project_name=project, zo_root=plan_root,
+        )
 
         console.print(f"\n[{_AMBER}]Drafting plan for:[/] {project}")
         console.print(f"  [{_DIM}]Description:[/] {desc}")
@@ -663,6 +700,10 @@ def draft(
         plan_path = drafter.generate_plan_from_description(desc)
 
     console.print(f"[green]Plan generated:[/] {plan_path}")
+    if plan_root != zo_root:
+        console.print(
+            f"  [{_DIM}]Written to main repo (not worktree)[/]"
+        )
 
     valid = drafter.validate_draft(plan_path)
     if valid:
@@ -696,22 +737,38 @@ def draft(
         elif desc:
             context_block = f"\n\nUser's project description: {desc}\n"
 
+        # Build path always references main repo for zo build
+        build_cmd = f"zo build plans/{project}.md"
+
         draft_prompt = (
-            f"You are drafting a plan.md for project '{project}' at {plan_path}.\n"
+            f"You are drafting a plan.md for project '{project}' "
+            f"at {plan_path}.\n"
             f"{context_block}\n"
-            f"A skeleton plan already exists at that path. Read it, then work with "
-            f"the user conversationally to complete it:\n\n"
-            f"1. Review what's there and summarise what you understand\n"
-            f"2. Ask about the objective — what exactly are we building?\n"
-            f"3. Ask about data sources — where does the data come from?\n"
-            f"4. Ask about oracle metrics — how do we measure success?\n"
-            f"5. Ask about constraints — time, compute, regulatory limits?\n"
+            f"A skeleton plan already exists at that path. Read it, "
+            f"then work with the user conversationally to complete "
+            f"it:\n\n"
+            f"1. Review what's there and summarise what you "
+            f"understand\n"
+            f"2. Ask about the objective — what exactly are we "
+            f"building?\n"
+            f"3. Ask about data sources — where does the data come "
+            f"from?\n"
+            f"4. Ask about oracle metrics — how do we measure "
+            f"success?\n"
+            f"5. Ask about constraints — time, compute, regulatory "
+            f"limits?\n"
             f"6. Fill in each section as you get answers\n"
-            f"7. Validate the final plan against specs/plan.md schema\n\n"
+            f"7. Validate the final plan against specs/plan.md "
+            f"schema\n\n"
             f"Write the completed plan to {plan_path}. "
-            f"The plan schema is defined in specs/plan.md — ensure compliance.\n"
-            f"After the plan is complete, tell the user to run: "
-            f"zo build {plan_path}"
+            f"The plan schema is defined in specs/plan.md — ensure "
+            f"compliance.\n\n"
+            f"When the plan is complete:\n"
+            f"- Ask the user: 'Is there anything else you'd like to "
+            f"adjust? If not, this session is done — run "
+            f"`{build_cmd}` to start building.'\n"
+            f"- Once confirmed, say goodbye and tell them to type "
+            f"/exit to close this session.\n"
         )
 
         prompt_file = zo_root / "logs" / "wrapper" / f"zo-draft-{project}-prompt.txt"

--- a/src/zo/cli.py
+++ b/src/zo/cli.py
@@ -449,6 +449,8 @@ def continue_(project_name: str, gate_mode: str, no_tmux: bool) -> None:
 
     Finds plans/{project_name}.md and runs zo build on it.
     """
+    _show_banner(project=project_name, mode="continue")
+
     zo_root = _zo_root()
     plan_path = zo_root / "plans" / f"{project_name}.md"
     if not plan_path.exists():
@@ -483,6 +485,8 @@ def init(project_name: str, scaffold_delivery: str | None) -> None:
     With --scaffold-delivery PATH, also creates a delivery repo layout
     with data/, src/, Docker files, and a bare pyproject.toml.
     """
+    _show_banner(project=project_name, mode="init")
+
     zo_root = _zo_root()
 
     # Initialize memory
@@ -535,6 +539,8 @@ def init(project_name: str, scaffold_delivery: str | None) -> None:
 @click.argument("project_name")
 def status(project_name: str) -> None:
     """Show current project status from STATE.md."""
+    _show_banner(project=project_name, mode="status")
+
     from zo.memory import MemoryManager
 
     zo_root = _zo_root()
@@ -586,6 +592,8 @@ def preflight(plan_file: Path, target_repo: Path | None) -> None:
     Runs local-only checks: CLI availability, plan validation, agent
     definitions, memory round-trip, Docker, and GPU availability.
     """
+    _show_banner(mode="preflight")
+
     from zo.preflight import run_preflight
 
     zo_root = _zo_root()
@@ -639,6 +647,8 @@ def draft(
         zo draft --project my-project
     """
     from zo.draft import PlanDrafter
+
+    _show_banner(project=project, mode="draft")
 
     zo_root = _zo_root()
     main_root = _main_repo_root()

--- a/src/zo/memory.py
+++ b/src/zo/memory.py
@@ -277,6 +277,33 @@ class MemoryManager:
             pass
         return None
 
+    # -- Gate mode file -------------------------------------------------------
+
+    def read_gate_mode(self) -> str | None:
+        """Read the current gate mode from the ``gate_mode`` file.
+
+        Returns:
+            The mode string (e.g. ``"supervised"``, ``"auto"``,
+            ``"full_auto"``) or ``None`` if the file does not exist.
+        """
+        path = self._memory_root / "gate_mode"
+        if not path.exists():
+            return None
+        try:
+            return path.read_text(encoding="utf-8").strip()
+        except OSError:
+            return None
+
+    def write_gate_mode(self, mode: str) -> None:
+        """Write the gate mode to the ``gate_mode`` file.
+
+        Args:
+            mode: One of ``"supervised"``, ``"auto"``, ``"full_auto"``.
+        """
+        self._memory_root.mkdir(parents=True, exist_ok=True)
+        path = self._memory_root / "gate_mode"
+        path.write_text(mode + "\n", encoding="utf-8")
+
     # -- Project initialization ---------------------------------------------
 
     def initialize_project(self) -> None:

--- a/src/zo/orchestrator.py
+++ b/src/zo/orchestrator.py
@@ -313,6 +313,29 @@ class Orchestrator:
                 return phase
         return None
 
+    def _refresh_gate_mode(self) -> None:
+        """Re-read the gate mode from the file system if it exists.
+
+        This allows ``zo gates set`` to change the mode mid-session
+        from a separate terminal.  Falls back to the configured mode
+        if the file is missing or contains an invalid value.
+        """
+        raw = self._memory.read_gate_mode()
+        if raw is None:
+            return
+        try:
+            new_mode = GateMode(raw)
+        except ValueError:
+            return
+        if new_mode != self._gate_mode:
+            self._comms.log_decision(
+                agent="orchestrator",
+                title=f"Gate mode changed: {self._gate_mode} -> {new_mode}",
+                rationale="Detected gate_mode file update (zo gates set).",
+                outcome=new_mode,
+            )
+            self._gate_mode = new_mode
+
     def advance_phase(self, phase_id: str) -> GateEvaluation:
         """Evaluate the gate for a phase and advance if criteria are met.
 
@@ -325,6 +348,7 @@ class Orchestrator:
         * **full_auto** — no human gates at all; all gates are treated as
           automated and ZO runs to completion autonomously.
         """
+        self._refresh_gate_mode()
         phase = self._find_phase(phase_id)
         all_done = set(phase.subtasks) == set(phase.completed_subtasks)
 

--- a/src/zo/wrapper.py
+++ b/src/zo/wrapper.py
@@ -307,18 +307,48 @@ class LifecycleWrapper:
         poll_interval: float = 10.0,
         timeout: float | None = None,
         on_status: Any | None = None,
+        gate_mode_file: Path | None = None,
     ) -> LeadProcess:
         """Poll until the lead session completes.
 
         In tmux mode, monitors the pane existence. In headless mode,
         polls the subprocess. Calls ``on_status(team_status)`` each
         cycle if provided, so the CLI can print live progress.
+
+        Args:
+            gate_mode_file: Optional path to the ``gate_mode`` file.
+                When provided, the wrapper re-reads the file each poll
+                cycle and logs when the mode changes (set via
+                ``zo gates set`` from another terminal).
         """
+        self._gate_mode_file = gate_mode_file
+        self._last_gate_mode: str | None = None
         if process.tmux_pane_id:
             return self._wait_tmux(process, poll_interval=poll_interval,
                                    timeout=timeout, on_status=on_status)
         return self._wait_headless(process, poll_interval=poll_interval,
                                    timeout=timeout, on_status=on_status)
+
+    def _check_gate_mode_change(self) -> None:
+        """Re-read the gate_mode file and log if the mode changed."""
+        gate_file = getattr(self, "_gate_mode_file", None)
+        if gate_file is None or not gate_file.exists():
+            return
+        try:
+            current = gate_file.read_text(encoding="utf-8").strip()
+        except OSError:
+            return
+        last = getattr(self, "_last_gate_mode", None)
+        if last is None:
+            self._last_gate_mode = current
+            return
+        if current != last:
+            self._comms.log_checkpoint(
+                agent="wrapper", phase="lifecycle",
+                subtask="gate-mode-change",
+                progress=f"Gate mode changed: {last} -> {current}",
+            )
+            self._last_gate_mode = current
 
     def _wait_tmux(
         self,
@@ -333,6 +363,8 @@ class LifecycleWrapper:
         process = process.model_copy(update={"status": AgentStatus.RUNNING})
 
         while True:
+            self._check_gate_mode_change()
+
             if not self._tmux_pane_alive(process.tmux_pane_id or ""):
                 process = process.model_copy(update={
                     "exit_code": 0, "completed_at": datetime.now(UTC),
@@ -374,6 +406,8 @@ class LifecycleWrapper:
         process = process.model_copy(update={"status": AgentStatus.RUNNING})
 
         while True:
+            self._check_gate_mode_change()
+
             rc = self._proc.poll() if self._proc else -1
             if rc is not None:
                 self._close_log_handles()

--- a/tests/unit/test_cli.py
+++ b/tests/unit/test_cli.py
@@ -54,7 +54,8 @@ class TestInitCommand:
     def test_init_creates_directory_structure(
         self, runner: click.testing.CliRunner, tmp_path: Path
     ) -> None:
-        with patch("zo.cli._zo_root", return_value=tmp_path):
+        with patch("zo.cli._zo_root", return_value=tmp_path), \
+             patch("zo.cli._main_repo_root", return_value=tmp_path):
             result = runner.invoke(cli, ["init", "test-project"])
 
         assert result.exit_code == 0
@@ -90,7 +91,8 @@ class TestInitCommand:
     def test_init_idempotent(
         self, runner: click.testing.CliRunner, tmp_path: Path
     ) -> None:
-        with patch("zo.cli._zo_root", return_value=tmp_path):
+        with patch("zo.cli._zo_root", return_value=tmp_path), \
+             patch("zo.cli._main_repo_root", return_value=tmp_path):
             result1 = runner.invoke(cli, ["init", "test-project"])
             result2 = runner.invoke(cli, ["init", "test-project"])
 
@@ -104,7 +106,8 @@ class TestInitCommand:
         zo_root = tmp_path / "zo"
         delivery = tmp_path / "delivery"
 
-        with patch("zo.cli._zo_root", return_value=zo_root):
+        with patch("zo.cli._zo_root", return_value=zo_root), \
+             patch("zo.cli._main_repo_root", return_value=zo_root):
             result = runner.invoke(
                 cli,
                 ["init", "my-ml", "--scaffold-delivery", str(delivery)],
@@ -171,7 +174,8 @@ class TestInitCommand:
         # Pre-create a file that should NOT be overwritten
         (delivery / "README.md").write_text("custom content", encoding="utf-8")
 
-        with patch("zo.cli._zo_root", return_value=zo_root):
+        with patch("zo.cli._zo_root", return_value=zo_root), \
+             patch("zo.cli._main_repo_root", return_value=zo_root):
             result = runner.invoke(
                 cli,
                 ["init", "my-ml", "--scaffold-delivery", str(delivery)],
@@ -179,13 +183,14 @@ class TestInitCommand:
 
         assert result.exit_code == 0
         assert (delivery / "README.md").read_text() == "custom content"
-        assert "Already exists" in result.output
+        assert "already exists" in result.output.lower()
 
     def test_init_without_scaffold_still_works(
         self, runner: click.testing.CliRunner, tmp_path: Path
     ) -> None:
         """Ensure the flag is optional and init works without it."""
-        with patch("zo.cli._zo_root", return_value=tmp_path):
+        with patch("zo.cli._zo_root", return_value=tmp_path), \
+             patch("zo.cli._main_repo_root", return_value=tmp_path):
             result = runner.invoke(cli, ["init", "plain-project"])
 
         assert result.exit_code == 0

--- a/tests/unit/test_cli.py
+++ b/tests/unit/test_cli.py
@@ -399,7 +399,8 @@ class TestDraftCommand:
 
         with patch("zo.cli._zo_root", return_value=zo_root):
             result = runner.invoke(
-                cli, ["draft", str(source_dir), "--project", "test-draft"]
+                cli, ["draft", str(source_dir), "--project", "test-draft",
+                      "--no-tmux"]
             )
 
         assert result.exit_code == 0
@@ -417,7 +418,8 @@ class TestDraftCommand:
             result = runner.invoke(
                 cli,
                 ["draft", "--project", "test-desc", "-d",
-                 "CIFAR-10 image classification with PyTorch CNN, target 90% accuracy"],
+                 "CIFAR-10 image classification with PyTorch CNN, target 90% accuracy",
+                 "--no-tmux"],
             )
 
         assert result.exit_code == 0

--- a/tests/unit/test_cli.py
+++ b/tests/unit/test_cli.py
@@ -25,7 +25,7 @@ class TestCliGroup:
     """Tests for the CLI group and its registered commands."""
 
     def test_cli_group_has_all_commands(self) -> None:
-        expected = {"build", "continue", "init", "status", "draft", "preflight"}
+        expected = {"build", "continue", "init", "status", "draft", "preflight", "gates"}
         actual = set(cli.commands.keys())
         assert expected == actual
 
@@ -489,3 +489,87 @@ class TestGateModeMapping:
 
         with pytest.raises(KeyError):
             _gate_mode_from_str("invalid")
+
+
+# ---------------------------------------------------------------------------
+# gates set command
+# ---------------------------------------------------------------------------
+
+
+class TestGatesSetCommand:
+    """Tests for the ``zo gates set`` command."""
+
+    def test_gates_set_writes_mode_file(
+        self, runner: click.testing.CliRunner, tmp_path: Path
+    ) -> None:
+        # Set up minimal memory directory
+        mem_root = tmp_path / "memory" / "test-project"
+        mem_root.mkdir(parents=True)
+
+        with patch("zo.cli._zo_root", return_value=tmp_path):
+            result = runner.invoke(
+                cli, ["gates", "set", "auto", "--project", "test-project"]
+            )
+
+        assert result.exit_code == 0
+        assert "Gate mode set to" in result.output
+
+        gate_file = mem_root / "gate_mode"
+        assert gate_file.exists()
+        assert gate_file.read_text().strip() == "auto"
+
+    def test_gates_set_full_auto(
+        self, runner: click.testing.CliRunner, tmp_path: Path
+    ) -> None:
+        mem_root = tmp_path / "memory" / "test-project"
+        mem_root.mkdir(parents=True)
+
+        with patch("zo.cli._zo_root", return_value=tmp_path):
+            result = runner.invoke(
+                cli, ["gates", "set", "full-auto", "--project", "test-project"]
+            )
+
+        assert result.exit_code == 0
+        gate_file = mem_root / "gate_mode"
+        assert gate_file.read_text().strip() == "full_auto"
+
+    def test_gates_set_supervised(
+        self, runner: click.testing.CliRunner, tmp_path: Path
+    ) -> None:
+        mem_root = tmp_path / "memory" / "test-project"
+        mem_root.mkdir(parents=True)
+
+        with patch("zo.cli._zo_root", return_value=tmp_path):
+            result = runner.invoke(
+                cli, ["gates", "set", "supervised", "--project", "test-project"]
+            )
+
+        assert result.exit_code == 0
+        gate_file = mem_root / "gate_mode"
+        assert gate_file.read_text().strip() == "supervised"
+
+    def test_gates_set_invalid_mode(
+        self, runner: click.testing.CliRunner
+    ) -> None:
+        result = runner.invoke(
+            cli, ["gates", "set", "yolo", "--project", "test-project"]
+        )
+        assert result.exit_code != 0
+        assert "Invalid value" in result.output
+
+    def test_gates_set_missing_project(
+        self, runner: click.testing.CliRunner, tmp_path: Path
+    ) -> None:
+        with patch("zo.cli._zo_root", return_value=tmp_path):
+            result = runner.invoke(
+                cli, ["gates", "set", "auto", "--project", "nonexistent"]
+            )
+
+        assert result.exit_code == 1
+        assert "No memory found" in result.output
+
+    def test_gates_set_requires_project_option(
+        self, runner: click.testing.CliRunner
+    ) -> None:
+        result = runner.invoke(cli, ["gates", "set", "auto"])
+        assert result.exit_code != 0


### PR DESCRIPTION
## Summary

**Worktree-aware draft (commit 1):**
- Plans always write to main repo via `_main_repo_root()` helper
- Draft session prompt instructs Claude to wrap up and tell user to `/exit`

**Brand panel on all commands (commit 2):**
- Shared `_show_banner()` called by build, draft, init, status, preflight, continue
- Shows project/mode/phase/gates contextually per command

**Production-grade Phase 1 (commit 2):**
- 6 new subtasks: schema validation, missing value analysis, outlier detection, class imbalance, split strategy, drift baseline (13 total)
- 3 new agents: research-scout, code-reviewer, domain-evaluator

**Cross-cutting agents on ALL phases (commit 2):**
- `code-reviewer` + `research-scout` now default in every phase across all 3 workflow modes

## Test plan
- [x] 341 tests pass, ruff clean, validate-docs 9/9

🤖 Generated with [Claude Code](https://claude.com/claude-code)