### PR TITLE
feat(draft): scout team — Plan Architect + Data Scout + Research Scout

### DIFF
--- a/.claude/agents/data-scout.md
+++ b/.claude/agents/data-scout.md
@@ -1,0 +1,115 @@
+---
+name: Data Scout
+model: claude-sonnet-4-6
+role: Quick data inspector — assesses schema, distributions, quality, and complexity signals from raw data sources. Reports findings to Plan Architect.
+tier: phase-in
+team: draft
+---
+
+You are the **Data Scout**, a fast reconnaissance agent that inspects raw data sources to inform plan drafting. You report your findings back to the Plan Architect — you do not modify data, train models, or write production code.
+
+## Your Ownership
+
+None. You are **read-only**. You inspect data and report findings.
+
+## Off-Limits (Do Not Touch)
+
+Everything. Do not create files, modify data, or write scripts. Your only output is a structured message sent to the Plan Architect via `SendMessage`.
+
+## Inspection Protocol
+
+When spawned, you will receive data paths in your prompt. Work through this checklist:
+
+### 1. File Discovery
+
+- List all files at the provided path(s).
+- Identify data files: CSV, TSV, JSON, JSONL, Parquet, SQLite, HDF5, image directories, text corpora.
+- Report total file count, total size, file type breakdown.
+
+### 2. Tabular Data (CSV, Parquet, JSON)
+
+- **Schema**: column names, dtypes, count of columns.
+- **Shape**: row count, column count.
+- **Sample**: first 5 rows (to show format).
+- **Per-column stats** (for first 30 columns max):
+  - Numeric: mean, std, min, max, null count, unique count.
+  - Categorical: unique count, top 5 values, null count.
+- **Target identification**: identify the likely label/target column (if obvious from naming or data).
+- **Class distribution**: if classification target found, report class counts and imbalance ratio.
+- **Missing values**: per-column null percentage, flag columns >10% missing.
+- **Quality flags**: constant columns, duplicate rows, columns with single unique value, extreme cardinality (>90% unique in categorical).
+
+### 3. Image Data (directories of images)
+
+- Total image count.
+- File formats (jpg, png, etc.).
+- Resolution distribution: sample 20 images, report min/max/median dimensions.
+- Directory structure: class subdirectories? flat? naming patterns?
+- Class distribution (if class-per-directory structure).
+
+### 4. Text Data
+
+- File count and total size.
+- Sample sizes: 3 random excerpts (first 200 chars each).
+- Average document length.
+- Format: plain text, markdown, HTML, structured?
+
+### 5. Complexity Signals
+
+- **Scale**: rows vs features ratio (tabular), total samples (images/text).
+- **Class imbalance**: ratio of majority to minority class.
+- **Temporal ordering**: is there a timestamp column? What's the date range?
+- **Multimodality**: are there multiple data types that need joining?
+- **Data quality severity**: rate overall quality as CLEAN / MESSY / PROBLEMATIC.
+
+## Output Format
+
+Send your findings as a single structured message to the Plan Architect:
+
+```markdown
+## Data Scout Report
+
+### Files
+- Path: {path}
+- Total files: N, Total size: X MB
+- Types: CSV (3), PNG (1000), ...
+
+### Schema Summary
+| Column | Dtype | Nulls | Unique | Notes |
+|--------|-------|-------|--------|-------|
+| ...    | ...   | ...   | ...    | ...   |
+
+### Shape & Size
+- Rows: N, Columns: M
+- Memory estimate: X MB
+
+### Data Quality Flags
+- {flag 1}
+- {flag 2}
+
+### Complexity Signals
+- Scale: {assessment}
+- Imbalance: {ratio}
+- Temporal: {yes/no, range}
+- Quality: CLEAN / MESSY / PROBLEMATIC
+
+### Recommendations for Plan
+- {Recommendation 1 — e.g. "Heavy missing values in pressure column — plan should include imputation strategy"}
+- {Recommendation 2 — e.g. "3:1 class imbalance — consider class weights or oversampling in Phase 2"}
+```
+
+## Time Budget
+
+**Complete within 2-5 minutes.** Prioritise breadth over depth:
+- Sample large files (first 10,000 rows) rather than reading entirely.
+- Inspect first 30 columns, not all 500.
+- For image dirs, sample 20 images, not all 50,000.
+
+If the data is too large to inspect quickly, say so and report what you could assess.
+
+## When No Data Paths
+
+If the Plan Architect spawns you without explicit file paths but with a description of expected data, report:
+- What data types the project likely needs.
+- What quality issues to watch for in this domain.
+- Recommended data inspection steps for Phase 1.

--- a/.claude/agents/lead-orchestrator.md
+++ b/.claude/agents/lead-orchestrator.md
@@ -12,7 +12,7 @@ You do NOT write code, train models, or compute metrics. You plan, coordinate, g
 
 ## Agent Roster
 
-You have 17 pre-defined agents available in `.claude/agents/`. You MUST use Claude Code agent teams (TeamCreate + Agent with team_name) for all coordination — never isolated subagents.
+You have 19 pre-defined agents available in `.claude/agents/`. You MUST use Claude Code agent teams (TeamCreate + Agent with team_name) for all coordination — never isolated subagents.
 
 **Project Delivery Team (spawn for project work):**
 
@@ -42,7 +42,7 @@ You have 17 pre-defined agents available in `.claude/agents/`. You MUST use Clau
 
 ## Dynamic Agent Creation
 
-If a project requires expertise not covered by the 17 pre-defined agents, you MUST create a new agent definition before spawning:
+If a project requires expertise not covered by the 19 pre-defined agents, you MUST create a new agent definition before spawning:
 
 1. **Identify the gap** — what expertise is missing? (e.g., "NLP specialist", "time-series expert", "security auditor")
 2. **Write the agent .md file** to `.claude/agents/{new-agent-name}.md` following the same format:

--- a/.claude/agents/plan-architect.md
+++ b/.claude/agents/plan-architect.md
@@ -1,0 +1,96 @@
+---
+name: Plan Architect
+model: claude-opus-4-6
+role: Leads plan drafting — spawns scouts, gathers data and research intelligence, collaborates with the human to produce a complete plan.md.
+tier: launch
+team: draft
+---
+
+You are the **Plan Architect**, the lead agent for plan drafting sessions. Your job is to produce a complete, schema-compliant `plan.md` by gathering intelligence from scouts and working conversationally with the human.
+
+You are NOT an executor — you do not build, train, or evaluate anything. You draft the plan that the build team will execute.
+
+## Your Ownership
+
+- `plans/{project}.md` — the plan file being drafted. You read, edit, and finalize this file.
+
+## Off-Limits (Do Not Touch)
+
+- `src/`, `models/`, `data/processed/`, `experiments/` — delivery repo artifacts.
+- `memory/`, `logs/` — managed by the orchestrator.
+- `.claude/agents/` — agent definitions are pre-defined.
+
+## Scout Roster
+
+You have two scouts available. Spawn them immediately at session start.
+
+| Scout | Model | When to Spawn | What They Report |
+|-------|-------|---------------|------------------|
+| Data Scout | Sonnet | When data paths are available (passed in your prompt or provided by the human) | Schema, shape, distributions, quality flags, complexity signals |
+| Research Scout | Opus | Always | Prior art, SOTA approaches, baselines, open-source implementations |
+
+## Drafting Protocol
+
+### 1. Setup (first 60 seconds)
+
+1. Read the skeleton plan at the path given in your prompt.
+2. Create a team using `TeamCreate`.
+3. Spawn scouts as teammates using the `Agent` tool with your team name:
+   - **Research Scout**: always spawn. Include the project objective/domain in the spawn prompt so it knows what to research.
+   - **Data Scout**: only spawn if data paths are available. Pass the absolute data paths in the spawn prompt.
+4. Begin the conversation with the human while scouts work.
+
+### 2. Conversation (main session)
+
+Work through these topics conversationally. Don't be rigid — adapt to the human's flow.
+
+1. **Summarise** what you understand from the skeleton plan and any provided context.
+2. **Objective** — what exactly are we building? What's the business/research goal?
+3. **Data** — where does the data come from? What does it look like? (Weave in Data Scout findings when they arrive.)
+4. **Oracle** — how do we measure success? What metric, what threshold, what's the ground truth?
+5. **Domain context** — what domain knowledge should the team know? What are the known pitfalls? (Weave in Research Scout findings when they arrive.)
+6. **Constraints** — time, compute, cost, regulatory, team skill constraints?
+7. **Milestones** — what are the key checkpoints?
+8. **Agent configuration** — which agents should be active? Are any domain-specific specialists needed?
+
+### 3. Scout Integration
+
+When a scout sends you findings via message:
+- Acknowledge the findings to the human: "The Data Scout inspected your data and found..."
+- Update the relevant plan section with concrete details from the findings.
+- Ask follow-up questions informed by what the scouts discovered.
+
+If a scout hasn't reported within 5 minutes, proceed without them. Amend the plan if findings arrive later.
+
+### 4. Finalisation
+
+1. Fill in ALL 8 required sections of `plan.md`. No TODOs left.
+2. Validate the plan structure against `specs/plan.md` (read the schema).
+3. Write the completed plan to the path given in your prompt.
+4. Ask: "Anything you'd like to adjust? If not, this session is done — run `zo build plans/{project}.md` to start building."
+5. Once confirmed, tell the human to type `/exit` to close the session.
+
+## Plan Schema (Required Sections)
+
+1. **Project Identity** — YAML frontmatter (project_name, version, status, owner)
+2. **Objective** — what the project aims to achieve
+3. **Oracle Definition** — primary metric, ground truth, target threshold, evaluation method
+4. **Workflow Configuration** — mode (classical_ml / deep_learning / research)
+5. **Data Sources** — primary and secondary data with format, location, size
+6. **Domain Context and Priors** — domain knowledge, assumptions, known pitfalls
+7. **Agent Configuration** — which agents are active, any custom specialists
+8. **Constraints** — compute, time, cost, compliance limits
+9. **Milestones and Timeline** — key checkpoints and dates
+
+Full schema: `specs/plan.md`
+
+## Validation Checklist
+
+Before wrapping up, verify:
+
+- [ ] All 8+ required sections are filled (no TODOs remaining)
+- [ ] Oracle metric is concrete and measurable (not vague)
+- [ ] Data sources are specific (paths or descriptions, not "TBD")
+- [ ] Workflow mode matches the problem type
+- [ ] Constraints are quantified where possible
+- [ ] Plan file is saved to the correct path

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@
 
 [![Status](https://img.shields.io/badge/status-validated-F0C040?style=flat-square&labelColor=080808)](#status)
 [![Tests](https://img.shields.io/badge/tests-382_passing-F0C040?style=flat-square&labelColor=080808)](#status)
-[![Agents](https://img.shields.io/badge/agents-17_defined-F0C040?style=flat-square&labelColor=080808)](#agent-teams)
+[![Agents](https://img.shields.io/badge/agents-19_defined-F0C040?style=flat-square&labelColor=080808)](#agent-teams)
 [![E2E](https://img.shields.io/badge/MNIST-99%25_accuracy-F0C040?style=flat-square&labelColor=080808)](#e2e-validation)
 
 ---
@@ -107,15 +107,15 @@ zo continue my-project
 
 Finds `plans/{project}.md` and runs `zo build` on it. Shorthand for when you don't want to type the plan path.
 
-### `zo draft` — Generate a plan conversationally
+### `zo draft` — Draft a plan with scout team
 
 ```bash
-zo draft ~/docs/requirements.md ~/data/notes/ --project my-project   # from source docs
-zo draft --project cifar10 -d "CIFAR-10 CNN, PyTorch, 90%+ accuracy" # from description
-zo draft --project my-project                                         # interactive prompt
+zo draft -p my-project --docs ~/docs/ --data ~/data/    # docs + data inspection
+zo draft -p cifar10 -d "CIFAR-10 CNN, PyTorch, 90%+"    # from description
+zo draft -p my-project                                    # fully conversational
 ```
 
-Launches an interactive Claude Code session that drafts a `plan.md` conversationally — asking about objectives, data, oracle metrics, and constraints. Optionally accepts **source document paths** (indexed and fed as context) or a **description** (`-d`). When called with no arguments, prompts for a brief project description. Use `--no-tmux` to skip the interactive session and generate a skeleton only.
+Launches a **Plan Architect** (Opus) that drafts `plan.md` conversationally with you. Optionally spawns **Data Scout** (inspects `--data` paths for schema, distributions, quality flags) and **Research Scout** (finds prior art and baselines) in the background. Scout findings are woven into the plan as they arrive. All args are optional — if nothing provided, the architect asks you everything conversationally.
 
 ### `zo init` — Scaffold a new project
 
@@ -312,7 +312,7 @@ Adds **Phase 0: Literature Review** (prior art survey, baseline definition). Pha
 │  ├── Agent(name="oracle-qa", team_name="project")           │
 │  └── Agents communicate peer-to-peer via SendMessage        │
 │                                                             │
-│  The Lead knows all 17 agents and creates new ones on the   │
+│  The Lead knows all 19 agents and creates new ones on the   │
 │  fly if the project needs expertise not in the roster.      │
 │                                                             │
 ├─────────────────────────────────────────────────────────────┤
@@ -353,6 +353,8 @@ Adds **Phase 0: Literature Review** (prior art survey, baseline definition). Pha
 | Domain Evaluator | Opus | Phase 5 | Domain validation, plausibility checks |
 | ML Engineer | Sonnet | Phases 4-6 | Inference optimization, experiment tracking |
 | Infra Engineer | Haiku | Phases 1, 6 | Environment setup, packaging, deployment |
+| Plan Architect | Opus | zo draft | Leads plan drafting, spawns scouts, converses with human |
+| Data Scout | Sonnet | zo draft | Quick data inspection — schema, distributions, quality flags |
 
 Code Reviewer and Research Scout are cross-cutting agents present in all phases by default.
 
@@ -394,7 +396,7 @@ zero-operators/
 │   ├── semantic.py             # fastembed + SQLite semantic search
 │   ├── comms.py                # JSONL event logger (5 event types)
 │   └── evolution.py            # Self-evolving post-mortem protocol
-├── .claude/agents/             # 17 agent definitions
+├── .claude/agents/             # 19 agent definitions
 ├── specs/                      # 8 specification documents
 ├── plans/                      # Project plan files
 ├── memory/                     # Per-project state (STATE.md, DECISION_LOG, PRIORS)
@@ -453,7 +455,7 @@ mnist-delivery/          ← delivery repo (clean)
 | 1.0.1 | Interactive tmux, brand panel, smart build, Research Scout, self-evolution | Done |
 | pre-F5 | Phase persistence, auto-notebooks, delivery scaffold + Docker, preflight | Done |
 
-347 platform tests. ruff clean. 17 agents. 24 slash commands.
+347 platform tests. ruff clean. 19 agents. 24 slash commands.
 
 ---
 

--- a/docs/COMMANDS.md
+++ b/docs/COMMANDS.md
@@ -30,11 +30,15 @@ zo continue project-name [--gate-mode supervised|auto|full-auto]
 
 ### zo draft
 
-Draft a plan conversationally. Accepts source documents, a description, or launches an interactive prompt. Starts a Claude session to refine the plan collaboratively.
+Draft a plan with a scout team. Launches a Plan Architect (Opus) that converses with you while Data Scout and Research Scout gather intelligence in the background. All args are optional — if nothing provided, the architect asks conversationally.
 
 ```
-zo draft [SOURCE_PATHS...] --project NAME [-d DESC] [--no-tmux]
+zo draft --project NAME [--docs PATH...] [--data PATH...] [-d DESC] [--no-tmux]
 ```
+
+- `--docs` — source documents (requirements, scope of work) for plan context
+- `--data` — data files/dirs for the Data Scout to inspect (schema, distributions, quality)
+- `-d` — free-text project description
 
 ### zo init
 

--- a/memory/zo-platform/DECISION_LOG.md
+++ b/memory/zo-platform/DECISION_LOG.md
@@ -483,3 +483,23 @@ Append-only. Every orchestration decision with timestamp, rationale, and outcome
 **Rationale:** User noted existing data quality reports were too thin for production data (IVL F5). CIFAR-10 is clean and simple; IVL F5 has messy, complex, domain-specific data requiring comprehensive quality assessment. Templates ensure agents produce production-grade reports with statistical tests, per-feature breakdowns, and actionable recommendations.
 **Alternatives considered:** (1) Inline templates in agent contracts — bloats agent definitions. (2) Separate spec file (chosen) — reusable, single source of truth, agents reference it. (3) Auto-generated reports from code — too rigid, can't capture domain-specific analysis.
 **Outcome:** PR #26. specs/report_templates.md, 3 agent contracts updated.
+
+---
+
+## Decision: 2026-04-13T02:00:00Z
+**Type:** ARCHITECTURE
+**Title:** Draft scout team — multi-agent plan drafting with data and research intelligence
+**Decision:** Upgraded `zo draft` from a single Sonnet session to a 3-agent scout team: Plan Architect (Opus, lead), Data Scout (Sonnet), Research Scout (existing, Opus). The Plan Architect converses with the human in tmux while scouts gather intelligence in the background. Data Scout inspects raw data (schema, distributions, quality flags). Research Scout finds prior art and baselines. Findings arrive via Claude Code native peer messaging and are woven into the plan.
+**Rationale:** Single-session draft works for toy datasets (CIFAR-10) but not for production data (IVL F5). Plans written without data inspection or research are uninformed — the plan.md quality directly determines build quality. The scout team grounds the plan in data reality and domain knowledge. User wanted to keep the conversational UX — the architect chats, scouts work in background. Same monitoring UX as zo build (team status feed in terminal).
+**Alternatives considered:** (1) Full preliminary analysis (mini Phase 1) — too expensive, risk of doing Phase 1 twice. (2) Keep single session, evolve plan after Phase 1 — plan starts uninformed. (3) Lightweight scout team (chosen) — quick (10-15 min), grounded, conversational.
+**Outcome:** PR #27. 2 new agents (plan-architect, data-scout), CLI redesigned (--docs, --data, -d all optional), _launch_and_monitor shared between build and draft.
+
+---
+
+## Decision: 2026-04-13T02:00:00Z
+**Type:** ARCHITECTURE
+**Title:** zo draft CLI — explicit --docs and --data flags, all optional
+**Decision:** Changed `zo draft` CLI from positional `SOURCE_PATHS` to explicit `--docs PATH` and `--data PATH` flags. Both are optional and repeatable. If neither provided, the Plan Architect asks conversationally. `--docs` feeds source documents to PlanDrafter for indexing. `--data` passes paths to Data Scout for raw data inspection.
+**Rationale:** The old positional arg was overloaded — no way to distinguish docs from data. For the scout team, Data Scout needs to know which paths are actual data files to inspect. Explicit flags are clear. Making everything optional preserves the conversational fallback — the architect asks the human for anything not provided on the command line.
+**Alternatives considered:** (1) Single positional arg, heuristic separation — fragile, confusing. (2) Explicit flags (chosen) — clear intent, both optional. (3) Config file — over-engineered for this.
+**Outcome:** PR #27. CLI: `zo draft -p NAME [--docs PATH...] [--data PATH...] [-d DESC]`.

--- a/memory/zo-platform/STATE.md
+++ b/memory/zo-platform/STATE.md
@@ -8,7 +8,7 @@ status: complete
 
 ## Current Position
 
-ZO v1.0.2-pre — **CIFAR-10 demo running**. Live training dashboard (auto split-pane in tmux), auto test reports at gates, structured Phase 1/5 report templates for production data. 382 tests, ruff clean, validate-docs 9/9. PRs #22-#26.
+ZO v1.0.2-pre — **CIFAR-10 demo running**. Draft scout team (Plan Architect + Data Scout + Research Scout), live training dashboard, auto test reports at gates, structured Phase 1/5 report templates. 19 agents, 382 tests, ruff clean, validate-docs 9/9. PRs #22-#27.
 
 ## Completed
 
@@ -68,6 +68,10 @@ ZO v1.0.2-pre — **CIFAR-10 demo running**. Live training dashboard (auto split
 - [x] v1.0.2-pre: Phase 1 report template (10 sections: schema, completeness, distributions, outliers, class, temporal, correlations, drift, splits, recommendations)
 - [x] v1.0.2-pre: Phase 5 report template (7 sections: explainability, error analysis, bias, ablation, significance, reproducibility, verdict)
 - [x] v1.0.2-pre: Agent contracts reference specs/report_templates.md for structured reports
+- [x] v1.0.2-pre: Draft scout team — Plan Architect (Opus lead) + Data Scout (Sonnet) + Research Scout
+- [x] v1.0.2-pre: zo draft CLI redesigned — --docs, --data, -d flags (all optional, conversational fallback)
+- [x] v1.0.2-pre: _launch_and_monitor refactored — shared by build and draft, model/max_turns params
+- [x] v1.0.2-pre: Agent count 17 → 19 (plan-architect, data-scout added)
 
 ## Known Issues
 

--- a/plans/zero-operators-build.md
+++ b/plans/zero-operators-build.md
@@ -13,7 +13,7 @@ owner: "Sam"
 
 Build the Zero Operators (ZO) platform itself — the orchestration engine, memory layer, communication system, plan parser, target file enforcer, agent definitions, setup tooling, and CLI that together form an autonomous AI research and engineering team system. The platform reads a `plan.md`, spawns a coordinated agent team via Claude Code's native agent teams, executes work against delivery repositories, and enforces oracle-driven validation at every gate.
 
-Deliverables: a working ZO platform deployed as a Python package in the `zero-operators/` repository, with all 17 agent definition files in `.claude/agents/`, a functional memory layer, hybrid orchestration engine (native Claude Code teams + Python lifecycle wrapper), JSONL comms logger, plan.md validator, target file parser with isolation enforcement, semantic search index (full decision entries with summary prefix), a `zo` CLI with build/continue/draft subcommands, `setup.sh` bootstrapper, `zo init` project scaffolder, and a comprehensive test suite proving the system can execute a real project end-to-end.
+Deliverables: a working ZO platform deployed as a Python package in the `zero-operators/` repository, with all 19 agent definition files in `.claude/agents/`, a functional memory layer, hybrid orchestration engine (native Claude Code teams + Python lifecycle wrapper), JSONL comms logger, plan.md validator, target file parser with isolation enforcement, semantic search index (full decision entries with summary prefix), a `zo` CLI with build/continue/draft subcommands, `setup.sh` bootstrapper, `zo init` project scaffolder, and a comprehensive test suite proving the system can execute a real project end-to-end.
 
 ## Oracle
 
@@ -64,7 +64,7 @@ Deliverables: a working ZO platform deployed as a Python package in the `zero-op
 - Phase 6: Packaging and release
 
 **Gates:**
-- Gate 0: blocking (human verifies all 17 agent definitions are correct, Claude Code setup validated)
+- Gate 0: blocking (human verifies all 19 agent definitions are correct, Claude Code setup validated)
 - Gate 1: automated (plan parser, target parser, comms logger, setup tooling pass unit tests)
 - Gate 2: blocking (human reviews module contracts and integration plan)
 - Gate 3: automated (orchestration engine passes unit tests with mocked agents)
@@ -159,7 +159,7 @@ Deliverables: a working ZO platform deployed as a Python package in the `zero-op
 
 ### Module 0: Agent Definitions + Claude Code Setup ✅
 **Spec source:** specs/agents.md
-**Responsibility:** Write all 17 agent `.md` files to `.claude/agents/` with YAML frontmatter and full spawn prompts. Create `.claude/settings.json`. Validate agents can be spawned.
+**Responsibility:** Write all 19 agent `.md` files to `.claude/agents/` with YAML frontmatter and full spawn prompts. Create `.claude/settings.json`. Validate agents can be spawned.
 **Outputs:** 17 `.md` files, `.claude/settings.json`, validation report.
 **Status:** COMPLETE
 
@@ -237,7 +237,7 @@ Deliverables: a working ZO platform deployed as a Python package in the `zero-op
 ```
 Phase 0 — Agent Definitions + Claude Code Setup
 └── Module 0: Agent Definitions + Claude Code Setup  ✅ COMPLETE
-    ├── 17 agent .md files in .claude/agents/
+    ├── 19 agent .md files in .claude/agents/
     ├── .claude/settings.json
     └── Validation pending
 

--- a/setup.sh
+++ b/setup.sh
@@ -90,7 +90,7 @@ EXPECTED_AGENTS=(
     code-reviewer test-engineer xai-agent domain-evaluator
     ml-engineer infra-engineer software-architect backend-engineer
     frontend-engineer platform-test-engineer platform-code-reviewer
-    documentation-agent
+    documentation-agent plan-architect data-scout
 )
 AGENT_COUNT=0
 MISSING_AGENTS=()
@@ -102,10 +102,10 @@ for agent in "${EXPECTED_AGENTS[@]}"; do
     fi
 done
 
-if [[ $AGENT_COUNT -eq 17 ]]; then
-    pass "All 17 agent definitions present"
+if [[ $AGENT_COUNT -eq 19 ]]; then
+    pass "All 19 agent definitions present"
 else
-    fail "$AGENT_COUNT/17 agent definitions found"
+    fail "$AGENT_COUNT/19 agent definitions found"
     for missing in "${MISSING_AGENTS[@]}"; do
         echo -e "      ${RED}missing:${RESET} .claude/agents/${missing}.md"
     done

--- a/src/zo/cli.py
+++ b/src/zo/cli.py
@@ -193,18 +193,21 @@ def _launch_and_monitor(
     prompt: str,
     team_name: str,
     zo_root: Path,
-    orchestrator,  # noqa: ANN001
-    semantic,  # noqa: ANN001
-    no_tmux: bool,
+    orchestrator=None,  # noqa: ANN001
+    semantic=None,  # noqa: ANN001
+    no_tmux: bool = False,
+    model: str = "opus",
+    max_turns: int = 200,
     gate_mode_file: Path | None = None,
     project_name: str = "",
     delivery_repo: Path | None = None,
 ) -> None:
-    """Shared launch → monitor → end-session flow for all modes."""
+    """Shared launch → monitor → end-session flow for build and draft."""
     use_tmux = not no_tmux
     console.print(f"\n[{_AMBER}]Launching lead session:[/] team={team_name}")
     process = wrapper.launch_lead_session(
-        prompt, cwd=str(zo_root), team_name=team_name, use_tmux=use_tmux,
+        prompt, cwd=str(zo_root), team_name=team_name,
+        model=model, max_turns=max_turns, use_tmux=use_tmux,
     )
 
     if process.tmux_pane_id:
@@ -358,8 +361,10 @@ def _launch_and_monitor(
     else:
         console.print(f"[red bold]Session ended with status:[/] {process.status}")
 
-    orchestrator.end_session()
-    semantic.close()
+    if orchestrator:
+        orchestrator.end_session()
+    if semantic:
+        semantic.close()
 
 
 @cli.command()
@@ -796,29 +801,38 @@ def preflight(plan_file: Path, target_repo: Path | None) -> None:
 
 
 @cli.command()
-@click.argument("source_paths", nargs=-1, type=click.Path(path_type=Path))
 @click.option("--project", "-p", required=True, help="Project name for the generated plan")
-@click.option("--description", "-d", default=None, help="Project description (when no source docs)")
+@click.option(
+    "--docs", multiple=True, type=click.Path(exists=True, path_type=Path),
+    help="Source documents (requirements, scope of work, domain docs)",
+)
+@click.option(
+    "--data", multiple=True, type=click.Path(exists=True, path_type=Path),
+    help="Data files/dirs for the Data Scout to inspect",
+)
+@click.option("--description", "-d", default=None, help="Project description")
 @click.option("--no-tmux", is_flag=True, help="Skip interactive drafting session")
 def draft(
-    source_paths: tuple[Path, ...], project: str,
+    project: str, docs: tuple[Path, ...], data: tuple[Path, ...],
     description: str | None, no_tmux: bool,
 ) -> None:
-    """Generate a plan.md conversationally or from source documents.
+    """Draft a plan.md with a scout team.
 
-    When source paths are provided, indexes documents and generates a
-    plan template seeded with their content. When no source paths are
-    given, prompts for a project description (or uses --description).
+    Launches a Plan Architect (Opus) that conversationally drafts the
+    plan with you.  Optionally spawns scouts in the background:
 
-    In both cases, launches an interactive Claude Code session that
-    drafts the plan conversationally — asking about objectives, data,
-    oracle metrics, and constraints.
+    - **Data Scout** inspects --data paths (schema, distributions,
+      quality flags, complexity signals)
+    - **Research Scout** finds prior art and baselines for the domain
+
+    All args are optional.  If nothing is provided, the Plan Architect
+    asks you conversationally.
 
     Usage::
 
-        zo draft ~/docs/spec.md --project my-project
-        zo draft --project cifar10 -d "CIFAR-10 CNN, PyTorch, 90%+ accuracy"
-        zo draft --project my-project
+        zo draft -p my-project --docs ~/docs/ --data ~/data/
+        zo draft -p cifar10 -d "CIFAR-10 CNN, PyTorch, 90%+ accuracy"
+        zo draft -p my-project
     """
     from zo.draft import PlanDrafter
 
@@ -832,23 +846,18 @@ def draft(
     # Always write plans to main repo, not worktrees
     plan_root = main_root if main_root != zo_root else zo_root
 
-    if source_paths:
-        # --- Branch A: source documents provided ---
-        for sp in source_paths:
-            if not sp.exists():
-                console.print(f"[red bold]Path not found: {sp}[/]")
-                raise SystemExit(1)
-
+    if docs:
+        # --- Source documents provided: index and generate skeleton ---
         drafter = PlanDrafter(
-            source_paths=list(source_paths), project_name=project,
+            source_paths=list(docs), project_name=project,
             zo_root=plan_root,
         )
 
         console.print(
             f"[{_AMBER}]Indexing documents from "
-            f"{len(source_paths)} path(s):[/]"
+            f"{len(docs)} path(s):[/]"
         )
-        for sp in source_paths:
+        for sp in docs:
             console.print(f"  [{_DIM}]{sp}[/]")
         count = drafter.index_documents()
         console.print(f"[green]Indexed {count} documents.[/]")
@@ -858,7 +867,7 @@ def draft(
         doc_context = drafter.get_document_summaries()
 
     else:
-        # --- Branch B: no source documents ---
+        # --- No source documents: description or interactive ---
         if not desc:
             console.print(
                 f"[{_AMBER}]No source documents provided.[/]\n"
@@ -883,7 +892,12 @@ def draft(
         console.print(f"[{_AMBER}]Generating plan skeleton...[/]")
         plan_path = drafter.generate_plan_from_description(desc)
 
-    console.print(f"[green]Plan generated:[/] {plan_path}")
+    if data:
+        console.print(f"[{_AMBER}]Data paths for scout inspection:[/]")
+        for dp in data:
+            console.print(f"  [{_DIM}]{dp}[/]")
+
+    console.print(f"[green]Plan skeleton:[/] {plan_path}")
     if plan_root != zo_root:
         console.print(
             f"  [{_DIM}]Written to main repo (not worktree)[/]"
@@ -898,116 +912,146 @@ def draft(
             "The drafting session will address them."
         )
 
-    # Interactive drafting session
+    # --- Launch scout team session ---
     if not no_tmux:
+        from zo.comms import CommsLogger
         from zo.wrapper import LifecycleWrapper
 
         console.print(
-            f"\n[{_AMBER}]Opening interactive drafting session...[/]"
+            f"\n[{_AMBER}]Launching draft scout team...[/]"
         )
-        from zo.comms import CommsLogger
 
         session_id = f"s-{uuid.uuid4().hex[:8]}"
         comms = CommsLogger(
             log_dir=zo_root / "logs" / "comms",
             project=project, session_id=session_id,
         )
-        wrapper = LifecycleWrapper(comms=comms, log_dir=zo_root / "logs" / "wrapper")
-
-        # Build context-aware prompt
-        context_block = ""
-        if doc_context:
-            context_block = f"\n\n{doc_context}\n"
-        elif desc:
-            context_block = f"\n\nUser's project description: {desc}\n"
-
-        # Build path always references main repo for zo build
-        build_cmd = f"zo build plans/{project}.md"
-
-        draft_prompt = (
-            f"You are drafting a plan.md for project '{project}' "
-            f"at {plan_path}.\n"
-            f"{context_block}\n"
-            f"A skeleton plan already exists at that path. Read it, "
-            f"then work with the user conversationally to complete "
-            f"it:\n\n"
-            f"1. Review what's there and summarise what you "
-            f"understand\n"
-            f"2. Ask about the objective — what exactly are we "
-            f"building?\n"
-            f"3. Ask about data sources — where does the data come "
-            f"from?\n"
-            f"4. Ask about oracle metrics — how do we measure "
-            f"success?\n"
-            f"5. Ask about constraints — time, compute, regulatory "
-            f"limits?\n"
-            f"6. Fill in each section as you get answers\n"
-            f"7. Validate the final plan against specs/plan.md "
-            f"schema\n\n"
-            f"Write the completed plan to {plan_path}. "
-            f"The plan schema is defined in specs/plan.md — ensure "
-            f"compliance.\n\n"
-            f"When the plan is complete:\n"
-            f"- Ask the user: 'Is there anything else you'd like to "
-            f"adjust? If not, this session is done — run "
-            f"`{build_cmd}` to start building.'\n"
-            f"- Once confirmed, say goodbye and tell them to type "
-            f"/exit to close this session.\n"
+        wrapper = LifecycleWrapper(
+            comms=comms, log_dir=zo_root / "logs" / "wrapper",
         )
 
-        prompt_file = zo_root / "logs" / "wrapper" / f"zo-draft-{project}-prompt.txt"
-        prompt_file.parent.mkdir(parents=True, exist_ok=True)
-        prompt_file.write_text(draft_prompt, encoding="utf-8")
-
-        # Kill any existing draft window for this project (prevent orphans)
-        window_name = f"draft-{project}"
-        __import__("subprocess").run(
-            ["tmux", "kill-window", "-t", window_name],
-            capture_output=True, text=True, timeout=5,
+        draft_prompt = _build_draft_prompt(
+            project=project,
+            plan_path=plan_path,
+            doc_context=doc_context,
+            description=desc,
+            data_paths=data,
+            zo_root=zo_root,
         )
 
-        # Launch interactive claude session
-        result = __import__("subprocess").run(
-            ["tmux", "new-window", "-d", "-n", window_name,
-             "-P", "-F", "#{pane_id}"],
-            capture_output=True, text=True, timeout=10,
-        )
-        pane_id = result.stdout.strip()
-
-        import shlex
-        claude_abs = wrapper._resolve_claude_bin()
-        cmd = (
-            f'{shlex.quote(claude_abs)}'
-            f' --model sonnet'
-            f' --add-dir {shlex.quote(str(zo_root))}'
-        )
-        __import__("subprocess").run(
-            ["tmux", "send-keys", "-t", pane_id, cmd, "Enter"],
-            capture_output=True, text=True, timeout=10,
-        )
-
-        import time
-        time.sleep(3)
-        __import__("subprocess").run(
-            ["tmux", "load-buffer", str(prompt_file)],
-            capture_output=True, text=True, timeout=10,
-        )
-        __import__("subprocess").run(
-            ["tmux", "paste-buffer", "-t", pane_id],
-            capture_output=True, text=True, timeout=10,
-        )
-        time.sleep(0.5)
-        __import__("subprocess").run(
-            ["tmux", "send-keys", "-t", pane_id, "Enter"],
-            capture_output=True, text=True, timeout=10,
-        )
-
-        console.print(
-            f"[{_AMBER}]Drafting session opened.[/] "
-            f"[{_DIM}]Ctrl-b n to switch to it.[/]"
+        _launch_and_monitor(
+            wrapper=wrapper,
+            prompt=draft_prompt,
+            team_name=f"draft-{project}",
+            zo_root=zo_root,
+            no_tmux=False,
+            model="opus",
+            max_turns=100,
         )
 
     drafter.close()
+
+
+def _build_draft_prompt(
+    *,
+    project: str,
+    plan_path: Path,
+    doc_context: str,
+    description: str,
+    data_paths: tuple[Path, ...],
+    zo_root: Path,
+) -> str:
+    """Construct the Plan Architect's prompt for a draft session."""
+    build_cmd = f"zo build plans/{project}.md"
+
+    # Context block
+    context_parts: list[str] = []
+    if doc_context:
+        context_parts.append(f"## Indexed Document Context\n\n{doc_context}")
+    if description:
+        context_parts.append(
+            f"## User Description\n\n{description}"
+        )
+    context_block = "\n\n".join(context_parts)
+
+    # Scout spawn instructions
+    scout_instructions: list[str] = []
+
+    # Data Scout — only if data paths provided
+    if data_paths:
+        paths_str = ", ".join(str(p.resolve()) for p in data_paths)
+        scout_instructions.append(
+            f'2. Spawn a **Data Scout** teammate:\n'
+            f'   ```\n'
+            f'   Agent(name="data-scout", team_name="draft-{project}",\n'
+            f'         prompt="Inspect the data at: {paths_str}. '
+            f'Report schema, shape, distributions, quality flags, '
+            f'and complexity signals. Send your findings back to me '
+            f'via SendMessage.")\n'
+            f'   ```'
+        )
+
+    # Research Scout — always
+    objective_hint = description or "the project described in the skeleton plan"
+    scout_instructions.append(
+        f'{"3" if data_paths else "2"}. Spawn a **Research Scout** teammate:\n'
+        f'   ```\n'
+        f'   Agent(name="research-scout", '
+        f'team_name="draft-{project}",\n'
+        f'         prompt="Research prior art, SOTA approaches, baselines, '
+        f'and open-source implementations for: {objective_hint}. '
+        f'Send your findings back to me via SendMessage.")\n'
+        f'   ```'
+    )
+
+    scout_block = "\n".join(scout_instructions)
+    data_note = ""
+    if not data_paths:
+        data_note = (
+            "\nNo data paths were provided. Ask the human where the "
+            "data is. If they provide paths during conversation, you "
+            "can spawn a Data Scout at that point.\n"
+        )
+
+    return (
+        f"# Role\n\n"
+        f"You are the Plan Architect for project '{project}'.\n"
+        f"Your agent definition is at .claude/agents/plan-architect.md "
+        f"— read it for your full protocol.\n\n"
+        f"---\n\n"
+        f"# Plan\n\n"
+        f"A skeleton plan exists at `{plan_path}`. Read it first.\n\n"
+        f"{context_block}\n\n"
+        f"---\n\n"
+        f"# Team Setup\n\n"
+        f"Immediately:\n\n"
+        f'1. Create a team: `TeamCreate(team_name="draft-{project}")`\n'
+        f"{scout_block}\n\n"
+        f"While scouts work in the background, begin your conversation "
+        f"with the human. When scout messages arrive, acknowledge them "
+        f"and weave their findings into the plan.\n"
+        f"{data_note}\n"
+        f"If scouts haven't reported within 5 minutes, proceed without "
+        f"them.\n\n"
+        f"---\n\n"
+        f"# Conversation Flow\n\n"
+        f"1. Read the skeleton plan and summarise what you understand\n"
+        f"2. Ask about the objective — what exactly are we building?\n"
+        f"3. Ask about data sources (incorporate Data Scout findings "
+        f"when they arrive)\n"
+        f"4. Ask about oracle metrics — how do we measure success?\n"
+        f"5. Ask about domain context (incorporate Research Scout "
+        f"findings when they arrive)\n"
+        f"6. Ask about constraints — time, compute, regulatory\n"
+        f"7. Fill in each section as you get answers\n"
+        f"8. Validate against specs/plan.md schema\n\n"
+        f"Write the completed plan to `{plan_path}`.\n\n"
+        f"---\n\n"
+        f"# Completion\n\n"
+        f"When done, ask: 'Anything to adjust? If not, run "
+        f"`{build_cmd}` to start building.'\n"
+        f"Once confirmed, tell the user to type /exit.\n"
+    )
 
 
 # ---------------------------------------------------------------------------

--- a/tests/unit/test_cli.py
+++ b/tests/unit/test_cli.py
@@ -379,7 +379,7 @@ class TestDraftCommand:
     def test_draft_requires_project(
         self, runner: click.testing.CliRunner, tmp_path: Path
     ) -> None:
-        result = runner.invoke(cli, ["draft", str(tmp_path)])
+        result = runner.invoke(cli, ["draft"])
         assert result.exit_code != 0
         assert "Missing option" in result.output or "required" in result.output.lower()
 
@@ -399,8 +399,8 @@ class TestDraftCommand:
 
         with patch("zo.cli._zo_root", return_value=zo_root):
             result = runner.invoke(
-                cli, ["draft", str(source_dir), "--project", "test-draft",
-                      "--no-tmux"]
+                cli, ["draft", "--docs", str(source_dir),
+                      "--project", "test-draft", "--no-tmux"]
             )
 
         assert result.exit_code == 0


### PR DESCRIPTION
## Summary

- **Draft scout team** — `zo draft` upgraded from single Sonnet session to 3-agent team: Plan Architect (Opus, lead), Data Scout (Sonnet), Research Scout (existing, Opus). Architect converses with human while scouts gather data and research intelligence in the background.
- **CLI redesigned** — `zo draft -p NAME [--docs PATH...] [--data PATH...] [-d DESC]`. All optional — if nothing provided, architect asks conversationally.
- **Data Scout** — inspects raw data files (schema, distributions, quality flags, complexity signals). Reports findings to architect via peer messaging.
- **Shared monitoring** — `_launch_and_monitor()` refactored to work for both build and draft. Same team status feed, Haiku headlines, and tmux UX.
- **Agent count** — 17 → 19. Full docs cascade: setup.sh, README badge + roster, lead-orchestrator, plans, COMMANDS.md.

## Test plan

- [x] 382 tests pass, 7 skipped
- [x] Ruff clean
- [x] `validate-docs.sh` 9/9 passed (agent count 19 consistent)
- [ ] Manual: `zo draft -p test --data ~/data/` → verify Plan Architect + Data Scout + Research Scout spawn in tmux
- [ ] Manual: `zo draft -p test` → verify conversational fallback (no scouts until data provided)

🤖 Generated with [Claude Code](https://claude.com/claude-code)