### PR TITLE
feat(agents): dynamic agent creation — custom specialists

### DIFF
--- a/.claude/agents/custom/README.md
+++ b/.claude/agents/custom/README.md
@@ -1,0 +1,33 @@
+# Custom Agents
+
+Project-specific specialist agents created during `zo draft` or `zo build`.
+
+## How They Get Here
+
+1. **Plan-defined** — the Plan Architect suggests custom agents during `zo draft`, written into plan.md's `## Agent Configuration` section. The orchestrator auto-creates the `.md` files here at build start.
+
+2. **Mid-build** — the Lead Orchestrator identifies an expertise gap during execution and creates a specialist on the fly. Logged to DECISION_LOG.
+
+## Reuse
+
+Custom agents persist across projects. The orchestrator scans this directory and includes custom agents in the roster prompt. If a future project has a similar domain, the lead can reuse existing specialists instead of creating new ones.
+
+## Format
+
+Same as core agents in `.claude/agents/`:
+
+```yaml
+---
+name: Agent Display Name
+model: claude-sonnet-4-6
+role: One-line description
+tier: phase-in
+team: project
+---
+```
+
+Followed by: role description, coordination rules, validation checklist.
+
+## Not Limited
+
+Custom agents can be any role — domain specialists, data scientists, signal processing experts, security auditors, calibration engineers, NLP researchers, testing specialists, etc. The team adapts to the project.

--- a/.claude/agents/lead-orchestrator.md
+++ b/.claude/agents/lead-orchestrator.md
@@ -42,16 +42,23 @@ You have 19 pre-defined agents available in `.claude/agents/`. You MUST use Clau
 
 ## Dynamic Agent Creation
 
-If a project requires expertise not covered by the 19 pre-defined agents, you MUST create a new agent definition before spawning:
+Custom agents live in `.claude/agents/custom/`. Some may already exist from previous projects — check before creating duplicates.
 
-1. **Identify the gap** — what expertise is missing? (e.g., "NLP specialist", "time-series expert", "security auditor")
-2. **Write the agent .md file** to `.claude/agents/{new-agent-name}.md` following the same format:
+**Plan-defined custom agents** are auto-created by the orchestrator at build start from the plan's `## Agent Configuration` section. You spawn them like any other agent.
+
+**Mid-build agent creation** — if you discover an expertise gap during execution that the plan didn't anticipate:
+
+1. **Identify the gap** — what expertise is missing? (e.g., signal processing analyst, calibration expert, NLP specialist, security auditor, statistical tester)
+2. **Check `.claude/agents/custom/`** — a suitable specialist may already exist from a previous project
+3. **Write the agent .md file** to `.claude/agents/custom/{new-agent-name}.md` following the same format:
    - YAML frontmatter: name, model (pick appropriate tier), role, tier: phase-in, team: project
-   - Markdown body: role description, ownership, off-limits, contract produced/consumed, coordination rules, validation checklist
-3. **Log the decision** — append to DECISION_LOG.md why this agent was created
-4. **Spawn the agent** — include it in the team via Agent(name="{new-agent-name}", team_name=...)
+   - Markdown body: role description, coordination rules, validation checklist
+4. **Log the decision** — this is full-auto, no human approval needed. Log to DECISION_LOG.md with rationale.
+5. **Spawn the agent** — include in the team via Agent(name="{new-agent-name}", team_name=...) with a detailed spawn prompt defining their contract for this phase
 
-The agent roster is a starting point, not a ceiling. Adapt the team to the project.
+Custom agents are NOT limited to domain specialists. They can be researchers, data scientists, coders, testers, QA specialists — any role the project needs. The team adapts to the problem.
+
+The agent roster is a starting point, not a ceiling.
 
 ## Your Ownership
 

--- a/.claude/agents/plan-architect.md
+++ b/.claude/agents/plan-architect.md
@@ -51,7 +51,15 @@ Work through these topics conversationally. Don't be rigid — adapt to the huma
 5. **Domain context** — what domain knowledge should the team know? What are the known pitfalls? (Weave in Research Scout findings when they arrive.)
 6. **Constraints** — time, compute, cost, regulatory, team skill constraints?
 7. **Milestones** — what are the key checkpoints?
-8. **Agent configuration** — which agents should be active? Are any domain-specific specialists needed?
+8. **Agent configuration & custom specialists** — which core agents should be active? Based on scout findings, suggest custom specialists the project needs. These can be any role: data scientists, signal processing experts, calibration engineers, NLP researchers, statistical testers, etc.
+
+Write custom agents into the plan using this format:
+```markdown
+**Custom agents:**
+- signal-analyst: Sonnet — Signal processing specialist for vibration/acoustic data
+- calibration-expert: Sonnet — Sensor calibration and drift correction specialist
+```
+The orchestrator auto-creates these as agent definitions at build start.
 
 ### 3. Scout Integration
 

--- a/README.md
+++ b/README.md
@@ -402,7 +402,7 @@ zero-operators/
 ├── memory/                     # Per-project state (STATE.md, DECISION_LOG, PRIORS)
 ├── logs/                       # JSONL audit trails
 ├── targets/                    # Delivery repo configuration
-├── tests/                      # 398 tests (unit + integration)
+├── tests/                      # 407 tests (unit + integration)
 ├── setup.sh                    # Environment validation (10 checks)
 └── pyproject.toml              # Python package config
 ```

--- a/README.md
+++ b/README.md
@@ -402,7 +402,7 @@ zero-operators/
 ├── memory/                     # Per-project state (STATE.md, DECISION_LOG, PRIORS)
 ├── logs/                       # JSONL audit trails
 ├── targets/                    # Delivery repo configuration
-├── tests/                      # 382 tests (unit + integration)
+├── tests/                      # 398 tests (unit + integration)
 ├── setup.sh                    # Environment validation (10 checks)
 └── pyproject.toml              # Python package config
 ```

--- a/README.md
+++ b/README.md
@@ -402,7 +402,7 @@ zero-operators/
 ├── memory/                     # Per-project state (STATE.md, DECISION_LOG, PRIORS)
 ├── logs/                       # JSONL audit trails
 ├── targets/                    # Delivery repo configuration
-├── tests/                      # 407 tests (unit + integration)
+├── tests/                      # 415 tests (unit + integration)
 ├── setup.sh                    # Environment validation (10 checks)
 └── pyproject.toml              # Python package config
 ```

--- a/memory/zo-platform/DECISION_LOG.md
+++ b/memory/zo-platform/DECISION_LOG.md
@@ -503,3 +503,13 @@ Append-only. Every orchestration decision with timestamp, rationale, and outcome
 **Rationale:** The old positional arg was overloaded — no way to distinguish docs from data. For the scout team, Data Scout needs to know which paths are actual data files to inspect. Explicit flags are clear. Making everything optional preserves the conversational fallback — the architect asks the human for anything not provided on the command line.
 **Alternatives considered:** (1) Single positional arg, heuristic separation — fragile, confusing. (2) Explicit flags (chosen) — clear intent, both optional. (3) Config file — over-engineered for this.
 **Outcome:** PR #27. CLI: `zo draft -p NAME [--docs PATH...] [--data PATH...] [-d DESC]`.
+
+---
+
+## Decision: 2026-04-13T03:00:00Z
+**Type:** ARCHITECTURE
+**Title:** Dynamic agent creation — custom/ directory, plan-defined + mid-build
+**Decision:** Custom agents live in `.claude/agents/custom/` (separate from 19 core agents). Two creation paths: (1) plan.md declares custom agents via `**Custom agents:**` block — orchestrator auto-creates `.md` files at build start. (2) Lead orchestrator creates agents mid-build when it discovers unplanned expertise gaps — full-auto, logged to DECISION_LOG. Custom agents persist across projects and are reusable. `_agents_for_phase()` treats unknown agents as available for ALL phases (lead decides when to spawn). `_prompt_roster()` scans both core and custom/ directories.
+**Rationale:** Static 19-agent roster doesn't scale to production projects with domain-specific needs (IVL F5: signal processing, sensor calibration, etc.). Custom agents can be any role — researchers, data scientists, testers, QA — not limited to domain specialists. The agent library grows as ZO encounters new problem types.
+**Alternatives considered:** (1) All agents in flat directory — mixes core with project-specific, hard to tell apart. (2) Agents in delivery repo — doesn't persist across projects. (3) Custom subdirectory (chosen) — clean separation, reusable, visible in roster.
+**Outcome:** PR #28. CustomAgentSpec in plan parser, _ensure_custom_agents + _render_custom_agent in orchestrator, 16 new tests.

--- a/memory/zo-platform/STATE.md
+++ b/memory/zo-platform/STATE.md
@@ -8,7 +8,7 @@ status: complete
 
 ## Current Position
 
-ZO v1.0.2-pre — **CIFAR-10 demo running**. Dynamic agent creation (custom/ dir, plan-defined + mid-build), draft scout team, live training dashboard, auto test reports, structured phase report templates. 19 core agents + custom library, 398 tests, ruff clean, validate-docs 10/10. PRs #22-#28.
+ZO v1.0.2-pre — **CIFAR-10 demo running**. Dynamic agent creation (custom/ dir, plan-defined + mid-build), draft scout team, live training dashboard, auto test reports, structured phase report templates. 19 core agents + custom library, 407 tests, ruff clean, validate-docs 10/10. PRs #22-#28.
 
 ## Completed
 
@@ -101,7 +101,7 @@ ZO v1.0.2-pre — **CIFAR-10 demo running**. Dynamic agent creation (custom/ dir
 last_checkpoint: 2026-04-13T01:00:00Z
 last_session: session-012
 branch: claude/charming-lovelace (worktree)
-test_count: 398 passed, 7 skipped
+test_count: 407 passed, 7 skipped
 lint: ruff clean (src/zo/)
 validation: scripts/validate-docs.sh 10/10 passed, 0 warnings
 prs: #22-#25 (UX), #26 (training dashboard + test reports), #27 (draft scout team), #28 (dynamic agents)

--- a/memory/zo-platform/STATE.md
+++ b/memory/zo-platform/STATE.md
@@ -8,7 +8,7 @@ status: complete
 
 ## Current Position
 
-ZO v1.0.2-pre — **CIFAR-10 demo running**. Draft scout team (Plan Architect + Data Scout + Research Scout), live training dashboard, auto test reports at gates, structured Phase 1/5 report templates. 19 agents, 382 tests, ruff clean, validate-docs 9/9. PRs #22-#27.
+ZO v1.0.2-pre — **CIFAR-10 demo running**. Dynamic agent creation (custom/ dir, plan-defined + mid-build), draft scout team, live training dashboard, auto test reports, structured phase report templates. 19 core agents + custom library, 398 tests, ruff clean, validate-docs 10/10. PRs #22-#28.
 
 ## Completed
 
@@ -72,6 +72,11 @@ ZO v1.0.2-pre — **CIFAR-10 demo running**. Draft scout team (Plan Architect + 
 - [x] v1.0.2-pre: zo draft CLI redesigned — --docs, --data, -d flags (all optional, conversational fallback)
 - [x] v1.0.2-pre: _launch_and_monitor refactored — shared by build and draft, model/max_turns params
 - [x] v1.0.2-pre: Agent count 17 → 19 (plan-architect, data-scout added)
+- [x] v1.0.2-pre: Dynamic agent creation — .claude/agents/custom/ for project-specific specialists
+- [x] v1.0.2-pre: Plan parser supports **Custom agents:** block (name: Model — role)
+- [x] v1.0.2-pre: Orchestrator auto-creates custom agent .md files from plan at build start
+- [x] v1.0.2-pre: Custom agents available for all phases (not restricted by AGENT_PHASE_MAP)
+- [x] v1.0.2-pre: _prompt_roster scans both core and custom/ directories, labels each
 
 ## Known Issues
 
@@ -96,7 +101,7 @@ ZO v1.0.2-pre — **CIFAR-10 demo running**. Draft scout team (Plan Architect + 
 last_checkpoint: 2026-04-13T01:00:00Z
 last_session: session-012
 branch: claude/charming-lovelace (worktree)
-test_count: 382 passed, 7 skipped
+test_count: 398 passed, 7 skipped
 lint: ruff clean (src/zo/)
-validation: scripts/validate-docs.sh 9/9 passed, 1 warning (test badge grep heuristic)
-prs: #22 (setup auto-fix), #23 (zo CLI install), #24 (conversational draft), #25 (banner + phases + worktree draft), #26 (training dashboard + test reports + phase templates)
+validation: scripts/validate-docs.sh 10/10 passed, 0 warnings
+prs: #22-#25 (UX), #26 (training dashboard + test reports), #27 (draft scout team), #28 (dynamic agents)

--- a/memory/zo-platform/STATE.md
+++ b/memory/zo-platform/STATE.md
@@ -8,7 +8,7 @@ status: complete
 
 ## Current Position
 
-ZO v1.0.2-pre — **CIFAR-10 demo running**. Dynamic agent creation (custom/ dir, plan-defined + mid-build), draft scout team, live training dashboard, auto test reports, structured phase report templates. 19 core agents + custom library, 407 tests, ruff clean, validate-docs 10/10. PRs #22-#28.
+ZO v1.0.2-pre — **CIFAR-10 demo running**. Dynamic agent creation (custom/ dir, plan-defined + mid-build), draft scout team, live training dashboard, auto test reports, structured phase report templates. 19 core agents + custom library, 415 tests, ruff clean, validate-docs 10/10. PRs #22-#28.
 
 ## Completed
 
@@ -101,7 +101,7 @@ ZO v1.0.2-pre — **CIFAR-10 demo running**. Dynamic agent creation (custom/ dir
 last_checkpoint: 2026-04-13T01:00:00Z
 last_session: session-012
 branch: claude/charming-lovelace (worktree)
-test_count: 407 passed, 7 skipped
+test_count: 415 passed, 7 skipped
 lint: ruff clean (src/zo/)
 validation: scripts/validate-docs.sh 10/10 passed, 0 warnings
 prs: #22-#25 (UX), #26 (training dashboard + test reports), #27 (draft scout team), #28 (dynamic agents)

--- a/src/zo/orchestrator.py
+++ b/src/zo/orchestrator.py
@@ -57,6 +57,47 @@ __all__ = [
 ]
 
 # ---------------------------------------------------------------------------
+# Custom agent template
+# ---------------------------------------------------------------------------
+
+
+def _render_custom_agent(spec: object) -> str:
+    """Render a custom agent definition from a ``CustomAgentSpec``."""
+    name_display = getattr(spec, "name", "custom").replace("-", " ").title()
+    model = getattr(spec, "model", "claude-sonnet-4-6")
+    role = getattr(spec, "role", "Custom specialist agent.")
+    return (
+        f"---\n"
+        f"name: {name_display}\n"
+        f"model: {model}\n"
+        f"role: {role}\n"
+        f"tier: phase-in\n"
+        f"team: project\n"
+        f"---\n\n"
+        f"You are **{name_display}**, a custom specialist agent.\n\n"
+        f"{role}\n\n"
+        f"## Coordination Rules\n\n"
+        f"- You are spawned by the Lead Orchestrator when your "
+        f"expertise is needed.\n"
+        f"- Communicate findings via SendMessage to the orchestrator "
+        f"and relevant peers.\n"
+        f"- Log significant decisions via the orchestrator for "
+        f"DECISION_LOG.md.\n"
+        f"- Follow all coding conventions: PEP8, type hints, Google "
+        f"docstrings, <500 line files, <50 line functions.\n"
+        f"- Do not modify files outside your assigned scope (the "
+        f"orchestrator defines your scope at spawn time).\n\n"
+        f"## Validation Checklist\n\n"
+        f"Before reporting done:\n\n"
+        f"- [ ] All deliverables produced as specified in your spawn "
+        f"contract\n"
+        f"- [ ] Findings communicated to relevant peers\n"
+        f"- [ ] No files modified outside assigned scope\n"
+        f"- [ ] Code follows project conventions\n"
+    )
+
+
+# ---------------------------------------------------------------------------
 # Contract metadata lookups
 # ---------------------------------------------------------------------------
 
@@ -205,6 +246,8 @@ class Orchestrator:
 
     def decompose_plan(self) -> WorkflowDecomposition:
         """Decompose the plan into phases and agent contracts."""
+        self._ensure_custom_agents()
+
         mode = (
             self._plan.workflow.mode
             if self._plan.workflow
@@ -215,6 +258,11 @@ class Orchestrator:
         phases = factory()
 
         active = self._plan.agents.active_agents if self._plan.agents else []
+        # Include custom agents from the plan in the active list
+        if self._plan.agents and self._plan.agents.custom_agents:
+            for spec in self._plan.agents.custom_agents:
+                if spec.name not in active:
+                    active.append(spec.name)
         for phase in phases:
             phase.assigned_agents = self._agents_for_phase(phase.phase_id, active)
 
@@ -503,7 +551,14 @@ class Orchestrator:
 
     @staticmethod
     def _agents_for_phase(phase_id: str, active_agents: list[str]) -> list[str]:
-        return [a for a in active_agents if phase_id in AGENT_PHASE_MAP.get(a, [])]
+        result: list[str] = []
+        for a in active_agents:
+            phases = AGENT_PHASE_MAP.get(a)
+            # Custom agents (not in map) are available for all phases —
+            # the lead orchestrator decides when to actually spawn them.
+            if phases is None or phase_id in phases:
+                result.append(a)
+        return result
 
     def _compute_plan_hash(self) -> str:
         if self._plan.source_path and self._plan.source_path.exists():
@@ -663,16 +718,55 @@ class Orchestrator:
                 )
         return ("# Agent Contracts\n\n" + "\n\n".join(lines)) if lines else ""
 
+    def _ensure_custom_agents(self) -> None:
+        """Create agent definition files for plan-specified custom agents.
+
+        Writes ``.md`` files to ``.claude/agents/custom/`` for any custom
+        agents declared in the plan that don't already have definitions.
+        Existing files are reused (from previous projects).
+        """
+        if not self._plan.agents or not self._plan.agents.custom_agents:
+            return
+        custom_dir = self._zo_root / ".claude" / "agents" / "custom"
+        custom_dir.mkdir(parents=True, exist_ok=True)
+        for spec in self._plan.agents.custom_agents:
+            agent_path = custom_dir / f"{spec.name}.md"
+            if agent_path.exists():
+                self._comms.log_checkpoint(
+                    agent="orchestrator", phase="setup",
+                    subtask="custom-agent-reuse",
+                    progress=f"Reusing custom agent: {spec.name}",
+                )
+                continue
+            agent_md = _render_custom_agent(spec)
+            agent_path.write_text(agent_md, encoding="utf-8")
+            self._comms.log_decision(
+                agent="orchestrator",
+                title=f"Created custom agent: {spec.name}",
+                rationale=f"Plan specifies specialist not in core library: {spec.role}",
+                outcome="agent_created",
+            )
+
     def _prompt_roster(self) -> str:
         agents_dir = self._zo_root / ".claude" / "agents"
-        files = sorted(agents_dir.glob("*.md")) if agents_dir.is_dir() else []
-        roster = [f"- {f.stem}" for f in files]
-        return (
-            "# Agent Roster\n\nAvailable agents in `.claude/agents/`:\n"
-            + "\n".join(roster)
-            + "\n\nCreate new agent definitions if project requires "
-            "expertise not covered above."
+        core = sorted(agents_dir.glob("*.md")) if agents_dir.is_dir() else []
+        custom_dir = agents_dir / "custom"
+        custom = sorted(custom_dir.glob("*.md")) if custom_dir.is_dir() else []
+        # Exclude README from custom agents list
+        custom = [f for f in custom if f.stem.lower() != "readme"]
+
+        lines = ["# Agent Roster\n", "## Core Agents\n"]
+        lines.extend(f"- {f.stem}" for f in core)
+        if custom:
+            lines.append("\n## Custom Agents (from previous projects)\n")
+            lines.extend(f"- {f.stem}" for f in custom)
+        lines.append(
+            "\nCreate new specialists in `.claude/agents/custom/` "
+            "when the project needs expertise not covered above. "
+            "Custom agents can be any role: domain experts, data "
+            "scientists, researchers, testers, QA specialists, etc."
         )
+        return "\n".join(lines)
 
     def _prompt_memory(self) -> str:
         state = self.session_state

--- a/src/zo/plan.py
+++ b/src/zo/plan.py
@@ -69,10 +69,19 @@ class DataSource(BaseModel):
     raw_content: str = ""
 
 
+class CustomAgentSpec(BaseModel):
+    """A custom agent declared in the plan's Agent Configuration section."""
+
+    name: str
+    model: str = "claude-sonnet-4-6"
+    role: str = ""
+
+
 class AgentConfig(BaseModel):
     """Agent configuration section."""
 
     active_agents: list[str] = Field(default_factory=list)
+    custom_agents: list[CustomAgentSpec] = Field(default_factory=list)
     raw_content: str = ""
 
 
@@ -327,22 +336,56 @@ _ACTIVE_AGENTS_RE = re.compile(
     re.IGNORECASE,
 )
 
+_CUSTOM_AGENTS_RE = re.compile(
+    r"\*\*Custom agents:?\*\*\s*:?\s*\n((?:\s*-\s*.+\n?)+)",
+    re.IGNORECASE,
+)
+
+_CUSTOM_AGENT_LINE_RE = re.compile(
+    r"-\s*(\S+)\s*:\s*(\S+)\s*[—–-]\s*(.+)",
+)
+
+_MODEL_ALIASES: dict[str, str] = {
+    "opus": "claude-opus-4-6",
+    "sonnet": "claude-sonnet-4-6",
+    "haiku": "claude-haiku-4-5-20251001",
+}
+
 
 def _parse_agents(body: str) -> AgentConfig:
     """Parse the Agents section.
 
-    Args:
-        body: Raw markdown body of the Agents section.
+    Supports both active agents and custom agent declarations::
 
-    Returns:
-        Populated ``AgentConfig``.
+        **Active agents:** data-engineer, model-builder, oracle-qa
+
+        **Custom agents:**
+        - signal-analyst: Sonnet — Signal processing for vibration data
+        - calibration-expert: Sonnet — Sensor calibration specialist
     """
     agents: list[str] = []
     m = _ACTIVE_AGENTS_RE.search(body)
     if m:
         raw = m.group(1)
         agents = [a.strip() for a in raw.split(",") if a.strip()]
-    return AgentConfig(active_agents=agents, raw_content=body)
+
+    custom: list[CustomAgentSpec] = []
+    cm = _CUSTOM_AGENTS_RE.search(body)
+    if cm:
+        for line in cm.group(1).strip().splitlines():
+            lm = _CUSTOM_AGENT_LINE_RE.match(line.strip())
+            if lm:
+                name = lm.group(1).strip()
+                model_raw = lm.group(2).strip().lower()
+                model = _MODEL_ALIASES.get(model_raw, model_raw)
+                role = lm.group(3).strip()
+                custom.append(CustomAgentSpec(
+                    name=name, model=model, role=role,
+                ))
+
+    return AgentConfig(
+        active_agents=agents, custom_agents=custom, raw_content=body,
+    )
 
 
 

--- a/tests/integration/test_dynamic_agents_e2e.py
+++ b/tests/integration/test_dynamic_agents_e2e.py
@@ -1,0 +1,349 @@
+"""End-to-end integration test for dynamic agent creation.
+
+Full pipeline: plan with custom agents → parse → decompose → verify
+agent files created, roster includes them, phase assignment works,
+contracts generated, prompt includes custom agents.
+
+No Claude CLI calls — wrapper is not invoked.
+"""
+
+from __future__ import annotations
+
+import json
+import shutil
+import subprocess
+from pathlib import Path
+
+import pytest
+
+from zo._orchestrator_models import GateDecision, GateMode, PhaseStatus
+from zo.comms import CommsLogger
+from zo.memory import MemoryManager
+from zo.orchestrator import Orchestrator
+from zo.plan import CustomAgentSpec, parse_plan
+from zo.semantic import SemanticIndex
+from zo.target import parse_target
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+FIXTURES_DIR = Path(__file__).resolve().parent.parent / "fixtures" / "test-project"
+
+# Plan with custom agents — extends the fixture plan
+_PLAN_WITH_CUSTOM_AGENTS = """\
+---
+project_name: "sensor-anomaly"
+version: "1.0"
+created: "2026-04-13"
+last_modified: "2026-04-13"
+status: active
+owner: "TestEngineer"
+---
+
+## Objective
+
+Build an anomaly detection model for industrial sensor data. The model
+should flag abnormal vibration and temperature patterns that precede
+equipment failure.
+
+## Oracle Definition
+
+**Primary metric:** F1-score
+**Ground truth source:** maintenance logs with failure timestamps
+**Evaluation method:** time-series aware cross-validation
+**Target threshold:** > 0.85
+**Evaluation frequency:** per training iteration
+
+## Workflow Configuration
+
+**Mode:** deep_learning
+
+## Data Sources
+
+### Sensor Readings
+
+- **Location:** data/raw/sensors.parquet
+- **Format:** Parquet, ~2M rows, 50 features
+- **Key columns:** timestamp, sensor_id, vibration, temperature, pressure
+
+## Domain Context and Priors
+
+- Vibration spectral features (FFT) are the strongest predictors.
+- Sensor drift requires calibration correction before modeling.
+- Class imbalance expected: <2% anomaly rate.
+
+## Agent Configuration
+
+**Active agents:** data-engineer, model-builder, oracle-qa, test-engineer
+
+**Custom agents:**
+- signal-analyst: Sonnet — Signal processing specialist for vibration and acoustic FFT analysis, spectral feature extraction, and filtering strategies
+- calibration-expert: Opus — Sensor calibration and drift correction specialist, reviews data-engineer output and advises on regime-aware features
+- anomaly-researcher: Sonnet — Reviews anomaly detection literature, suggests architectures (autoencoders, isolation forests, transformers) and evaluation strategies
+
+## Constraints
+
+- Training must complete within 4 hours on a single GPU.
+- Model must handle sensor dropout (missing channels) gracefully.
+"""
+
+
+def _make_git_repo(path: Path) -> None:
+    subprocess.run(["git", "init", str(path)], capture_output=True, check=True)
+    subprocess.run(
+        ["git", "commit", "--allow-empty", "-m", "init"],
+        cwd=path, capture_output=True,
+        env={**__import__("os").environ, "GIT_AUTHOR_NAME": "test",
+             "GIT_AUTHOR_EMAIL": "t@t.com",
+             "GIT_COMMITTER_NAME": "test", "GIT_COMMITTER_EMAIL": "t@t.com"},
+        check=True,
+    )
+
+
+def _build_e2e(tmp_path: Path) -> tuple[Orchestrator, CommsLogger, Path]:
+    """Build a fully wired orchestrator from the custom-agents plan."""
+    project_dir = tmp_path / "project"
+    project_dir.mkdir(parents=True)
+    _make_git_repo(project_dir)
+
+    # Write plan with custom agents
+    plan_path = project_dir / "plan.md"
+    plan_path.write_text(_PLAN_WITH_CUSTOM_AGENTS, encoding="utf-8")
+
+    # Copy target fixture (just need valid target)
+    target_path = project_dir / "target.md"
+    shutil.copy(FIXTURES_DIR / "target.md", target_path)
+
+    # Create .claude/agents/ dir (simulates ZO repo structure)
+    agents_dir = project_dir / ".claude" / "agents"
+    agents_dir.mkdir(parents=True)
+    # Add a few core agents so roster isn't empty
+    for name in ["lead-orchestrator", "data-engineer", "model-builder",
+                 "oracle-qa", "test-engineer"]:
+        (agents_dir / f"{name}.md").write_text(
+            f"---\nname: {name}\nmodel: claude-sonnet-4-6\n"
+            f"role: Core agent\ntier: launch\nteam: project\n---\n",
+            encoding="utf-8",
+        )
+
+    # Create delivery repo dir (needed for artifact checks)
+    target = parse_target(target_path)
+    delivery_dir = Path(target.target_repo)
+    delivery_dir.mkdir(parents=True, exist_ok=True)
+
+    plan = parse_plan(plan_path)
+    comms = CommsLogger(
+        log_dir=project_dir / "logs" / "comms",
+        project=plan.frontmatter.project_name,
+        session_id="e2e-dynamic-agents",
+    )
+    memory = MemoryManager(
+        project_dir=project_dir,
+        project_name=plan.frontmatter.project_name,
+    )
+    memory.initialize_project()
+    semantic = SemanticIndex(db_path=project_dir / "memory" / "index.db")
+
+    orch = Orchestrator(
+        plan=plan, target=target, memory=memory, comms=comms,
+        semantic=semantic, zo_root=project_dir,
+        gate_mode=GateMode.FULL_AUTO,
+    )
+    return orch, comms, project_dir
+
+
+# ---------------------------------------------------------------------------
+# Tests
+# ---------------------------------------------------------------------------
+
+
+class TestDynamicAgentsE2E:
+    """Full end-to-end: plan → parse → decompose → verify custom agents."""
+
+    def test_plan_parses_custom_agents(self, tmp_path: Path) -> None:
+        """Step 1: plan parser extracts custom agent specs."""
+        plan_path = tmp_path / "plan.md"
+        plan_path.write_text(_PLAN_WITH_CUSTOM_AGENTS, encoding="utf-8")
+        plan = parse_plan(plan_path)
+
+        assert plan.agents is not None
+        assert len(plan.agents.custom_agents) == 3
+
+        names = [a.name for a in plan.agents.custom_agents]
+        assert "signal-analyst" in names
+        assert "calibration-expert" in names
+        assert "anomaly-researcher" in names
+
+        # Model aliases resolved
+        signal = next(a for a in plan.agents.custom_agents if a.name == "signal-analyst")
+        assert signal.model == "claude-sonnet-4-6"
+        calibration = next(a for a in plan.agents.custom_agents if a.name == "calibration-expert")
+        assert calibration.model == "claude-opus-4-6"
+
+        # Roles captured
+        assert "FFT" in signal.role
+        assert "calibration" in calibration.role.lower()
+
+    def test_decompose_creates_custom_agent_files(self, tmp_path: Path) -> None:
+        """Step 2: orchestrator creates .md files in custom/ on decompose."""
+        orch, comms, project_dir = _build_e2e(tmp_path)
+        orch.start_session()
+        decomp = orch.decompose_plan()
+
+        custom_dir = project_dir / ".claude" / "agents" / "custom"
+        assert custom_dir.is_dir()
+
+        # All 3 custom agents should have .md files
+        assert (custom_dir / "signal-analyst.md").exists()
+        assert (custom_dir / "calibration-expert.md").exists()
+        assert (custom_dir / "anomaly-researcher.md").exists()
+
+        # Files have valid YAML frontmatter
+        content = (custom_dir / "signal-analyst.md").read_text()
+        assert "name: Signal Analyst" in content
+        assert "model: claude-sonnet-4-6" in content
+        assert "tier: phase-in" in content
+        assert "FFT" in content
+
+        content = (custom_dir / "calibration-expert.md").read_text()
+        assert "model: claude-opus-4-6" in content
+
+    def test_custom_agents_in_active_list(self, tmp_path: Path) -> None:
+        """Step 3: custom agents are added to the active agent list."""
+        orch, _, _ = _build_e2e(tmp_path)
+        orch.start_session()
+        decomp = orch.decompose_plan()
+
+        # Custom agents should appear in phase assignments
+        # Since they're not in AGENT_PHASE_MAP, they should be
+        # available for ALL phases
+        for phase in decomp.phases:
+            agent_names = phase.assigned_agents
+            assert "signal-analyst" in agent_names, (
+                f"signal-analyst missing from {phase.phase_id}: {agent_names}"
+            )
+            assert "calibration-expert" in agent_names
+            assert "anomaly-researcher" in agent_names
+
+    def test_contracts_generated_for_custom_agents(self, tmp_path: Path) -> None:
+        """Step 4: agent contracts are generated for custom agents."""
+        orch, _, _ = _build_e2e(tmp_path)
+        orch.start_session()
+        decomp = orch.decompose_plan()
+
+        custom_contracts = [
+            c for c in decomp.agent_contracts
+            if c.agent_name in ("signal-analyst", "calibration-expert", "anomaly-researcher")
+        ]
+        # Should have contracts across multiple phases
+        assert len(custom_contracts) > 0
+
+        # Each custom agent should have at least one contract
+        contract_agents = {c.agent_name for c in custom_contracts}
+        assert "signal-analyst" in contract_agents
+        assert "calibration-expert" in contract_agents
+        assert "anomaly-researcher" in contract_agents
+
+    def test_roster_prompt_includes_custom_agents(self, tmp_path: Path) -> None:
+        """Step 5: the lead prompt roster section lists custom agents."""
+        orch, _, _ = _build_e2e(tmp_path)
+        orch.start_session()
+        orch.decompose_plan()
+
+        roster = orch._prompt_roster()
+        assert "Core Agents" in roster
+        assert "Custom Agents" in roster
+        assert "signal-analyst" in roster
+        assert "calibration-expert" in roster
+        assert "anomaly-researcher" in roster
+
+    def test_lead_prompt_includes_custom_contracts(self, tmp_path: Path) -> None:
+        """Step 6: the full lead prompt references custom agent contracts."""
+        orch, _, _ = _build_e2e(tmp_path)
+        orch.start_session()
+        decomp = orch.decompose_plan()
+
+        phase = decomp.phases[0]
+        prompt = orch.build_lead_prompt(phase)
+
+        # Custom agents should appear in the prompt
+        assert "signal-analyst" in prompt
+        assert "calibration-expert" in prompt
+
+    def test_decisions_logged_for_custom_agents(self, tmp_path: Path) -> None:
+        """Step 7: DECISION_LOG entries are created for each custom agent."""
+        orch, comms, project_dir = _build_e2e(tmp_path)
+        orch.start_session()
+        orch.decompose_plan()
+
+        # Read comms log
+        log_dir = project_dir / "logs" / "comms"
+        events = []
+        for f in sorted(log_dir.glob("*.jsonl")):
+            for line in f.read_text(encoding="utf-8").strip().splitlines():
+                if line:
+                    events.append(json.loads(line))
+
+        decision_events = [e for e in events if e.get("event_type") == "decision"]
+        agent_creation_decisions = [
+            e for e in decision_events
+            if "custom agent" in e.get("title", "").lower()
+        ]
+
+        # Should have 3 creation decisions (one per custom agent)
+        assert len(agent_creation_decisions) == 3
+
+    def test_reuse_existing_custom_agents(self, tmp_path: Path) -> None:
+        """Step 8: existing custom agents are reused, not overwritten."""
+        orch, comms, project_dir = _build_e2e(tmp_path)
+
+        # Pre-create one custom agent with different content
+        custom_dir = project_dir / ".claude" / "agents" / "custom"
+        custom_dir.mkdir(parents=True, exist_ok=True)
+        existing = custom_dir / "signal-analyst.md"
+        existing.write_text("# Existing custom agent\nDo not overwrite!", encoding="utf-8")
+
+        orch.start_session()
+        orch.decompose_plan()
+
+        # Existing file should NOT be overwritten
+        assert existing.read_text() == "# Existing custom agent\nDo not overwrite!"
+
+        # Other two should be created
+        assert (custom_dir / "calibration-expert.md").exists()
+        assert (custom_dir / "anomaly-researcher.md").exists()
+
+    def test_full_pipeline_with_phase_advancement(self, tmp_path: Path) -> None:
+        """Step 9: full pipeline — decompose, advance through phase 1."""
+        orch, _, project_dir = _build_e2e(tmp_path)
+        orch.start_session()
+        decomp = orch.decompose_plan()
+
+        phase = orch.get_current_phase()
+        assert phase is not None
+        assert phase.phase_id == "phase_1"
+
+        # Custom agents should be in phase_1's assigned agents
+        assert "signal-analyst" in phase.assigned_agents
+
+        # Mark all subtasks complete
+        for st in phase.subtasks:
+            orch.mark_subtask_complete(phase.phase_id, st)
+
+        # Create required artifacts so gate passes
+        delivery = Path(orch._target.target_repo)
+        delivery.mkdir(parents=True, exist_ok=True)
+        (delivery / "reports").mkdir(parents=True, exist_ok=True)
+        (delivery / "reports" / "data_quality_report.md").write_text("ok")
+        (delivery / "reports" / "figures").mkdir(parents=True, exist_ok=True)
+        (delivery / "reports" / "figures" / "eda_summary.png").write_text("ok")
+        (delivery / "data").mkdir(parents=True, exist_ok=True)
+        (delivery / "data" / "processed").mkdir(parents=True, exist_ok=True)
+        (delivery / "data" / "processed" / "train.csv").write_text("ok")
+        # test_report needs tests/ dir or it writes "no tests found"
+        (delivery / "tests").mkdir(parents=True, exist_ok=True)
+
+        # Advance — should pass in full-auto mode
+        ev = orch.advance_phase("phase_1")
+        assert ev.decision.value in ("proceed", "hold"), f"Unexpected: {ev.decision}"

--- a/tests/unit/test_cli.py
+++ b/tests/unit/test_cli.py
@@ -469,6 +469,106 @@ class TestDraftCommand:
 
 
 # ---------------------------------------------------------------------------
+# draft prompt construction
+# ---------------------------------------------------------------------------
+
+
+class TestBuildDraftPrompt:
+    """Tests for _build_draft_prompt — the Plan Architect's prompt."""
+
+    def test_includes_role_and_team_setup(self) -> None:
+        from zo.cli import _build_draft_prompt
+
+        prompt = _build_draft_prompt(
+            project="test", plan_path=Path("/tmp/plan.md"),
+            doc_context="", description="test project",
+            data_paths=(), zo_root=Path("/tmp"),
+        )
+        assert "Plan Architect" in prompt
+        assert "TeamCreate" in prompt
+        assert "draft-test" in prompt
+
+    def test_data_scout_spawned_with_data_paths(self) -> None:
+        from zo.cli import _build_draft_prompt
+
+        prompt = _build_draft_prompt(
+            project="test", plan_path=Path("/tmp/plan.md"),
+            doc_context="", description="",
+            data_paths=(Path("/data/train.csv"), Path("/data/test.csv")),
+            zo_root=Path("/tmp"),
+        )
+        assert "data-scout" in prompt
+        assert "/data/train.csv" in prompt
+        assert "/data/test.csv" in prompt
+
+    def test_data_scout_not_spawned_without_data(self) -> None:
+        from zo.cli import _build_draft_prompt
+
+        prompt = _build_draft_prompt(
+            project="test", plan_path=Path("/tmp/plan.md"),
+            doc_context="", description="a project",
+            data_paths=(), zo_root=Path("/tmp"),
+        )
+        assert "data-scout" not in prompt
+        assert "No data paths were provided" in prompt
+
+    def test_research_scout_always_spawned(self) -> None:
+        from zo.cli import _build_draft_prompt
+
+        for data in ((), (Path("/data"),)):
+            prompt = _build_draft_prompt(
+                project="test", plan_path=Path("/tmp/plan.md"),
+                doc_context="", description="test",
+                data_paths=data, zo_root=Path("/tmp"),
+            )
+            assert "research-scout" in prompt
+
+    def test_doc_context_included(self) -> None:
+        from zo.cli import _build_draft_prompt
+
+        prompt = _build_draft_prompt(
+            project="test", plan_path=Path("/tmp/plan.md"),
+            doc_context="Summary of requirements docs",
+            description="", data_paths=(), zo_root=Path("/tmp"),
+        )
+        assert "Indexed Document Context" in prompt
+        assert "Summary of requirements docs" in prompt
+
+    def test_description_included(self) -> None:
+        from zo.cli import _build_draft_prompt
+
+        prompt = _build_draft_prompt(
+            project="test", plan_path=Path("/tmp/plan.md"),
+            doc_context="", description="CNN for CIFAR-10",
+            data_paths=(), zo_root=Path("/tmp"),
+        )
+        assert "CNN for CIFAR-10" in prompt
+
+    def test_build_command_in_completion(self) -> None:
+        from zo.cli import _build_draft_prompt
+
+        prompt = _build_draft_prompt(
+            project="my-proj", plan_path=Path("/tmp/plan.md"),
+            doc_context="", description="test",
+            data_paths=(), zo_root=Path("/tmp"),
+        )
+        assert "zo build plans/my-proj.md" in prompt
+
+    def test_conversation_flow_steps(self) -> None:
+        from zo.cli import _build_draft_prompt
+
+        prompt = _build_draft_prompt(
+            project="test", plan_path=Path("/tmp/plan.md"),
+            doc_context="", description="test",
+            data_paths=(), zo_root=Path("/tmp"),
+        )
+        assert "objective" in prompt.lower()
+        assert "oracle" in prompt.lower() or "metric" in prompt.lower()
+        assert "constraint" in prompt.lower()
+        assert "specs/plan.md" in prompt
+
+
+# ---------------------------------------------------------------------------
 # gate-mode mapping
 # ---------------------------------------------------------------------------
 

--- a/tests/unit/test_dynamic_agents.py
+++ b/tests/unit/test_dynamic_agents.py
@@ -1,0 +1,303 @@
+"""Unit tests for dynamic agent creation — plan parsing, phase assignment, and agent rendering."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from unittest.mock import MagicMock
+
+import pytest
+
+from zo.plan import AgentConfig, CustomAgentSpec, _parse_agents
+
+
+# ------------------------------------------------------------------ #
+# Plan parser — custom agent parsing
+# ------------------------------------------------------------------ #
+
+
+class TestParseAgentsCustom:
+    def test_parses_active_only(self) -> None:
+        body = "**Active agents:** data-engineer, model-builder, oracle-qa\n"
+        config = _parse_agents(body)
+        assert config.active_agents == ["data-engineer", "model-builder", "oracle-qa"]
+        assert config.custom_agents == []
+
+    def test_parses_custom_agents(self) -> None:
+        body = (
+            "**Active agents:** data-engineer, model-builder\n\n"
+            "**Custom agents:**\n"
+            "- signal-analyst: Sonnet — Signal processing for vibration data\n"
+            "- calibration-expert: Opus — Sensor calibration specialist\n"
+        )
+        config = _parse_agents(body)
+        assert config.active_agents == ["data-engineer", "model-builder"]
+        assert len(config.custom_agents) == 2
+        assert config.custom_agents[0].name == "signal-analyst"
+        assert config.custom_agents[0].model == "claude-sonnet-4-6"
+        assert "Signal processing" in config.custom_agents[0].role
+        assert config.custom_agents[1].name == "calibration-expert"
+        assert config.custom_agents[1].model == "claude-opus-4-6"
+
+    def test_parses_haiku_model(self) -> None:
+        body = (
+            "**Active agents:** data-engineer\n\n"
+            "**Custom agents:**\n"
+            "- log-formatter: Haiku — Formats structured logs\n"
+        )
+        config = _parse_agents(body)
+        assert config.custom_agents[0].model == "claude-haiku-4-5-20251001"
+
+    def test_empty_custom_block(self) -> None:
+        body = "**Active agents:** data-engineer\n"
+        config = _parse_agents(body)
+        assert config.custom_agents == []
+
+    def test_custom_with_em_dash(self) -> None:
+        body = (
+            "**Active agents:** data-engineer\n\n"
+            "**Custom agents:**\n"
+            "- nlp-expert: Sonnet \u2014 NLP specialist for text preprocessing\n"
+        )
+        config = _parse_agents(body)
+        assert len(config.custom_agents) == 1
+        assert config.custom_agents[0].name == "nlp-expert"
+
+    def test_custom_with_en_dash(self) -> None:
+        body = (
+            "**Active agents:** data-engineer\n\n"
+            "**Custom agents:**\n"
+            "- geo-analyst: Sonnet \u2013 Geospatial data specialist\n"
+        )
+        config = _parse_agents(body)
+        assert len(config.custom_agents) == 1
+
+
+# ------------------------------------------------------------------ #
+# Phase assignment — custom agents get all phases
+# ------------------------------------------------------------------ #
+
+
+class TestAgentsForPhaseCustom:
+    def test_known_agent_filtered_by_phase(self) -> None:
+        from zo.orchestrator import Orchestrator
+
+        result = Orchestrator._agents_for_phase(
+            "phase_1", ["data-engineer", "model-builder"],
+        )
+        assert "data-engineer" in result
+        assert "model-builder" not in result  # model-builder is phase_3+
+
+    def test_unknown_agent_available_all_phases(self) -> None:
+        from zo.orchestrator import Orchestrator
+
+        result = Orchestrator._agents_for_phase(
+            "phase_1", ["data-engineer", "signal-analyst"],
+        )
+        assert "data-engineer" in result
+        assert "signal-analyst" in result  # custom — available everywhere
+
+    def test_custom_agent_in_late_phase(self) -> None:
+        from zo.orchestrator import Orchestrator
+
+        result = Orchestrator._agents_for_phase(
+            "phase_5", ["signal-analyst", "calibration-expert"],
+        )
+        assert "signal-analyst" in result
+        assert "calibration-expert" in result
+
+
+# ------------------------------------------------------------------ #
+# Agent rendering
+# ------------------------------------------------------------------ #
+
+
+class TestRenderCustomAgent:
+    def test_renders_valid_markdown(self) -> None:
+        from zo.orchestrator import _render_custom_agent
+
+        spec = CustomAgentSpec(
+            name="signal-analyst",
+            model="claude-sonnet-4-6",
+            role="Signal processing specialist for vibration and acoustic data.",
+        )
+        md = _render_custom_agent(spec)
+        assert "---" in md
+        assert "name: Signal Analyst" in md
+        assert "model: claude-sonnet-4-6" in md
+        assert "tier: phase-in" in md
+        assert "Signal processing specialist" in md
+        assert "## Coordination Rules" in md
+        assert "## Validation Checklist" in md
+
+    def test_renders_with_hyphenated_name(self) -> None:
+        from zo.orchestrator import _render_custom_agent
+
+        spec = CustomAgentSpec(name="nlp-text-expert", role="NLP expert.")
+        md = _render_custom_agent(spec)
+        assert "name: Nlp Text Expert" in md
+
+
+# ------------------------------------------------------------------ #
+# Ensure custom agents — file creation
+# ------------------------------------------------------------------ #
+
+
+class TestEnsureCustomAgents:
+    def test_creates_custom_agent_files(self, tmp_path: Path) -> None:
+        from zo.orchestrator import Orchestrator
+
+        # Set up minimal orchestrator with mocks
+        plan = MagicMock()
+        plan.agents = AgentConfig(
+            active_agents=["data-engineer"],
+            custom_agents=[
+                CustomAgentSpec(
+                    name="signal-analyst",
+                    model="claude-sonnet-4-6",
+                    role="Signal processing specialist.",
+                ),
+            ],
+        )
+        plan.workflow = None
+        plan.objective = "test"
+        plan.source_path = None
+        plan.constraints = ""
+
+        comms = MagicMock()
+        memory = MagicMock()
+        target = MagicMock()
+        semantic = MagicMock()
+
+        orch = Orchestrator(
+            plan=plan, target=target, memory=memory,
+            comms=comms, semantic=semantic,
+            zo_root=tmp_path, gate_mode=MagicMock(),
+        )
+
+        # Create the agents dir structure
+        agents_dir = tmp_path / ".claude" / "agents"
+        agents_dir.mkdir(parents=True)
+
+        orch._ensure_custom_agents()
+
+        custom_dir = agents_dir / "custom"
+        assert custom_dir.is_dir()
+        agent_file = custom_dir / "signal-analyst.md"
+        assert agent_file.exists()
+        content = agent_file.read_text()
+        assert "Signal Analyst" in content
+        assert "Signal processing specialist" in content
+
+        # Verify decision was logged
+        comms.log_decision.assert_called_once()
+
+    def test_skips_existing_custom_agent(self, tmp_path: Path) -> None:
+        from zo.orchestrator import Orchestrator
+
+        plan = MagicMock()
+        plan.agents = AgentConfig(
+            active_agents=[],
+            custom_agents=[
+                CustomAgentSpec(name="signal-analyst", role="existing"),
+            ],
+        )
+        plan.objective = "test"
+        plan.source_path = None
+        plan.constraints = ""
+
+        comms = MagicMock()
+        orch = Orchestrator(
+            plan=plan, target=MagicMock(), memory=MagicMock(),
+            comms=comms, semantic=MagicMock(),
+            zo_root=tmp_path, gate_mode=MagicMock(),
+        )
+
+        # Pre-create the file
+        custom_dir = tmp_path / ".claude" / "agents" / "custom"
+        custom_dir.mkdir(parents=True)
+        (custom_dir / "signal-analyst.md").write_text("existing content")
+
+        orch._ensure_custom_agents()
+
+        # Should NOT overwrite — should log reuse instead
+        comms.log_decision.assert_not_called()
+        comms.log_checkpoint.assert_called_once()
+        assert (custom_dir / "signal-analyst.md").read_text() == "existing content"
+
+    def test_no_custom_agents_is_noop(self, tmp_path: Path) -> None:
+        from zo.orchestrator import Orchestrator
+
+        plan = MagicMock()
+        plan.agents = AgentConfig(active_agents=["data-engineer"])
+        plan.objective = "test"
+        plan.source_path = None
+        plan.constraints = ""
+
+        comms = MagicMock()
+        orch = Orchestrator(
+            plan=plan, target=MagicMock(), memory=MagicMock(),
+            comms=comms, semantic=MagicMock(),
+            zo_root=tmp_path, gate_mode=MagicMock(),
+        )
+
+        orch._ensure_custom_agents()
+        comms.log_decision.assert_not_called()
+
+
+# ------------------------------------------------------------------ #
+# Prompt roster — includes custom agents
+# ------------------------------------------------------------------ #
+
+
+class TestPromptRosterCustom:
+    def test_roster_includes_custom_agents(self, tmp_path: Path) -> None:
+        from zo.orchestrator import Orchestrator
+
+        agents_dir = tmp_path / ".claude" / "agents"
+        agents_dir.mkdir(parents=True)
+        (agents_dir / "data-engineer.md").write_text("core agent")
+
+        custom_dir = agents_dir / "custom"
+        custom_dir.mkdir()
+        (custom_dir / "signal-analyst.md").write_text("custom agent")
+        (custom_dir / "README.md").write_text("readme")
+
+        plan = MagicMock()
+        plan.agents = None
+        plan.objective = "test"
+        plan.source_path = None
+        plan.constraints = ""
+        orch = Orchestrator(
+            plan=plan, target=MagicMock(), memory=MagicMock(),
+            comms=MagicMock(), semantic=MagicMock(),
+            zo_root=tmp_path, gate_mode=MagicMock(),
+        )
+
+        roster = orch._prompt_roster()
+        assert "data-engineer" in roster
+        assert "signal-analyst" in roster
+        assert "Custom Agents" in roster
+        # README should be excluded
+        assert "readme" not in roster.lower().split("custom agents")[1].split("create")[0]
+
+    def test_roster_no_custom_dir(self, tmp_path: Path) -> None:
+        from zo.orchestrator import Orchestrator
+
+        agents_dir = tmp_path / ".claude" / "agents"
+        agents_dir.mkdir(parents=True)
+        (agents_dir / "data-engineer.md").write_text("core agent")
+
+        plan = MagicMock()
+        plan.agents = None
+        plan.objective = "test"
+        plan.source_path = None
+        plan.constraints = ""
+        orch = Orchestrator(
+            plan=plan, target=MagicMock(), memory=MagicMock(),
+            comms=MagicMock(), semantic=MagicMock(),
+            zo_root=tmp_path, gate_mode=MagicMock(),
+        )
+
+        roster = orch._prompt_roster()
+        assert "data-engineer" in roster
+        assert "Custom Agents" not in roster


### PR DESCRIPTION
## Summary

- **Custom agents directory** — `.claude/agents/custom/` for project-specific specialists, separate from 19 core agents. Persists across projects for reuse.
- **Plan-defined creation** — plan.md `**Custom agents:**` block declares specialists (e.g. `signal-analyst: Sonnet — Signal processing for vibration data`). Orchestrator auto-creates `.md` files at build start.
- **Mid-build creation** — Lead orchestrator creates agents on the fly when discovering unplanned expertise gaps. Full-auto, logged to DECISION_LOG.
- **Phase assignment** — Custom agents (not in AGENT_PHASE_MAP) are available for ALL phases. The lead decides when to spawn them.
- **Roster discovery** — `_prompt_roster()` scans both core and custom/ directories, clearly labelling each section.
- **Not limited** — Custom agents can be any role: researchers, data scientists, signal processing experts, calibration engineers, testers, QA specialists.

## Test plan

- [x] 16 new unit tests (plan parsing, phase assignment, agent rendering, file creation, roster scanning)
- [x] 398 total tests pass, 7 skipped
- [x] Ruff clean
- [x] `validate-docs.sh` 10/10 passed, 0 warnings
- [ ] Manual: plan with `**Custom agents:**` block → `zo build` → verify `.md` files created in `custom/`
- [ ] Manual: verify lead orchestrator can create agents mid-build in `custom/` dir

🤖 Generated with [Claude Code](https://claude.com/claude-code)