### PR TITLE
feat(wrapper): auto-cleanup tmux agent window and session summary

### DIFF
--- a/memory/zo-platform/DECISION_LOG.md
+++ b/memory/zo-platform/DECISION_LOG.md
@@ -581,3 +581,13 @@ Append-only. Every orchestration decision with timestamp, rationale, and outcome
 **Rationale:** First live `zo init ivl-f5` run opened a blank Claude Code session — the TUI rendered but no prompt was submitted. The 3s wait was insufficient for Claude Code's cold start (loading extensions, hooks, CLAUDE.md, memory files). The paste-buffer arrived before the input field was ready, so the prompt was silently dropped. 8s covers observed cold start times (5-10s) with margin. This is the same tmux paste-buffer approach validated in PR-001, but the timing assumption was wrong.
 **Alternatives considered:** (1) Poll-based wait (check tmux pane content for ready indicator) — fragile, depends on TUI rendering internals. (2) Retry with double-paste — risks submitting the prompt twice if the first paste succeeded. (3) Increase fixed wait to 8s (chosen) — simple, covers the range, no double-paste risk.
 **Outcome:** PR #34. 476 tests pass, 7 skipped. Fix applied to both worktree and main repo `src/zo/wrapper.py`. PR-022 prior added.
+
+---
+
+## Decision: 2026-04-14T12:45:00Z
+**Type:** UX
+**Title:** Agent session auto-cleanup — kill tmux window, Haiku summary, return control
+**Decision:** Three changes to the post-session flow: (1) `_tmux_claude_running()` checks `#{pane_current_command}` to detect when Claude exits but the shell remains — replaces the previous check that only tested pane existence. (2) `_kill_tmux_window()` closes the leftover shell window when Claude exits. (3) `_generate_session_summary()` asks Haiku for a 2-3 bullet summary of buffered events, printed in the invoking terminal before returning control.
+**Rationale:** After `zo init ivl-f5`, user typed `/exit` in the Claude session but: (a) the tmux agent window stayed open (shell still running), (b) the invoking terminal showed only elapsed-time ticks with no summary, (c) the monitoring loop never terminated. The user had to manually kill windows and got no feedback on what happened. The fix makes the end-of-session experience match the beginning: automatic, informative, clean.
+**Alternatives considered:** (1) Require user to kill the tmux window manually — poor UX, the whole point is automation. (2) Send SIGTERM to the pane — risks killing Claude mid-work if called too early. (3) Check `pane_current_command` for shell fallback (chosen) — safe, detects the natural /exit flow.
+**Outcome:** PR #34 updated. `_tmux_claude_running()`, `_kill_tmux_window()`, `_generate_session_summary()` added. `_wait_tmux()` uses two-condition check (pane exists AND Claude running). 476 tests pass.

--- a/memory/zo-platform/PRIORS.md
+++ b/memory/zo-platform/PRIORS.md
@@ -639,3 +639,39 @@ This separation fixed both failures in one pass: `[standard|adaptive]` renders v
 
 `time.sleep(8)` before `tmux load-buffer` + `paste-buffer`. `time.sleep(1)` before `send-keys Enter` (was 0.5s). If 8s proves insufficient on even slower machines, the user can manually paste the prompt from `logs/wrapper/{team}-prompt.txt` — it's always written before the tmux launch.
 
+---
+
+## PR-023: Tmux Agent Sessions Must Auto-Cleanup When Claude Exits
+**Source:** Session 016 (2026-04-14), first `zo init ivl-f5` run — post-session
+**Root cause category:** missing_rule
+**Failure:** After typing `/exit` in the Init Architect's Claude session: (a) the tmux agent window stayed open (shell still running after Claude exited), (b) the invoking terminal showed only elapsed-time ticks with no summary or next steps, (c) the `_wait_tmux` monitoring loop never terminated because `_tmux_pane_alive()` only checked pane existence, not whether Claude was the active process.
+
+### Rules
+
+1. **Check the running process, not just the pane.**
+   `tmux display-message -t PANE -p "#{pane_current_command}"` returns
+   the foreground command (e.g. `claude`, `node`). When Claude exits,
+   this falls back to the shell (`bash`, `zsh`). Checking pane existence
+   alone will hang forever because the shell never exits on its own.
+   - *Failure ref:* Monitoring loop ran indefinitely after user typed /exit.
+
+2. **Kill the agent window on session completion.**
+   The tmux window was created by ZO for the agent — ZO should clean it
+   up. Leaving orphan shell windows after every `zo init`/`zo draft`/
+   `zo build` accumulates clutter the user has to manually close.
+
+3. **Print a summary and next steps in the invoking terminal.**
+   The invoking terminal (where `zo init` was run) is the user's
+   home base. When the agent finishes, this terminal should show:
+   what happened (Haiku summary of events), what's next (the next
+   pipeline step), and return the shell prompt. Just printing
+   "Session completed" with no context wastes the buffered events.
+
+### Verified Solution
+
+Three additions to `wrapper.py` + `cli.py`:
+1. `_tmux_claude_running(pane_id)` — checks `#{pane_current_command}`, returns False if it's a shell
+2. `_kill_tmux_window(pane_id)` — kills the window containing the pane
+3. `_wait_tmux()` uses both conditions: pane exists AND Claude running; kills window on exit
+4. `_generate_session_summary(events, team_name)` — Haiku 2-3 bullet summary printed post-completion
+

--- a/memory/zo-platform/STATE.md
+++ b/memory/zo-platform/STATE.md
@@ -91,6 +91,7 @@ ZO v1.0.2-pre — **CIFAR-10 done, IVL F5 setup tightened + per-project agent ad
 - [x] v1.0.2-pre: Per-project agent adaptations — `**Agent adaptations:**` block in plan.md; Plan Architect populates during draft based on scout findings; orchestrator injects into spawn prompts at build time; works for both core (xai-agent, domain-evaluator) and custom agents; appended not replaced (agent `.md` files stay reusable)
 - [x] v1.0.2-pre: Branded `zo --help` — `ZoGroup`/`ZoCommand` override `get_help()` to render a Rich-formatted banner (orbital mark ◎ + `ZERO OPERATORS` + version in brand amber) with sectioned headers (USAGE, QUICK START, COMMANDS, OPTIONS) and an init→draft→preflight→build→continue quick-start sequence; propagates to every subcommand and nested group automatically via `command_class`/`group_class`
 - [x] v1.0.2-pre: Tmux TUI paste timing fix — increased wait from 3s to 8s, Enter delay from 0.5s to 1s; fixes blank-session bug where zo init/draft/build launched Claude but never submitted the prompt on cold starts
+- [x] v1.0.2-pre: Agent session auto-cleanup — `_tmux_claude_running()` detects Claude exit via `pane_current_command`, `_kill_tmux_window()` closes leftover shell, `_generate_session_summary()` prints Haiku bullet summary before returning control to terminal
 
 ## Known Issues
 

--- a/src/zo/cli.py
+++ b/src/zo/cli.py
@@ -396,6 +396,29 @@ def _ask_additional_instructions(gate_mode: str) -> str:
     return user_input
 
 
+def _generate_session_summary(events: list[str], team_name: str) -> None:
+    """Ask Haiku for a 2-3 line session summary and print next steps."""
+    events_text = "\n".join(events[-30:])
+    try:
+        result = __import__("subprocess").run(
+            ["claude", "-p", "--model", "haiku",
+             f"Summarise this agent session in 2-3 short bullet points "
+             f"(what was accomplished, what's ready). No preamble, just "
+             f"bullets:\n\n{events_text}"],
+            capture_output=True, text=True, timeout=20,
+        )
+        summary = result.stdout.strip()
+        if summary:
+            console.print(f"\n[{_AMBER}]Session summary:[/]")
+            for line in summary.split("\n"):
+                line = line.strip()
+                if line:
+                    console.print(f"  {line}")
+    except Exception:
+        pass  # Non-critical — skip if Haiku unavailable
+    console.print()
+
+
 def _launch_and_monitor(
     *,
     wrapper,  # noqa: ANN001
@@ -565,10 +588,15 @@ def _launch_and_monitor(
         project_name=project_name, delivery_repo=delivery_repo,
     )
 
+    console.print()
     if process.status == "completed":
-        console.print("[green bold]Session completed successfully.[/]")
+        console.print(f"[green bold]Session completed.[/]")
     else:
         console.print(f"[red bold]Session ended with status:[/] {process.status}")
+
+    # Generate a Haiku summary of the session from buffered events.
+    if _headline_buffer:
+        _generate_session_summary(_headline_buffer, team_name)
 
     if orchestrator:
         orchestrator.end_session()

--- a/src/zo/wrapper.py
+++ b/src/zo/wrapper.py
@@ -425,30 +425,41 @@ class LifecycleWrapper:
         timeout: float | None,
         on_status: Any | None,
     ) -> LeadProcess:
-        """Wait for the tmux pane to close (session complete)."""
+        """Wait for Claude to exit in the tmux pane, then clean up.
+
+        Checks two conditions each poll cycle:
+        1. Pane disappeared entirely (user killed the window) → done.
+        2. Pane alive but Claude is no longer the foreground process
+           (user typed /exit, Claude exited) → kill the window → done.
+        """
         start_time = time.monotonic()
         process = process.model_copy(update={"status": AgentStatus.RUNNING})
+        pane_id = process.tmux_pane_id or ""
 
         while True:
             self._check_gate_mode_change()
             self._maybe_open_training_pane()
 
-            if not self._tmux_pane_alive(process.tmux_pane_id or ""):
+            pane_exists = self._tmux_pane_alive(pane_id)
+            claude_running = pane_exists and self._tmux_claude_running(pane_id)
+
+            if not pane_exists or not claude_running:
+                # Claude exited — clean up the leftover shell window.
+                if pane_exists:
+                    self._kill_tmux_window(pane_id)
                 process = process.model_copy(update={
                     "exit_code": 0, "completed_at": datetime.now(UTC),
                     "status": AgentStatus.COMPLETED,
                 })
                 self._comms.log_checkpoint(
                     agent="wrapper", phase="lifecycle", subtask="completion",
-                    progress="Lead session tmux pane closed",
+                    progress="Lead session completed, agent window closed",
                 )
                 return process
 
             if on_status:
                 team_status = self.monitor_team(process.team_name)
-                pane_snapshot = self._capture_tmux_pane(
-                    process.tmux_pane_id or "", lines=5,
-                )
+                pane_snapshot = self._capture_tmux_pane(pane_id, lines=5)
                 on_status(team_status, pane_snapshot)
 
             if timeout and (time.monotonic() - start_time) > timeout:
@@ -629,6 +640,46 @@ class LifecycleWrapper:
         except (FileNotFoundError, subprocess.TimeoutExpired):
             return False
         return pane_id in result.stdout.splitlines()
+
+    @staticmethod
+    def _tmux_claude_running(pane_id: str) -> bool:
+        """Check if Claude Code is the active process in a tmux pane.
+
+        When the user types /exit in Claude Code, the process exits but
+        the tmux pane's shell remains.  ``_tmux_pane_alive`` would still
+        return True.  This method checks the *current command* running
+        in the pane — if it's ``claude``, the session is active; if it
+        has fallen back to the shell (``bash``, ``zsh``, ``fish``, etc.),
+        Claude has exited.
+        """
+        if not pane_id:
+            return False
+        try:
+            result = subprocess.run(
+                ["tmux", "display-message", "-t", pane_id,
+                 "-p", "#{pane_current_command}"],
+                capture_output=True, text=True, timeout=5,
+            )
+        except (FileNotFoundError, subprocess.TimeoutExpired):
+            return False
+        if result.returncode != 0:
+            return False
+        cmd = result.stdout.strip().lower()
+        # Claude Code runs as "claude" or "node" (the underlying runtime).
+        # When it exits, the pane falls back to the user's shell.
+        shells = {"bash", "zsh", "fish", "sh", "dash", "tcsh", "csh"}
+        return cmd not in shells and len(cmd) > 0
+
+    @staticmethod
+    def _kill_tmux_window(pane_id: str) -> None:
+        """Kill the tmux window containing a pane (cleanup after exit)."""
+        if not pane_id:
+            return
+        with contextlib.suppress(FileNotFoundError, subprocess.TimeoutExpired):
+            subprocess.run(
+                ["tmux", "kill-window", "-t", pane_id],
+                capture_output=True, timeout=5,
+            )
 
     @staticmethod
     def _is_in_tmux() -> bool:


### PR DESCRIPTION
## Summary
- Detects Claude exit via `#{pane_current_command}` instead of just pane existence — fixes monitoring loop hanging forever after `/exit`
- Auto-kills the orphan tmux agent window when Claude exits
- Generates a Haiku bullet summary of session events in the invoking terminal
- Updates DECISION_LOG (session cleanup decision), PRIORS (PR-023), STATE.md

## Test plan
- [x] Run `zo init ivl-f5` → complete init → type `/exit` → verify: agent window closes, summary prints, terminal returns to prompt
- [x] Run `zo draft` → same cleanup behavior
- [x] Verify `zo build` still works (long-running sessions don't get killed prematurely)
- [x] 476 tests pass, validate-docs 10/10

🤖 Generated with [Claude Code](https://claude.com/claude-code)