### PR TITLE
fix(preflight): use report.valid not report.is_valid

### DIFF
--- a/src/zo/preflight.py
+++ b/src/zo/preflight.py
@@ -104,7 +104,7 @@ def _check_plan(plan_path: Path) -> CheckResult:
     try:
         plan = parse_plan(plan_path)
         report = validate_plan(plan)
-        if report.is_valid:
+        if report.valid:
             return CheckResult("Plan", True, "All 8 sections valid")
         issues = "; ".join(f"{i.field}: {i.message}" for i in report.issues[:3])
         return CheckResult("Plan", False, f"Validation failed: {issues}")


### PR DESCRIPTION
## Summary
- `ValidationReport` model field is `valid`, not `is_valid`
- One-line fix in `preflight.py` line 107
- Caused plan validation check to always throw AttributeError

## Test plan
- [ ] `zo preflight plans/prod-001.md` — plan check passes
- [ ] 476 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)