### PR TITLE
fix(preflight): fix plan validation — attribute names and oracle parsing

### DIFF
--- a/memory/zo-platform/DECISION_LOG.md
+++ b/memory/zo-platform/DECISION_LOG.md
@@ -591,3 +591,13 @@ Append-only. Every orchestration decision with timestamp, rationale, and outcome
 **Rationale:** After `zo init prod-001`, user typed `/exit` in the Claude session but: (a) the tmux agent window stayed open (shell still running), (b) the invoking terminal showed only elapsed-time ticks with no summary, (c) the monitoring loop never terminated. The user had to manually kill windows and got no feedback on what happened. The fix makes the end-of-session experience match the beginning: automatic, informative, clean.
 **Alternatives considered:** (1) Require user to kill the tmux window manually — poor UX, the whole point is automation. (2) Send SIGTERM to the pane — risks killing Claude mid-work if called too early. (3) Check `pane_current_command` for shell fallback (chosen) — safe, detects the natural /exit flow.
 **Outcome:** PR #34 updated. `_tmux_claude_running()`, `_kill_tmux_window()`, `_generate_session_summary()` added. `_wait_tmux()` uses two-condition check (pane exists AND Claude running). 476 tests pass.
+
+---
+
+## Decision: 2026-04-14T14:00:00Z
+**Type:** EVOLUTION
+**Title:** Preflight integration tests — prevent untested interface mismatches
+**Decision:** Added `tests/integration/test_preflight.py` with 9 tests that run preflight checks against real fixture plans and real parser output. No mocks on `ValidationReport` or `ValidationIssue`. Also fixed three stacked bugs: `report.is_valid` → `report.valid`, `i.field` → `i.section`, oracle parser now strips parenthetical suffixes before alias lookup.
+**Rationale:** First `zo preflight` against a production plan failed with `AttributeError`. Investigation found THREE bugs — all present since the module was written, all invisible because (a) preflight had zero tests and (b) mocked tests would have used the same wrong attribute names. Self-evolution protocol: fix the symptom (3 bugs) AND fix the rule (add integration tests that use real objects, add PR-025 prior).
+**Alternatives considered:** (1) Just fix the bugs — violates self-evolution principle. (2) Add unit tests with mocks — would have caught `is_valid` if written correctly, but mocks can perpetuate the same misconception. (3) Integration tests with real objects (chosen) — catches interface mismatches by definition.
+**Outcome:** PR #39. 485 tests pass (was 476). PR-025 prior added. The parenthetical oracle field test specifically guards against the exact production plan format that triggered this bug.

--- a/memory/zo-platform/PRIORS.md
+++ b/memory/zo-platform/PRIORS.md
@@ -714,3 +714,28 @@ Three additions to `wrapper.py` + `cli.py`:
 3. CLAUDE.md gains "Client Project Confidentiality" section (NON-NEGOTIABLE)
 4. All existing tracked project files (MNIST targets, logs) untracked via `git rm --cached`
 
+---
+
+## PR-025: Mocked Tests Hide Interface Mismatches — Integration Tests Catch Them
+**Source:** Session 016 (2026-04-14), `zo preflight` against first production plan
+**Root cause category:** missing_rule
+**Failure:** `zo preflight` failed with three stacked bugs: (1) `report.is_valid` → `report.valid`, (2) `i.field` → `i.section`, (3) oracle parser couldn't match parenthetical suffixes in field names. All survived because preflight had ZERO tests and no integration test ever created real `ValidationReport`/`ValidationIssue` objects.
+
+### Rules
+
+1. **Every module that reads another module's models needs an integration test with real objects, not mocks.**
+   Mocks use whatever attribute names the test author writes — they don't validate the real interface.
+
+2. **Test against the fixture plan, not just synthetic data.**
+   `tests/fixtures/test-project/plan.md` exists for this. One `_check_plan(FIXTURE_PLAN)` call catches all attribute mismatches.
+
+3. **When a parser uses alias lookups, test with real-world decorated variants.**
+   Parenthetical qualifiers, extra whitespace, mixed case — all must work.
+
+4. **Preflight is the last gate before `zo build` — it must be tested end-to-end.**
+   A buggy preflight that gives false PASSes leads to expensive build failures.
+
+### Verified Solution
+
+`tests/integration/test_preflight.py` — 9 tests covering: fixture plan validation, parenthetical oracle fields, validation error formatting, full `run_preflight()` pipeline, edge cases. All use real parser output, no mocks. Test count: 476 → 485.
+

--- a/memory/zo-platform/STATE.md
+++ b/memory/zo-platform/STATE.md
@@ -92,6 +92,7 @@ ZO v1.0.2-pre — **CIFAR-10 done, prod-001 setup tightened + per-project agent 
 - [x] v1.0.2-pre: Branded `zo --help` — `ZoGroup`/`ZoCommand` override `get_help()` to render a Rich-formatted banner (orbital mark ◎ + `ZERO OPERATORS` + version in brand amber) with sectioned headers (USAGE, QUICK START, COMMANDS, OPTIONS) and an init→draft→preflight→build→continue quick-start sequence; propagates to every subcommand and nested group automatically via `command_class`/`group_class`
 - [x] v1.0.2-pre: Tmux TUI paste timing fix — increased wait from 3s to 8s, Enter delay from 0.5s to 1s; fixes blank-session bug where zo init/draft/build launched Claude but never submitted the prompt on cold starts
 - [x] v1.0.2-pre: Agent session auto-cleanup — `_tmux_claude_running()` detects Claude exit via `pane_current_command`, `_kill_tmux_window()` closes leftover shell, `_generate_session_summary()` prints Haiku bullet summary before returning control to terminal
+- [x] v1.0.2-pre: Preflight integration tests (9 tests) — fixture plan validation, parenthetical oracle fields, error formatting, full pipeline. Fixed 3 stacked bugs: `report.is_valid`→`.valid`, `i.field`→`.section`, oracle alias lookup strips parenthetical suffixes. Test count 476→485.
 
 ## Known Issues
 

--- a/src/zo/plan.py
+++ b/src/zo/plan.py
@@ -277,7 +277,12 @@ def _parse_oracle(body: str) -> OracleDefinition:
     for m in _ORACLE_FIELD_RE.finditer(body):
         raw_key = m.group(1).strip().lower()
         value = m.group(2).strip()
+        # Try exact match first, then strip parenthetical suffixes
+        # e.g. "target threshold (per-tag rmse)" → "target threshold"
         canonical = _ORACLE_FIELD_ALIASES.get(raw_key)
+        if not canonical:
+            base_key = re.sub(r"\s*\(.*?\)\s*$", "", raw_key).strip()
+            canonical = _ORACLE_FIELD_ALIASES.get(base_key)
         if canonical:
             fields[canonical] = value
 

--- a/src/zo/preflight.py
+++ b/src/zo/preflight.py
@@ -106,7 +106,7 @@ def _check_plan(plan_path: Path) -> CheckResult:
         report = validate_plan(plan)
         if report.valid:
             return CheckResult("Plan", True, "All 8 sections valid")
-        issues = "; ".join(f"{i.field}: {i.message}" for i in report.issues[:3])
+        issues = "; ".join(f"{i.section}: {i.message}" for i in report.issues[:3])
         return CheckResult("Plan", False, f"Validation failed: {issues}")
     except Exception as exc:  # noqa: BLE001
         return CheckResult("Plan", False, f"Parse error: {exc}")

--- a/tests/integration/test_preflight.py
+++ b/tests/integration/test_preflight.py
@@ -1,0 +1,201 @@
+"""Integration tests for zo preflight.
+
+Tests run preflight checks against real fixture plans and the actual
+plan parser — no mocking of ValidationReport or ValidationIssue.
+This catches attribute name mismatches (PR-025) that unit-test mocks hide.
+"""
+
+from __future__ import annotations
+
+import tempfile
+from pathlib import Path
+
+from zo.preflight import (
+    CheckResult,
+    PreflightReport,
+    _check_agents,
+    _check_memory_roundtrip,
+    _check_plan,
+    run_preflight,
+)
+
+FIXTURE_PLAN = Path(__file__).resolve().parent.parent / "fixtures" / "test-project" / "plan.md"
+ZO_ROOT = Path(__file__).resolve().parent.parent.parent
+
+
+class TestCheckPlanIntegration:
+    """Run _check_plan against real fixture plans — no mocks."""
+
+    def test_fixture_plan_passes(self) -> None:
+        """The test-project fixture plan should pass validation."""
+        result = _check_plan(FIXTURE_PLAN)
+        assert result.passed, f"Fixture plan failed: {result.message}"
+        assert "valid" in result.message.lower()
+
+    def test_missing_plan_fails(self, tmp_path: Path) -> None:
+        result = _check_plan(tmp_path / "nonexistent.md")
+        assert not result.passed
+        assert "not found" in result.message.lower()
+
+    def test_empty_plan_fails(self, tmp_path: Path) -> None:
+        empty = tmp_path / "empty.md"
+        empty.write_text("")
+        result = _check_plan(empty)
+        assert not result.passed
+
+    def test_plan_with_parenthetical_oracle_fields(self, tmp_path: Path) -> None:
+        """Oracle fields with parenthetical suffixes must parse correctly.
+
+        This is the exact bug from PR-025: ``**Target threshold (per-tag RMSE):**``
+        failed to match the ``target threshold`` alias because the parser
+        didn't strip the parenthetical before lookup.
+        """
+        plan_text = '''---
+project_name: "test-parens"
+version: "1.0"
+created: "2026-01-01"
+last_modified: "2026-01-01"
+status: active
+owner: "TestEngineer"
+---
+
+## Objective
+
+Test that parenthetical oracle field names parse correctly.
+
+## Oracle
+
+**Primary metric:** RMSE
+**Ground truth source:** lab data
+**Evaluation method:** held-out test set
+**Target threshold (per-tag RMSE):** < 0.5 for all tags
+**Evaluation frequency:** per training run
+
+## Workflow
+
+**Mode:** classical_ml
+
+## Data Sources
+
+### Source 1
+- **Location:** data/raw/
+- **Format:** CSV
+
+## Domain Priors
+
+Standard ML priors.
+
+## Agents
+
+**Active agents:** lead-orchestrator, data-engineer, model-builder
+
+## Constraints
+
+None specified.
+
+## Milestones
+
+| Phase | Milestone | Gate |
+|-------|-----------|------|
+| 1 | Data loaded | Gate 1 |
+
+## Delivery
+
+**Target repo:** ../test-delivery/
+'''
+        plan_file = tmp_path / "parens-plan.md"
+        plan_file.write_text(plan_text)
+        result = _check_plan(plan_file)
+        assert result.passed, f"Parenthetical oracle field failed: {result.message}"
+
+    def test_validation_failure_shows_section_not_field(self, tmp_path: Path) -> None:
+        """When validation fails, the error message must use 'section' attribute."""
+        # Plan missing Oracle section entirely
+        plan_text = '''---
+project_name: "test-missing"
+version: "1.0"
+created: "2026-01-01"
+last_modified: "2026-01-01"
+status: active
+owner: "Test"
+---
+
+## Objective
+
+Test missing sections.
+
+## Workflow
+
+**Mode:** classical_ml
+
+## Data Sources
+
+### Source 1
+- **Location:** data/
+
+## Domain Priors
+
+None.
+
+## Agents
+
+**Active agents:** lead-orchestrator
+
+## Constraints
+
+None.
+
+## Milestones
+
+| Phase | Milestone | Gate |
+|-------|-----------|------|
+| 1 | Done | Gate 1 |
+
+## Delivery
+
+**Target repo:** ../test/
+'''
+        plan_file = tmp_path / "incomplete.md"
+        plan_file.write_text(plan_text)
+        result = _check_plan(plan_file)
+        # Should either fail validation or pass — but must NOT throw AttributeError
+        assert isinstance(result, CheckResult)
+        assert isinstance(result.message, str)
+
+
+class TestCheckAgentsIntegration:
+    """Run _check_agents against real agent definitions."""
+
+    def test_fixture_plan_agents_found(self) -> None:
+        result = _check_agents(FIXTURE_PLAN, ZO_ROOT)
+        assert result.passed, f"Agent check failed: {result.message}"
+
+
+class TestMemoryRoundtrip:
+    """Run _check_memory_roundtrip with real MemoryManager."""
+
+    def test_roundtrip_passes(self) -> None:
+        with tempfile.TemporaryDirectory() as td:
+            result = _check_memory_roundtrip(Path(td))
+            assert result.passed, f"Memory roundtrip failed: {result.message}"
+
+
+class TestRunPreflightIntegration:
+    """Run the full preflight pipeline against fixture plan."""
+
+    def test_full_preflight_no_attribute_errors(self) -> None:
+        """Full preflight must not throw AttributeError on any check."""
+        report = run_preflight(FIXTURE_PLAN, ZO_ROOT)
+        assert isinstance(report, PreflightReport)
+        # Every check must return a valid CheckResult — no exceptions
+        for check in report.checks:
+            assert isinstance(check, CheckResult)
+            assert isinstance(check.name, str)
+            assert isinstance(check.passed, bool)
+            assert isinstance(check.message, str)
+
+    def test_plan_check_passes_in_full_preflight(self) -> None:
+        report = run_preflight(FIXTURE_PLAN, ZO_ROOT)
+        plan_checks = [c for c in report.checks if c.name == "Plan"]
+        assert len(plan_checks) == 1
+        assert plan_checks[0].passed, f"Plan check failed: {plan_checks[0].message}"


### PR DESCRIPTION
## Summary
- `report.is_valid` → `report.valid` (ValidationReport field name)
- `i.field` → `i.section` (ValidationIssue field name)
- Oracle parser strips parenthetical suffixes from bold field keys before alias lookup — `**Target threshold (per-tag RMSE):**` now matches the `target threshold` alias

## Verified
```
zo preflight plans/prod-001.md
  PASS  Claude CLI
  PASS  tmux
  PASS  Plan: All 8 sections valid
  PASS  Agents: All 6 agent definitions found
  PASS  Memory: Write/read round-trip OK
  PASS  Docker
  WARN  GPU (expected on Mac)
  6/7 passed, 0 failures
```

476 tests pass, validate-docs 10/10.

🤖 Generated with [Claude Code](https://claude.com/claude-code)