### PR TITLE
feat(memory): portable project memory via .zo/ directory

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@
 <br/>
 
 [![Status](https://img.shields.io/badge/status-validated-F0C040?style=flat-square&labelColor=080808)](#status)
-[![Tests](https://img.shields.io/badge/tests-464_passing-F0C040?style=flat-square&labelColor=080808)](#status)
+[![Tests](https://img.shields.io/badge/tests-521_passing-F0C040?style=flat-square&labelColor=080808)](#status)
 [![Agents](https://img.shields.io/badge/agents-20_defined-F0C040?style=flat-square&labelColor=080808)](#agent-teams)
 [![E2E](https://img.shields.io/badge/MNIST-99%25_accuracy-F0C040?style=flat-square&labelColor=080808)](#e2e-validation)
 
@@ -103,9 +103,11 @@ Shows a brand panel, phase review with subtasks/agents/oracle criteria, and prom
 
 ```bash
 zo continue my-project
+zo continue --repo /path/to/delivery    # auto-detect project from .zo/config.yaml
+zo continue                              # auto-detect if cwd has .zo/config.yaml
 ```
 
-Finds `plans/{project}.md` and runs `zo build` on it. Shorthand for when you don't want to type the plan path.
+Finds `plans/{project}.md` and runs `zo build` on it. Shorthand for when you don't want to type the plan path. With `--repo`, reads project config from the delivery repo's `.zo/` directory. If cwd contains `.zo/config.yaml`, the project name is auto-detected.
 
 ### `zo draft` — Draft a plan with scout team
 
@@ -143,9 +145,20 @@ Runs local-only validation: Claude CLI, tmux, plan parsing, agent definitions, m
 
 ```bash
 zo status my-project
+zo status --repo /path/to/delivery    # read state from .zo/memory/
+zo status                              # auto-detect if cwd has .zo/config.yaml
 ```
 
-Displays the current `STATE.md`: active phase, blockers, next steps, agent statuses.
+Displays the current `STATE.md`: active phase, blockers, next steps, agent statuses. With `--repo`, reads state from the delivery repo's `.zo/memory/` directory.
+
+### `zo migrate` — Portable project memory
+
+```bash
+zo migrate my-project
+zo migrate my-project --repo /path/to/delivery --clean
+```
+
+Copies project state (memory, plan, config) into the delivery repo's `.zo/` directory, making the project portable across machines via `git pull`. Use `--clean` to remove legacy artifacts from the ZO repo after migration.
 
 ### `zo watch-training` — Live training dashboard
 
@@ -336,6 +349,9 @@ Adds **Phase 0: Literature Review** (prior art survey, baseline definition). Pha
 │  src/ models/ reports/ tests/ — zero ZO artifacts           │
 │  Isolation enforced via target.py zo_only_paths blocklist   │
 │                                                             │
+│  Optional: .zo/ directory for portable project memory       │
+│  (config, state, plans — travels with the repo via git)     │
+│                                                             │
 └─────────────────────────────────────────────────────────────┘
 ```
 
@@ -391,7 +407,7 @@ Over time, `PRIORS.md` accumulates domain knowledge. The same mistake never happ
 ```
 zero-operators/
 ├── src/zo/                     # Platform code (10 modules)
-│   ├── cli.py                  # CLI: zo build/continue/init/status/draft/gates
+│   ├── cli.py                  # CLI: zo build/continue/init/status/draft/gates/migrate
 │   ├── draft.py                # Conversational plan generation (with or without source docs)
 │   ├── plan.py                 # Plan parser and validator (8 sections)
 │   ├── target.py               # Target file parser, isolation enforcer

--- a/docs/COMMANDS.md
+++ b/docs/COMMANDS.md
@@ -6,6 +6,8 @@ Zero Operators provides 24 slash commands for Claude Code, covering the full pro
 
 All commands are defined in `.claude/commands/` and invoked as `/category/command` in a Claude Code session.
 
+The `zo` CLI provides 10 terminal commands: `build`, `continue`, `draft`, `init`, `status`, `preflight`, `gates set`, `watch-training`, and `migrate`.
+
 ---
 
 ## CLI Commands
@@ -25,8 +27,12 @@ zo build plans/project.md [--gate-mode supervised|auto|full-auto] [--no-tmux]
 Resume a paused project. Shorthand for `zo build` with an existing plan -- finds the plan by project name and picks up from the current phase.
 
 ```
-zo continue project-name [--gate-mode supervised|auto|full-auto]
+zo continue [project-name] [--repo PATH] [--gate-mode supervised|auto|full-auto]
 ```
+
+**Options:**
+- `project-name` — optional if cwd contains `.zo/config.yaml` (auto-detected)
+- `--repo PATH` — path to delivery repo (overrides target file lookup)
 
 ### zo draft
 
@@ -99,8 +105,24 @@ zo init my-project --reset --yes     # no confirmation (for scripts)
 Show the current project status by reading `STATE.md`. Displays phase, blockers, recent activity, and next steps.
 
 ```
-zo status project-name
+zo status [project-name] [--repo PATH]
 ```
+
+**Options:**
+- `project-name` — optional if cwd contains `.zo/config.yaml` (auto-detected)
+- `--repo PATH` — path to delivery repo (reads state from `.zo/memory/`)
+
+### zo migrate
+
+Migrate project state from ZO repo to delivery repo `.zo/` directory.
+
+**Usage:** `zo migrate <project_name> [--repo PATH] [--clean]`
+
+**Options:**
+- `--repo PATH` — Path to delivery repo. If omitted, resolved from `targets/{project}.target.md`
+- `--clean` — Remove legacy artifacts from ZO repo after migration
+
+Copies memory (STATE.md, DECISION_LOG, PRIORS, sessions), plan, and target config into the delivery repo's `.zo/` directory, making the project portable across machines via git.
 
 ### zo preflight
 

--- a/memory/zo-platform/DECISION_LOG.md
+++ b/memory/zo-platform/DECISION_LOG.md
@@ -631,3 +631,13 @@ Append-only. Every orchestration decision with timestamp, rationale, and outcome
 **Rationale:** Three specialist reviews of the same prod-001 Phase 1 pipeline found non-overlapping issues: domain specialist found missing flow transmitter exclusions; ML specialist found trend slope inconsistency and test gaps; data scientist found detection limit handling issues and sample-to-feature ratios. No single reviewer would have caught all issues.
 **Alternatives considered:** (1) Single comprehensive review — misses domain-specific blind spots. (2) Automated-only checks — can't reason about process chemistry or ML methodology. (3) Multi-persona reviews (validated) — complementary coverage.
 **Outcome:** Applied to prod-001. The code-reviewer agent should support domain-specific review prompts when plan.md includes agent adaptations.
+
+---
+
+## Decision: 2026-04-15T10:00:00Z
+**Type:** ARCHITECTURE
+**Title:** Portable project memory — `.zo/` directory in delivery repo
+**Decision:** Move all project-specific state (STATE.md, DECISION_LOG, PRIORS, sessions, plans, project config) from the ZO repo (`memory/{project}/`, `plans/{project}.md`, `targets/{project}.target.md`) into the delivery repo under `.zo/`. ZO public repo retains only platform-level memory (`memory/zo-platform/`). Machine-specific paths (data_dir, GPU info, gate mode) stored in gitignored `.zo/local.yaml`; portable config in committed `.zo/config.yaml`.
+**Rationale:** User moved prod-001 from Mac Mini to GPU server. `zo status` failed — memory was gitignored in ZO (by design, for confidentiality) but that makes it non-portable. The delivery repo is private, committed to git, and already travels between machines via `git pull`. Putting project state there solves portability without compromising confidentiality. Separate `local.yaml` (gitignored) from `config.yaml` (committed) handles machine-specific vs portable config cleanly.
+**Alternatives considered:** (1) scp memory between machines — manual, error-prone, doesn't scale. (2) Track memory in ZO repo — violates confidentiality, ZO is public. (3) Separate private config repo — over-engineered, adds a third repo. (4) `.zo/` in delivery repo (chosen) — project state travels with the project, zero confidentiality risk.
+**Outcome:** New `project_config.py` module, MemoryManager `memory_root` override, scaffold `.zo/` dirs, CLI discovery layer (`_detect_delivery_repo`, `_load_project_context`), `zo migrate` command, `zo continue --repo` enhancement. Backward compatible — legacy layout still works.

--- a/memory/zo-platform/PRIORS.md
+++ b/memory/zo-platform/PRIORS.md
@@ -786,3 +786,31 @@ Switch `align.py` from `filter_allowed_tags()` to `filter_excluded_tags()`. Mark
 ### Verified Solution
 
 3 specialist reviews → 40+ domain validation tests. All findings addressed in code, config, and documentation. 297 tests passing.
+
+---
+
+## PR-028: Project Memory Must Live in the Delivery Repo, Not the Platform Repo
+**Source:** Session 018 (2026-04-15), prod-001 Mac Mini → GPU server transfer
+**Root cause category:** missing_rule
+**Failure:** User moved prod-001 from Mac Mini to GPU server. `zo status prod-001` failed with "No STATE.md found" because `memory/{project}/` is gitignored in the ZO public repo. All project state (STATE.md, DECISION_LOG, PRIORS, sessions, plans) was trapped on the original machine. The only recovery option was manual `scp`.
+
+### Rules
+
+1. **Project memory belongs in the delivery repo, not the platform repo.**
+   The delivery repo is private (client-specific) and committed to git. `git pull` on a new machine brings code AND state. The ZO public repo should contain zero project-specific artifacts — not even gitignored ones, since gitignored files don't transfer.
+   - *Failure ref:* `zo status` on GPU server found nothing. Memory existed only on Mac Mini.
+
+2. **Use a `.zo/` directory in the delivery repo for all project state.**
+   `.zo/config.yaml` (portable project config, committed), `.zo/local.yaml` (machine-specific paths, gitignored), `.zo/memory/` (STATE.md, DECISION_LOG, PRIORS, sessions), `.zo/plans/` (the project plan). This mirrors the `.git/`/`.claude/` convention.
+   - *Implementation:* scaffold.py adds `.zo/` dirs; CLI detects `.zo/config.yaml` as project marker.
+
+3. **Machine-specific paths must be separated from portable config.**
+   Data directories, GPU info, and gate mode vary per server. Store in `.zo/local.yaml` (gitignored). Portable config (project name, branch, agent dirs, workflow mode) goes in `.zo/config.yaml` (committed). On a new machine, `zo continue --repo` auto-detects environment and populates `local.yaml` conversationally.
+   - *Failure ref:* Target file stored absolute paths that were wrong on the new server.
+
+4. **Platform memory (zo-platform/) stays in the ZO repo — only generic learnings.**
+   ZO's own STATE.md, DECISION_LOG, PRIORS are platform infrastructure. Project-specific learnings go to the project's own PRIORS. Cross-reference with `**ZO Platform ref:** PR-XXX`.
+
+### Verified Solution
+
+New `.zo/` directory structure in delivery repos. `zo migrate` command for existing projects. `zo continue --repo` for reconnecting on new machines. `_detect_delivery_repo()` + `_load_project_context()` in CLI for dual-layout support (legacy + `.zo/`).

--- a/memory/zo-platform/STATE.md
+++ b/memory/zo-platform/STATE.md
@@ -106,7 +106,8 @@ ZO v1.0.2-pre — **CIFAR-10 done, prod-001 setup tightened + per-project agent 
 
 ## What's Next
 
-1. **prod-001 Phase 2** — baseline models on GPU server. Phase 1 data pipeline complete (denylist approach, 297 tests, full doc QA). Re-alignment with full tag set (~15k tags) needed on GPU.
+1. **Portable project memory** — `.zo/` directory in delivery repos. Project state (memory, plans, config) moves from ZO repo to delivery repo for cross-machine portability. `zo migrate` command, `zo continue --repo` enhancement, CLI discovery layer. IN PROGRESS (session-018).
+2. **prod-001 Phase 2** — baseline models on GPU server. Phase 1 data pipeline complete (denylist approach, 297 tests, full doc QA). Re-alignment with full tag set (~15k tags) needed on GPU. BLOCKED on portable memory (need to migrate prod-001 state to delivery repo first).
 2. Phase completion snapshots (C1) — capture context at phase boundaries for reports
 3. Domain evaluator refactor — make project-specific via plan.md domain priors
 4. ~~XAI + Domain Evaluator activation for prod-001 Phase 5~~ (UNBLOCKED by agent adaptations: Plan Architect proposes adaptations during draft; activation now means writing the adaptation block in plan.md)
@@ -125,10 +126,10 @@ ZO v1.0.2-pre — **CIFAR-10 done, prod-001 setup tightened + per-project agent 
 
 ## Session Metadata
 
-last_checkpoint: 2026-04-14T22:00:00Z
-last_session: session-017
-branch: claude/elated-hellman (worktree)
-test_count: 485 passed, 7 skipped (ZO); 297 passed (prod-001)
+last_checkpoint: 2026-04-15T12:00:00Z
+last_session: session-018
+branch: claude/lucid-swirles (worktree)
+test_count: 521 passed, 7 skipped (ZO); 297 passed (prod-001)
 lint: ruff clean (src/zo/)
 validation: scripts/validate-docs.sh 10/10 passed, 0 warnings
 prs: #22-#25 (UX), #26 (training dashboard + test reports), #27 (draft scout team), #28 (dynamic agents), #29-#33 (init-architect, branded help, website), #34 (tmux timing fix), #39 (preflight integration tests), #41 (notebook directory structure)

--- a/specs/architecture.md
+++ b/specs/architecture.md
@@ -193,7 +193,31 @@ Delivery repositories contain only project artifacts. They follow a standard str
 └── README.md
 ```
 
-No ZO-specific files appear in delivery repositories.
+No ZO-specific files appear in delivery repositories (except the optional `.zo/` directory below).
+
+### Portable Project Memory (.zo/ directory)
+
+Projects can optionally carry their own state in a `.zo/` directory at the delivery repo root. This makes projects portable across machines via `git pull` — no need to clone the ZO repo's `memory/` directory separately.
+
+```
+{project}/
+├── .zo/
+│   ├── config.yaml            ← portable project config (committed)
+│   ├── local.yaml             ← machine-specific paths and environment (gitignored)
+│   ├── memory/                ← STATE.md, DECISION_LOG.md, PRIORS.md, sessions/
+│   └── plans/                 ← the project plan.md
+├── src/
+├── ...
+```
+
+- `config.yaml` — project identity and settings (committed to git)
+- `local.yaml` — machine-specific paths (gitignored, regenerated per machine)
+- `memory/` — mirrors `memory/{project}/` from the ZO repo
+- `plans/` — the project plan file
+
+Platform memory (`memory/zo-platform/`) stays in the ZO repo. Only project-specific state moves to `.zo/`.
+
+Use `zo migrate <project>` to copy existing project state from the ZO repo into `.zo/`. Once migrated, `zo continue` and `zo status` auto-detect the project from `.zo/config.yaml` when run inside the delivery repo.
 
 ---
 

--- a/specs/memory.md
+++ b/specs/memory.md
@@ -339,6 +339,25 @@ Memory is **always per-project**. No shared state across projects.
 - Never copy, share, or reference DECISION_LOG across projects
 - PRIORS.md is domain-specific; different projects learn different facts
 
+### Portable Project Memory (.zo/ directory)
+
+Project memory can optionally live in the delivery repo under `.zo/memory/` instead of (or in addition to) the ZO repo's `memory/{project}/`. This makes projects portable across machines via `git pull`.
+
+**Layout in the delivery repo:**
+
+```
+{delivery-repo}/
+└── .zo/
+    ├── config.yaml            ← project config (committed)
+    ├── local.yaml             ← machine-specific paths (gitignored)
+    ├── memory/                ← STATE.md, DECISION_LOG.md, PRIORS.md, sessions/
+    └── plans/                 ← the project plan.md
+```
+
+- `zo migrate <project>` copies state from `memory/{project}/` into the delivery repo's `.zo/` directory
+- `zo continue` and `zo status` auto-detect the project from `.zo/config.yaml` when run inside the delivery repo
+- Platform memory (`memory/zo-platform/`) always stays in the ZO repo — only project-specific state is portable
+
 **Multi-project concurrency** (v2 trigger):
 
 - When running 3+ concurrent projects, implement SONA-style routing heuristics

--- a/specs/plan.md
+++ b/specs/plan.md
@@ -43,9 +43,9 @@ A clear, concise statement of what the project aims to achieve. This is not a va
 ```markdown
 ## Objective
 
-Build a soft sensor model that predicts real-time PO composition and purity
+Build a soft sensor model that predicts real-time product composition and purity
 from process sensor data (DCS tags), calibrated against lab measurements
-(SAP QM F5LB tag series). The model must operate in advisory mode (no DCS
+(SAP QM lab tag series). The model must operate in advisory mode (no DCS
 writes) and produce predictions with quantified uncertainty at 1-minute
 resolution.
 
@@ -61,7 +61,7 @@ The oracle is the hard, verifiable metric that determines success. Without this 
 ## Oracle
 
 **Primary metric:** RMSE on held-out lab samples
-**Ground truth source:** SAP QM F5LB tag series (frozen at project start, 81,906 records)
+**Ground truth source:** SAP QM lab tag series (frozen at project start, ~80,000 records)
 **Evaluation method:** Evaluate on temporally disjoint held-out set (last 6 months of data)
 **Target threshold:** RMSE ≤ 0.05 (Tier 1), RMSE ≤ 0.08 (Tier 2), RMSE ≤ 0.12 (Tier 3)
 **Evaluation frequency:** After every training iteration
@@ -127,7 +127,7 @@ Describes where data comes from, its format, and access requirements.
 - **Known issues:** Bypass period flags in _MA tags, turnaround gaps
 
 ### Source 2: Lab Measurements
-- **Location:** /data/raw/sap_qm_f5lb.csv
+- **Location:** /data/raw/lab_measurements.csv
 - **Format:** CSV, ~6-hour sampling cadence, 6 sample points per measurement
 - **Time range:** Same as Source 1
 - **Access:** Read-only

--- a/src/zo/cli.py
+++ b/src/zo/cli.py
@@ -15,13 +15,19 @@ Usage::
 from __future__ import annotations
 
 import uuid
+from dataclasses import dataclass
 from pathlib import Path
+from typing import TYPE_CHECKING
 
 import click
 from rich.console import Console
 from rich.table import Table
 
 from zo._orchestrator_models import GateMode
+
+if TYPE_CHECKING:
+    from zo.memory import MemoryManager
+    from zo.target import TargetConfig
 
 console = Console()
 
@@ -35,6 +41,178 @@ _VERSION = "1.0.1"
 def _zo_root() -> Path:
     """Derive the ZO repository root from the CLI package location."""
     return Path(__file__).resolve().parent.parent.parent
+
+
+# ---------------------------------------------------------------------------
+# Project discovery — find project state in .zo/ (new) or legacy layout
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class ProjectContext:
+    """Resolved paths for a project, whether from .zo/ or legacy layout."""
+
+    layout: str  # "zo-dir" or "legacy"
+    delivery_repo: Path
+    plan_path: Path
+    project_name: str
+    zo_root: Path
+
+    def make_memory(self) -> MemoryManager:
+        """Create a MemoryManager pointing at the right root."""
+        from zo.memory import MemoryManager
+
+        if self.layout == "zo-dir":
+            return MemoryManager(
+                project_dir=self.delivery_repo,
+                project_name=self.project_name,
+                memory_root=self.delivery_repo / ".zo" / "memory",
+            )
+        return MemoryManager(
+            project_dir=self.zo_root, project_name=self.project_name,
+        )
+
+    def make_target(self) -> TargetConfig:
+        """Load target config from .zo/config.yaml or legacy target file."""
+        if self.layout == "zo-dir":
+            from zo.project_config import load_project_config, to_target_config
+
+            pc = load_project_config(self.delivery_repo)
+            return to_target_config(pc, self.delivery_repo)
+
+        from zo.target import parse_target
+
+        target_path = self.zo_root / "targets" / f"{self.project_name}.target.md"
+        return parse_target(target_path)
+
+
+def _detect_delivery_repo(project_name: str | None = None) -> Path | None:
+    """Check cwd for a .zo/config.yaml marker. Return cwd if found."""
+    from zo.project_config import has_zo_dir, load_project_config
+
+    cwd = Path.cwd()
+    if not has_zo_dir(cwd):
+        return None
+
+    if project_name is not None:
+        try:
+            pc = load_project_config(cwd)
+            if pc.project_name != project_name:
+                return None
+        except Exception:  # noqa: BLE001
+            return None
+
+    return cwd
+
+
+def _load_project_context(
+    project_name: str,
+    delivery_repo: Path | None = None,
+) -> ProjectContext:
+    """Resolve project paths from .zo/ layout or legacy layout.
+
+    Precedence:
+    1. Explicit ``delivery_repo`` with .zo/config.yaml
+    2. cwd with .zo/config.yaml matching ``project_name``
+    3. Legacy layout (zo_root/targets/, zo_root/plans/, zo_root/memory/)
+    """
+    from zo.project_config import has_zo_dir, load_project_config
+
+    zo_root = _zo_root()
+
+    # Try explicit delivery repo
+    if delivery_repo is not None:
+        delivery_repo = Path(delivery_repo).resolve()
+        if has_zo_dir(delivery_repo):
+            pc = load_project_config(delivery_repo)
+            plan_path = delivery_repo / ".zo" / "plans" / f"{pc.project_name}.md"
+            return ProjectContext(
+                layout="zo-dir",
+                delivery_repo=delivery_repo,
+                plan_path=plan_path,
+                project_name=pc.project_name,
+                zo_root=zo_root,
+            )
+
+    # Try cwd detection
+    detected = _detect_delivery_repo(project_name)
+    if detected is not None:
+        pc = load_project_config(detected)
+        plan_path = detected / ".zo" / "plans" / f"{pc.project_name}.md"
+        return ProjectContext(
+            layout="zo-dir",
+            delivery_repo=detected,
+            plan_path=plan_path,
+            project_name=pc.project_name,
+            zo_root=zo_root,
+        )
+
+    # Fall back to legacy layout
+    main_root = _main_repo_root()
+    plan_path = main_root / "plans" / f"{project_name}.md"
+    target_path = main_root / "targets" / f"{project_name}.target.md"
+
+    # Resolve delivery repo from legacy target file
+    delivery_path = main_root.parent / f"{project_name}-delivery"
+    if target_path.exists():
+        from zo.target import parse_target
+
+        target = parse_target(target_path)
+        delivery_path = Path(target.target_repo).resolve()
+
+    return ProjectContext(
+        layout="legacy",
+        delivery_repo=delivery_path,
+        plan_path=plan_path,
+        project_name=project_name,
+        zo_root=zo_root,
+    )
+
+
+def _ensure_local_config(delivery_repo: Path) -> None:
+    """Check for .zo/local.yaml; auto-detect environment if missing.
+
+    On a new machine, local.yaml won't exist yet. This function detects
+    the environment (GPU, CUDA, Docker) and prompts for any paths that
+    can't be auto-detected (data_dir), then writes .zo/local.yaml.
+    """
+    from zo.project_config import LocalConfig, load_local_config, save_local_config
+
+    existing = load_local_config(delivery_repo)
+    if existing is not None:
+        return  # Already set up on this machine
+
+    from zo.environment import detect_environment
+
+    console.print(f"\n[{_AMBER}]New machine detected — setting up local config.[/]")
+
+    env = detect_environment()
+    gpu_names: list[str] = []
+    if env and env.gpu_names:
+        gpu_names = list(env.gpu_names) if not isinstance(env.gpu_names, list) else env.gpu_names
+
+    # Prompt for data directory (can't auto-detect)
+    data_dir = click.prompt(
+        "  Data directory (raw data path on this machine)",
+        default="", show_default=False,
+    )
+
+    local = LocalConfig(
+        data_dir=data_dir or None,
+        gpu_count=env.gpu_count if env else 0,
+        gpu_names=gpu_names,
+        cuda_version=env.cuda_version if env else None,
+        docker_available=env.docker_available if env else False,
+        gate_mode="supervised",
+        zo_repo_path=str(_zo_root()),
+    )
+    save_local_config(delivery_repo, local)
+
+    console.print(f"[green]Local config written:[/] {delivery_repo / '.zo' / 'local.yaml'}")
+    if env and env.gpu_count:
+        console.print(f"  [{_DIM}]GPUs: {env.gpu_count}x {', '.join(gpu_names)}[/]")
+    if env and env.cuda_version:
+        console.print(f"  [{_DIM}]CUDA: {env.cuda_version}[/]")
 
 
 def _main_repo_root() -> Path:
@@ -615,7 +793,7 @@ def _launch_and_monitor(
 
     console.print()
     if process.status == "completed":
-        console.print(f"[green bold]Session completed.[/]")
+        console.print("[green bold]Session completed.[/]")
     else:
         console.print(f"[red bold]Session ended with status:[/] {process.status}")
 
@@ -648,13 +826,15 @@ def build(plan_path: Path, gate_mode: str, no_tmux: bool) -> None:
     - Fresh project (no state) -> build from scratch
     - Existing state -> continue from current phase
     - Plan edited since last run -> re-decompose and continue
+
+    Supports both .zo/ layout (plan in delivery repo) and legacy layout
+    (plan in ZO repo). When run from a delivery repo with .zo/, the
+    plan_path is resolved from .zo/plans/.
     """
     from zo.comms import CommsLogger
-    from zo.memory import MemoryManager
     from zo.orchestrator import Orchestrator
     from zo.plan import parse_plan, validate_plan
     from zo.semantic import SemanticIndex
-    from zo.target import parse_target
     from zo.wrapper import LifecycleWrapper
 
     zo_root = _zo_root()
@@ -670,16 +850,13 @@ def build(plan_path: Path, gate_mode: str, no_tmux: bool) -> None:
 
     project_name = plan.frontmatter.project_name
 
-    # 2. Parse target file
-    target_path = zo_root / "targets" / f"{project_name}.target.md"
-    if not target_path.exists():
-        console.print(f"[red bold]Target file not found:[/] {target_path}")
-        raise SystemExit(1)
-    target = parse_target(target_path)
-
-    # 3. Initialize memory and detect mode
-    memory = MemoryManager(project_dir=zo_root, project_name=project_name)
+    # 2. Resolve project context (.zo/ or legacy)
+    ctx = _load_project_context(project_name)
+    target = ctx.make_target()
+    memory = ctx.make_memory()
     memory.initialize_project()
+
+    # 3. Detect mode from state
     state_check = memory.read_state()
     detected_mode = "build" if state_check.phase == "init" else "continue"
 
@@ -713,6 +890,7 @@ def build(plan_path: Path, gate_mode: str, no_tmux: bool) -> None:
     orchestrator = Orchestrator(
         plan=plan, target=target, memory=memory, comms=comms,
         semantic=semantic, zo_root=zo_root, gate_mode=gm,
+        plan_path=plan_path,
     )
     orchestrator.start_session()
 
@@ -741,6 +919,7 @@ def build(plan_path: Path, gate_mode: str, no_tmux: bool) -> None:
         prompt += f"\n\n---\n\n# Additional Human Instructions\n\n{extra}\n"
 
     # 10. Launch, monitor, end session
+    delivery_path = Path(target.target_repo).resolve()
     wrapper = LifecycleWrapper(comms=comms, log_dir=zo_root / "logs" / "wrapper")
     _launch_and_monitor(
         wrapper=wrapper,
@@ -752,36 +931,89 @@ def build(plan_path: Path, gate_mode: str, no_tmux: bool) -> None:
         no_tmux=no_tmux,
         gate_mode_file=memory.memory_root / "gate_mode",
         project_name=project_name,
-        delivery_repo=Path(target.target_repo),
-        add_dirs=[str(Path(target.target_repo).resolve())],
+        delivery_repo=delivery_path,
+        add_dirs=[str(delivery_path)],
     )
 
 
 @cli.command("continue")
-@click.argument("project_name")
+@click.argument("project_name", required=False, default=None)
+@click.option(
+    "--repo", type=click.Path(exists=True, file_okay=False),
+    default=None,
+    help="Path to delivery repo with .zo/ directory. "
+    "Use when reconnecting to a project on a new machine.",
+)
 @click.option(
     "--gate-mode",
     type=click.Choice(["supervised", "auto", "full-auto"]),
     default="supervised",
 )
 @click.option("--no-tmux", is_flag=True, help="Disable tmux agent visibility")
-def continue_(project_name: str, gate_mode: str, no_tmux: bool) -> None:
-    """Resume a paused project. Shorthand for zo build with the existing plan.
+def continue_(
+    project_name: str | None,
+    repo: str | None,
+    gate_mode: str,
+    no_tmux: bool,
+) -> None:
+    """Resume a paused project or reconnect on a new machine.
 
-    Finds plans/{project_name}.md and runs zo build on it.
+    Finds the project plan and runs zo build on it. Supports both
+    .zo/ layout (delivery repo) and legacy layout (ZO repo).
+
+    On a new machine, use --repo to point at the delivery repo::
+
+        zo continue --repo ~/my-project
+
+    If .zo/local.yaml is missing, ZO will auto-detect the environment
+    and prompt for any machine-specific paths before proceeding.
+
+    From inside the delivery repo (cwd has .zo/), project_name is
+    optional — it's read from .zo/config.yaml.
     """
+    from zo.project_config import has_zo_dir, load_project_config
+
+    # Resolve delivery repo from --repo flag or cwd
+    delivery = Path(repo).resolve() if repo else None
+
+    # If no project_name given, try to infer from .zo/config.yaml
+    if project_name is None:
+        detect_path = delivery or Path.cwd()
+        if has_zo_dir(detect_path):
+            pc = load_project_config(detect_path)
+            project_name = pc.project_name
+            if delivery is None:
+                delivery = detect_path
+        else:
+            console.print(
+                "[red bold]No project name given and no .zo/ found in cwd.[/]"
+            )
+            console.print(
+                "Usage: [bold]zo continue PROJECT[/] or "
+                "[bold]zo continue --repo /path/to/delivery[/]"
+            )
+            raise SystemExit(1)
+
     _show_banner(project=project_name, mode="continue")
 
-    zo_root = _zo_root()
-    plan_path = zo_root / "plans" / f"{project_name}.md"
+    # Load project context
+    pctx = _load_project_context(project_name, delivery_repo=delivery)
+
+    # If .zo/ layout and local.yaml is missing, set it up
+    if pctx.layout == "zo-dir":
+        _ensure_local_config(pctx.delivery_repo)
+
+    plan_path = pctx.plan_path
     if not plan_path.exists():
         console.print(f"[red bold]Plan not found:[/] {plan_path}")
         console.print("Run [bold]zo build plans/your-plan.md[/] first.")
         raise SystemExit(1)
 
     # Delegate to build
-    ctx = click.get_current_context()
-    ctx.invoke(build, plan_path=plan_path, gate_mode=gate_mode, no_tmux=no_tmux)
+    click_ctx = click.get_current_context()
+    click_ctx.invoke(
+        build, plan_path=plan_path, gate_mode=gate_mode, no_tmux=no_tmux,
+    )
 
 
 @cli.command("init")
@@ -1130,34 +1362,18 @@ def _init_commit_writes(
     layout_mode: str,
 ) -> None:
     """Actually write all init artifacts. Called after a successful
-    dry-run or directly when the user chose not to preview."""
+    dry-run or directly when the user chose not to preview.
+
+    Writes to BOTH locations for backward compatibility:
+    - .zo/ in delivery repo (new portable layout)
+    - Legacy locations in ZO repo (so older commands still work)
+    """
     from zo.memory import MemoryManager
+    from zo.project_config import ProjectConfig, save_project_config
     from zo.scaffold import scaffold_delivery as _scaffold
 
-    # Memory
-    memory = MemoryManager(project_dir=zo_root, project_name=project_name)
-    memory.initialize_project()
-    console.print(f"[green]Memory initialized:[/] {memory.memory_root}")
-
-    # Target file
-    target_path.parent.mkdir(parents=True, exist_ok=True)
-    if not target_path.exists():
-        target_path.write_text(target_content, encoding="utf-8")
-        console.print(f"[green]Target created:[/] {target_path}")
-        console.print(f"  [{_DIM}]Delivery repo:[/] {delivery_path}")
-        console.print(f"  [{_DIM}]Branch:[/] {branch}")
-    else:
-        console.print(f"[{_DIM}]Target already exists:[/] {target_path}")
-
-    # Plan template
-    plan_path.parent.mkdir(parents=True, exist_ok=True)
-    if not plan_path.exists():
-        plan_path.write_text(plan_content, encoding="utf-8")
-        console.print(f"[green]Plan template created:[/] {plan_path}")
-    else:
-        console.print(f"[{_DIM}]Plan already exists:[/] {plan_path}")
-
-    # Delivery repo scaffold (fresh) or overlay (existing)
+    # Delivery repo scaffold (fresh) or overlay (existing) — do this
+    # first so .zo/ directories exist before we write into them.
     if overlay:
         _scaffold(
             delivery_path, project_name,
@@ -1177,13 +1393,81 @@ def _init_commit_writes(
             overlay=True, layout_mode=layout_mode,
         )
 
+    # -- .zo/ layout (new, portable) --
+
+    # .zo/config.yaml — portable project config
+    zo_dir = delivery_path / ".zo"
+    zo_dir.mkdir(parents=True, exist_ok=True)
+    config_path = zo_dir / "config.yaml"
+    if not config_path.exists():
+        pc = ProjectConfig(
+            project_name=project_name,
+            branch=branch,
+            agent_working_dirs={
+                "data-engineer": "src/data/",
+                "model-builder": "src/model/",
+                "ml-engineer": "src/engineering/",
+                "inference": "src/inference/",
+                "oracle-qa": "reports/",
+                "test-engineer": "tests/",
+                "xai-agent": "reports/",
+                "domain-evaluator": "reports/",
+            },
+        )
+        save_project_config(delivery_path, pc)
+        console.print(f"[green]Project config created:[/] {config_path}")
+    else:
+        console.print(f"[{_DIM}]Project config already exists:[/] {config_path}")
+
+    # Memory in .zo/memory/ (portable)
+    zo_memory = MemoryManager(
+        project_dir=delivery_path,
+        project_name=project_name,
+        memory_root=zo_dir / "memory",
+    )
+    zo_memory.initialize_project()
+    console.print(f"[green]Memory initialized:[/] {zo_memory.memory_root}")
+
+    # Plan in .zo/plans/ (portable)
+    zo_plan_path = zo_dir / "plans" / f"{project_name}.md"
+    zo_plan_path.parent.mkdir(parents=True, exist_ok=True)
+    if not zo_plan_path.exists():
+        zo_plan_path.write_text(plan_content, encoding="utf-8")
+        console.print(f"[green]Plan template created:[/] {zo_plan_path}")
+    else:
+        console.print(f"[{_DIM}]Plan already exists:[/] {zo_plan_path}")
+
+    # -- Legacy layout (backward compat) --
+
+    # Legacy memory in ZO repo
+    legacy_memory = MemoryManager(
+        project_dir=zo_root, project_name=project_name,
+    )
+    legacy_memory.initialize_project()
+
+    # Legacy target file
+    target_path.parent.mkdir(parents=True, exist_ok=True)
+    if not target_path.exists():
+        target_path.write_text(target_content, encoding="utf-8")
+        console.print(f"  [{_DIM}]Legacy target:[/] {target_path}")
+
+    # Legacy plan
+    plan_path.parent.mkdir(parents=True, exist_ok=True)
+    if not plan_path.exists():
+        plan_path.write_text(plan_content, encoding="utf-8")
+        console.print(f"  [{_DIM}]Legacy plan:[/] {plan_path}")
+
     console.print(f"\n[{_AMBER}]Project '{project_name}' ready.[/]")
     console.print("Next steps:")
     console.print(
         f"  1. Draft plan: [bold]zo draft --project {project_name}[/]"
     )
     console.print(
-        f"  2. Build: [bold]zo build plans/{project_name}.md[/]"
+        f"  2. Build: [bold]zo build {zo_plan_path}[/]"
+    )
+    console.print(
+        f"  3. Commit .zo/: [bold]cd {delivery_path} && "
+        f"git add .zo/ && git commit -m 'feat: add ZO project state'[/]"
     )
 
 
@@ -1485,14 +1769,258 @@ def _build_init_architect_prompt(*, project: str, hints: dict) -> str:
 
 @cli.command()
 @click.argument("project_name")
-def status(project_name: str) -> None:
-    """Show current project status from STATE.md."""
+@click.option(
+    "--repo", type=click.Path(exists=True, file_okay=False), default=None,
+    help="Path to delivery repo. If omitted, resolved from "
+    "targets/{project_name}.target.md.",
+)
+@click.option(
+    "--clean", is_flag=True,
+    help="Remove legacy artifacts from ZO repo after migration.",
+)
+def migrate(project_name: str, repo: str | None, clean: bool) -> None:
+    """Migrate project state from ZO repo to delivery repo .zo/ directory.
+
+    Copies memory (STATE.md, DECISION_LOG, PRIORS, sessions), plan, and
+    target config into the delivery repo's .zo/ directory, making the
+    project portable across machines via git.
+
+    After migration, commit .zo/ in the delivery repo::
+
+        cd /path/to/delivery && git add .zo/ && git commit
+
+    Use --clean to remove the old artifacts from the ZO repo after
+    verifying the migration succeeded.
+    """
+    import shutil
+
+    from zo.project_config import (
+        ProjectConfig,
+        has_zo_dir,
+        save_local_config,
+        save_project_config,
+    )
+
+    _show_banner(project=project_name, mode="migrate")
+
+    zo_root = _main_repo_root()
+
+    # Resolve delivery repo path
+    if repo:
+        delivery_path = Path(repo).resolve()
+    else:
+        target_path = zo_root / "targets" / f"{project_name}.target.md"
+        if not target_path.exists():
+            console.print(
+                f"[red bold]Target file not found:[/] {target_path}\n"
+                f"Use [bold]--repo /path/to/delivery[/] to specify the "
+                f"delivery repo path explicitly."
+            )
+            raise SystemExit(1)
+        from zo.target import parse_target
+
+        target = parse_target(target_path)
+        delivery_path = Path(target.target_repo).resolve()
+
+    if not delivery_path.is_dir():
+        console.print(f"[red bold]Delivery repo not found:[/] {delivery_path}")
+        raise SystemExit(1)
+
+    # Check if already migrated
+    if has_zo_dir(delivery_path):
+        console.print(
+            f"[{_DIM}]Delivery repo already has .zo/ — "
+            f"checking for missing files.[/]"
+        )
+
+    # Source paths (legacy ZO repo layout)
+    legacy_memory = zo_root / "memory" / project_name
+    legacy_plan = zo_root / "plans" / f"{project_name}.md"
+    legacy_target = zo_root / "targets" / f"{project_name}.target.md"
+
+    # Destination paths (.zo/ in delivery repo)
+    zo_dir = delivery_path / ".zo"
+    zo_memory = zo_dir / "memory"
+    zo_plans = zo_dir / "plans"
+
+    # Create .zo/ structure
+    for d in [zo_dir, zo_memory, zo_memory / "sessions", zo_plans]:
+        d.mkdir(parents=True, exist_ok=True)
+
+    # Write .zo/.gitignore
+    gitignore = zo_dir / ".gitignore"
+    if not gitignore.exists():
+        gitignore.write_text(
+            "# Machine-specific config (paths, GPU info, gate mode)\n"
+            "local.yaml\n\n"
+            "# SQLite databases (regenerated from DECISION_LOG)\n"
+            "memory/index.db\n"
+            "memory/draft_index.db\n",
+            encoding="utf-8",
+        )
+
+    copied = 0
+
+    # Copy memory files
+    if legacy_memory.is_dir():
+        for f in ["STATE.md", "DECISION_LOG.md", "PRIORS.md"]:
+            src = legacy_memory / f
+            dst = zo_memory / f
+            if src.exists() and not dst.exists():
+                shutil.copy2(src, dst)
+                console.print(f"  [green]Copied:[/] {f}")
+                copied += 1
+            elif src.exists():
+                console.print(f"  [{_DIM}]Already exists:[/] {f}")
+
+        # Copy sessions
+        sessions_src = legacy_memory / "sessions"
+        sessions_dst = zo_memory / "sessions"
+        if sessions_src.is_dir():
+            for sf in sessions_src.iterdir():
+                if sf.is_file():
+                    dst = sessions_dst / sf.name
+                    if not dst.exists():
+                        shutil.copy2(sf, dst)
+                        copied += 1
+            session_count = sum(1 for _ in sessions_src.iterdir())
+            if session_count:
+                console.print(
+                    f"  [green]Copied:[/] {session_count} session files"
+                )
+
+        # Copy index.db if exists (will be regenerated but saves time)
+        for db in ["index.db", "draft_index.db"]:
+            src = legacy_memory / db
+            dst = zo_memory / db
+            if src.exists() and not dst.exists():
+                shutil.copy2(src, dst)
+
+        # Copy gate_mode into local.yaml
+        gm_src = legacy_memory / "gate_mode"
+        gm_content = ""
+        if gm_src.exists():
+            gm_content = gm_src.read_text(encoding="utf-8").strip()
+    else:
+        console.print(f"  [{_DIM}]No legacy memory found at {legacy_memory}[/]")
+        gm_content = ""
+
+    # Always write local.yaml — even without gate_mode, the user needs
+    # environment detection on the current machine for portability.
+    from zo.environment import detect_environment
+    from zo.project_config import LocalConfig
+
+    local_path = zo_dir / "local.yaml"
+    if not local_path.exists():
+        env = detect_environment()
+        local = LocalConfig(
+            gate_mode=gm_content or "supervised",
+            gpu_count=env.gpu_count if env else 0,
+            cuda_version=env.cuda_version if env else None,
+            docker_available=env.docker_available if env else False,
+            zo_repo_path=str(zo_root),
+        )
+        save_local_config(delivery_path, local)
+        console.print(
+            f"  [green]Local config written[/] (gate_mode="
+            f"{gm_content or 'supervised'})"
+        )
+
+    # Copy plan
+    if legacy_plan.exists():
+        dst = zo_plans / f"{project_name}.md"
+        if not dst.exists():
+            shutil.copy2(legacy_plan, dst)
+            console.print(f"  [green]Copied:[/] plan → .zo/plans/{project_name}.md")
+            copied += 1
+        else:
+            console.print(f"  [{_DIM}]Plan already exists in .zo/[/]")
+    else:
+        console.print(f"  [{_DIM}]No legacy plan found[/]")
+
+    # Generate .zo/config.yaml from target file
+    config_path = zo_dir / "config.yaml"
+    if not config_path.exists() and legacy_target.exists():
+        from zo.target import parse_target
+
+        target = parse_target(legacy_target)
+        pc = ProjectConfig(
+            project_name=project_name,
+            branch=target.target_branch,
+            agent_working_dirs=dict(target.agent_working_dirs),
+            zo_only_paths=[".zo/memory/", ".zo/plans/"],
+            git_author_name=target.git_author_name,
+            git_author_email=target.git_author_email,
+            enforce_isolation=target.enforce_isolation,
+        )
+        save_project_config(delivery_path, pc)
+        console.print("  [green]Config created:[/] .zo/config.yaml")
+        copied += 1
+    elif not config_path.exists():
+        # No target file — create minimal config
+        pc = ProjectConfig(project_name=project_name)
+        save_project_config(delivery_path, pc)
+        console.print("  [green]Config created:[/] .zo/config.yaml (minimal)")
+        copied += 1
+
+    # Summary
+    console.print(f"\n[{_AMBER}]Migration complete:[/] {copied} files copied")
+    console.print(
+        f"\nNext: [bold]cd {delivery_path} && git add .zo/ && "
+        f"git commit -m 'feat: add ZO project state'[/]"
+    )
+    console.print(
+        f"Then on new machine: [bold]zo continue --repo {delivery_path}[/]"
+    )
+
+    # Clean up legacy artifacts if requested
+    if clean:
+        console.print(f"\n[{_AMBER}]Cleaning legacy artifacts...[/]")
+        if legacy_memory.is_dir():
+            shutil.rmtree(legacy_memory)
+            console.print(f"  Removed: {legacy_memory}")
+        if legacy_plan.exists():
+            legacy_plan.unlink()
+            console.print(f"  Removed: {legacy_plan}")
+        if legacy_target.exists():
+            legacy_target.unlink()
+            console.print(f"  Removed: {legacy_target}")
+        console.print("[green]Legacy cleanup done.[/]")
+
+
+@cli.command()
+@click.argument("project_name", required=False, default=None)
+@click.option(
+    "--repo", type=click.Path(exists=True, file_okay=False), default=None,
+    help="Path to delivery repo with .zo/ directory.",
+)
+def status(project_name: str | None, repo: str | None) -> None:
+    """Show current project status from STATE.md.
+
+    Supports both .zo/ layout (delivery repo) and legacy layout.
+    From inside a delivery repo with .zo/, project_name is optional.
+    """
+    from zo.project_config import has_zo_dir, load_project_config
+
+    # Resolve project name from .zo/ if not given
+    delivery = Path(repo).resolve() if repo else None
+    if project_name is None:
+        detect_path = delivery or Path.cwd()
+        if has_zo_dir(detect_path):
+            pc = load_project_config(detect_path)
+            project_name = pc.project_name
+            if delivery is None:
+                delivery = detect_path
+        else:
+            console.print(
+                "[red bold]No project name given and no .zo/ found in cwd.[/]"
+            )
+            raise SystemExit(1)
+
     _show_banner(project=project_name, mode="status")
 
-    from zo.memory import MemoryManager
-
-    zo_root = _zo_root()
-    memory = MemoryManager(project_dir=zo_root, project_name=project_name)
+    pctx = _load_project_context(project_name, delivery_repo=delivery)
+    memory = pctx.make_memory()
 
     state_path = memory.memory_root / "STATE.md"
     if not state_path.exists():
@@ -1545,8 +2073,10 @@ def gates() -> None:
 def gates_set(mode: str, project: str) -> None:
     """Set the gate mode for a project mid-session.
 
-    Writes the mode to memory/{project}/gate_mode so that
+    Writes the mode to the project's gate_mode file so that
     the running orchestrator and wrapper pick it up dynamically.
+
+    Supports both .zo/ layout and legacy layout.
 
     Valid modes: supervised, auto, full-auto.
 
@@ -1555,10 +2085,8 @@ def gates_set(mode: str, project: str) -> None:
         zo gates set auto --project my-project
         zo gates set full-auto -p my-project
     """
-    from zo.memory import MemoryManager
-
-    zo_root = _zo_root()
-    memory = MemoryManager(project_dir=zo_root, project_name=project)
+    pctx = _load_project_context(project)
+    memory = pctx.make_memory()
 
     if not memory.memory_root.exists():
         console.print(
@@ -1591,23 +2119,17 @@ def watch_training(project: str, interval: float) -> None:
         zo watch-training --project my-project
     """
     from zo.plan import parse_plan
-    from zo.target import parse_target
     from zo.training_display import run_live_display
 
-    zo_root = _zo_root()
-
-    # Resolve delivery repo path from target file
-    target_path = zo_root / "targets" / f"{project}.target.md"
-    if not target_path.exists():
-        console.print(f"[red bold]Target file not found:[/] {target_path}")
-        raise SystemExit(1)
-    target = parse_target(target_path)
+    # Resolve delivery repo from context (.zo/ or legacy)
+    pctx = _load_project_context(project)
+    target = pctx.make_target()
     delivery_repo = Path(target.target_repo)
 
     # Try to get oracle target from plan
     target_metric: float | None = None
     target_metric_name = ""
-    plan_path = zo_root / "plans" / f"{project}.md"
+    plan_path = pctx.plan_path
     if plan_path.exists():
         try:
             plan = parse_plan(plan_path)

--- a/src/zo/memory.py
+++ b/src/zo/memory.py
@@ -74,12 +74,24 @@ class MemoryManager:
             git operations).
         project_name: Human-readable project identifier used as the
             subdirectory name under ``memory/``.
+        memory_root: Optional override for the memory directory. When
+            provided, this path is used instead of the default
+            ``project_dir / "memory" / project_name``.
     """
 
-    def __init__(self, project_dir: Path, project_name: str) -> None:
+    def __init__(
+        self,
+        project_dir: Path,
+        project_name: str,
+        *,
+        memory_root: Path | None = None,
+    ) -> None:
         self._project_dir = Path(project_dir)
         self._project_name = project_name
-        self._memory_root = self._project_dir / "memory" / project_name
+        if memory_root is not None:
+            self._memory_root = memory_root
+        else:
+            self._memory_root = self._project_dir / "memory" / project_name
 
     @property
     def memory_root(self) -> Path:

--- a/src/zo/orchestrator.py
+++ b/src/zo/orchestrator.py
@@ -149,6 +149,9 @@ class Orchestrator:
         comms: Comms logger for audit events.
         semantic: Semantic index for decision retrieval.
         zo_root: Root directory of the ZO repository.
+        plan_path: Optional override for the plan file path used in
+            the lead prompt. When provided, this path is referenced
+            instead of the default ``zo_root / "plans" / "<project>.md"``.
     """
 
     def __init__(
@@ -161,6 +164,7 @@ class Orchestrator:
         zo_root: Path,
         *,
         gate_mode: GateMode = GateMode.SUPERVISED,
+        plan_path: Path | None = None,
     ) -> None:
         self._plan = plan
         self._target = target
@@ -169,6 +173,7 @@ class Orchestrator:
         self._semantic = semantic
         self._zo_root = Path(zo_root)
         self._gate_mode = gate_mode
+        self._plan_path = plan_path
         self._workflow: WorkflowDecomposition | None = None
         self._session_state: SessionState | None = None
         self._plan_hash: str = self._compute_plan_hash()
@@ -719,7 +724,7 @@ class Orchestrator:
     def _prompt_plan_context(self) -> str:
         p = self._plan
         oracle_text = p.oracle.raw_content if p.oracle else "Not defined"
-        plan_path = (
+        plan_path = self._plan_path if self._plan_path is not None else (
             self._zo_root / "plans"
             / f"{p.frontmatter.project_name}.md"
         )

--- a/src/zo/project_config.py
+++ b/src/zo/project_config.py
@@ -1,0 +1,203 @@
+"""Project config reader/writer for .zo/ directory in delivery repos.
+
+Handles two config files:
+  - `.zo/config.yaml` — portable, committed to the delivery repo
+  - `.zo/local.yaml`  — machine-specific, gitignored
+
+Module provides Pydantic models for both configs plus load/save helpers
+and a backward-compatibility adapter to TargetConfig.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from zo.target import TargetConfig
+
+from pathlib import Path  # noqa: TC003 — used at runtime
+
+import yaml
+from pydantic import BaseModel
+
+# ---------------------------------------------------------------------------
+# Models
+# ---------------------------------------------------------------------------
+
+
+class ProjectConfig(BaseModel):
+    """Portable project config -- committed to delivery repo at .zo/config.yaml.
+
+    Attributes:
+        project_name: Human-readable project identifier.
+        alias: ZO platform alias (e.g. "prod-001") for logs and memory.
+        workflow_mode: Pipeline flavour — classical_ml, deep_learning, or research.
+        branch: Delivery repo branch agents operate on.
+        agent_working_dirs: Maps agent role to its subdirectory in the repo.
+        zo_only_paths: Path prefixes reserved for ZO internals (isolation blocklist).
+        git_author_name: Name used in commits from ZO agents.
+        git_author_email: Email used in commits from ZO agents.
+        enforce_isolation: When True, writes to blocked paths halt execution.
+    """
+
+    project_name: str
+    alias: str = ""
+    workflow_mode: str = "classical_ml"
+    branch: str = "main"
+    agent_working_dirs: dict[str, str] = {}
+    zo_only_paths: list[str] = [".zo/memory/", ".zo/plans/"]
+    git_author_name: str = "ZO Agent"
+    git_author_email: str = "zo-agent@zero-operators.dev"
+    enforce_isolation: bool = True
+
+
+class LocalConfig(BaseModel):
+    """Machine-specific config -- gitignored at .zo/local.yaml.
+
+    Attributes:
+        data_dir: Path to the local data directory (if any).
+        gpu_count: Number of available GPUs on this machine.
+        gpu_names: Human-readable GPU identifiers (e.g. ["A100-80GB"]).
+        cuda_version: Installed CUDA toolkit version string.
+        docker_available: Whether Docker is usable on this machine.
+        gate_mode: How gates are approved — supervised or autonomous.
+        zo_repo_path: Back-reference to the ZO install location on this machine.
+    """
+
+    data_dir: str | None = None
+    gpu_count: int = 0
+    gpu_names: list[str] = []
+    cuda_version: str | None = None
+    docker_available: bool = False
+    gate_mode: str = "supervised"
+    zo_repo_path: str | None = None
+
+
+# ---------------------------------------------------------------------------
+# Public API
+# ---------------------------------------------------------------------------
+
+
+def has_zo_dir(path: Path) -> bool:
+    """Check if *path* contains a .zo/config.yaml marker.
+
+    Args:
+        path: Root of the delivery repository (or any directory to probe).
+
+    Returns:
+        True when `.zo/config.yaml` exists as a regular file.
+    """
+    return (path / ".zo" / "config.yaml").is_file()
+
+
+def load_project_config(repo: Path) -> ProjectConfig:
+    """Read .zo/config.yaml from a delivery repo.
+
+    Args:
+        repo: Root of the delivery repository.
+
+    Returns:
+        Parsed ProjectConfig.
+
+    Raises:
+        FileNotFoundError: If `.zo/config.yaml` does not exist.
+    """
+    config_path = repo / ".zo" / "config.yaml"
+    if not config_path.is_file():
+        raise FileNotFoundError(f"Project config not found: {config_path}")
+    data = yaml.safe_load(config_path.read_text(encoding="utf-8"))
+    if data is None:
+        data = {}
+    return ProjectConfig(**data)
+
+
+def load_local_config(repo: Path) -> LocalConfig | None:
+    """Read .zo/local.yaml from a delivery repo.
+
+    Args:
+        repo: Root of the delivery repository.
+
+    Returns:
+        Parsed LocalConfig, or None if the file does not exist (new machine).
+    """
+    local_path = repo / ".zo" / "local.yaml"
+    if not local_path.is_file():
+        return None
+    data = yaml.safe_load(local_path.read_text(encoding="utf-8"))
+    if data is None:
+        data = {}
+    return LocalConfig(**data)
+
+
+def save_project_config(repo: Path, config: ProjectConfig) -> None:
+    """Write .zo/config.yaml to a delivery repo.
+
+    Creates the `.zo/` directory if it does not yet exist.
+
+    Args:
+        repo: Root of the delivery repository.
+        config: ProjectConfig to persist.
+    """
+    zo_dir = repo / ".zo"
+    zo_dir.mkdir(parents=True, exist_ok=True)
+    config_path = zo_dir / "config.yaml"
+    config_path.write_text(
+        yaml.dump(
+            config.model_dump(),
+            default_flow_style=False,
+            sort_keys=False,
+            allow_unicode=True,
+        ),
+        encoding="utf-8",
+    )
+
+
+def save_local_config(repo: Path, config: LocalConfig) -> None:
+    """Write .zo/local.yaml to a delivery repo.
+
+    Creates the `.zo/` directory if it does not yet exist.
+
+    Args:
+        repo: Root of the delivery repository.
+        config: LocalConfig to persist.
+    """
+    zo_dir = repo / ".zo"
+    zo_dir.mkdir(parents=True, exist_ok=True)
+    local_path = zo_dir / "local.yaml"
+    local_path.write_text(
+        yaml.dump(
+            config.model_dump(),
+            default_flow_style=False,
+            sort_keys=False,
+            allow_unicode=True,
+        ),
+        encoding="utf-8",
+    )
+
+
+def to_target_config(project: ProjectConfig, repo: Path) -> TargetConfig:
+    """Adapter: produce a TargetConfig from ProjectConfig for backward compat.
+
+    Maps ProjectConfig fields to TargetConfig fields so the orchestrator
+    and isolation enforcer work unchanged.
+
+    Args:
+        project: Portable project configuration.
+        repo: Absolute path to the delivery repository.
+
+    Returns:
+        A TargetConfig instance with fields populated from *project*.
+    """
+    from zo.target import TargetConfig
+
+    return TargetConfig(
+        project=project.project_name,
+        target_repo=str(repo),
+        target_branch=project.branch,
+        worktree_base=".worktrees",
+        git_author_name=project.git_author_name,
+        git_author_email=project.git_author_email,
+        agent_working_dirs=project.agent_working_dirs,
+        zo_only_paths=project.zo_only_paths,
+        enforce_isolation=project.enforce_isolation,
+    )

--- a/src/zo/scaffold.py
+++ b/src/zo/scaffold.py
@@ -34,6 +34,11 @@ console = Console()
 # agents drop configs, experiment trails, reports, phase notebooks, and
 # containerisation files.
 _META_DIRECTORIES: list[str] = [
+    # ZO project state (portable memory + plans)
+    ".zo",
+    ".zo/memory",
+    ".zo/memory/sessions",
+    ".zo/plans",
     # Config
     "configs/data",
     "configs/model",
@@ -140,7 +145,7 @@ Agent-generated analysis (read-only for humans).
 - `reports/validation_report.md` — Phase 6 output
 
 ## notebooks/
-- `notebooks/phase/` — Sequentially numbered per-phase notebooks (01_data_pipeline, 02_feature_engineering, etc.)
+- `notebooks/phase/` — Per-phase notebooks (01_data_pipeline, 02_feature_engineering, ...)
 
 ## tests/
 - `tests/unit/` — Code correctness (does the code run?)
@@ -288,7 +293,17 @@ services:
     tty: true
 """
 
+_ZO_GITIGNORE_TEMPLATE = """\
+# Machine-specific config (paths, GPU info, gate mode)
+local.yaml
+
+# SQLite databases (regenerated from DECISION_LOG)
+memory/index.db
+memory/draft_index.db
+"""
+
 _FILE_TEMPLATES: list[tuple[str, str]] = [
+    (".zo/.gitignore", _ZO_GITIGNORE_TEMPLATE),
     ("README.md", _README_TEMPLATE),
     ("STRUCTURE.md", _STRUCTURE_TEMPLATE),
     ("pyproject.toml", _PYPROJECT_TEMPLATE),

--- a/tests/integration/test_migrate.py
+++ b/tests/integration/test_migrate.py
@@ -1,0 +1,351 @@
+"""Integration tests for the ``zo migrate`` CLI command.
+
+Verifies that ``zo migrate PROJECT --repo /path`` correctly copies
+project state from the legacy ZO-repo layout (memory/, plans/, targets/)
+into the delivery repo's .zo/ directory structure.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from unittest.mock import patch
+
+import click.testing
+import pytest
+import yaml
+
+from zo.cli import cli
+
+
+@pytest.fixture()
+def runner() -> click.testing.CliRunner:
+    return click.testing.CliRunner()
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+_TARGET_FRONTMATTER = """\
+---
+project: "{project}"
+target_repo: "{target_repo}"
+target_branch: "main"
+worktree_base: "/tmp/zo-worktrees/{project}"
+git_author_name: "ZO Agent"
+git_author_email: "zo-agent@zero-operators.dev"
+agent_working_dirs:
+  data_engineer: "src/data/"
+  model_builder: "src/model/"
+zo_only_paths:
+  - ".zo/"
+  - "memory/"
+enforce_isolation: true
+---
+
+# {project} target
+"""
+
+_STATE_MD = """\
+# STATE
+
+## Current Phase
+Phase 1 — Data Engineering
+
+## Status
+In progress
+
+## Known Issues
+None
+"""
+
+_DECISION_LOG_MD = """\
+# Decision Log
+
+## 2024-01-01 — Setup
+- Decided on classical ML workflow.
+"""
+
+_PRIORS_MD = """\
+# Priors
+
+No priors yet.
+"""
+
+_PLAN_MD = """\
+# Plan: {project}
+
+## Objective
+Build a model.
+
+## Oracle Definition
+RMSE < 0.5
+"""
+
+
+def _mock_env() -> object:
+    """Return a mock EnvironmentInfo with no GPU."""
+    from zo.environment import EnvironmentInfo
+
+    return EnvironmentInfo(
+        platform="Darwin arm64",
+        python_version="3.11.9",
+        docker_available=False,
+        docker_compose_available=False,
+        gpu_count=0,
+        gpu_names=[],
+        gpu_memory_gb=[],
+        cuda_version=None,
+        nvidia_driver_version=None,
+    )
+
+
+def _setup_legacy(
+    zo_root: Path,
+    project: str,
+    delivery: Path,
+    *,
+    with_sessions: bool = False,
+    with_gate_mode: bool = False,
+) -> None:
+    """Create the legacy ZO repo layout for a project.
+
+    Writes memory files, plan, and target file under ``zo_root``.
+    """
+    # Memory directory
+    mem = zo_root / "memory" / project
+    mem.mkdir(parents=True, exist_ok=True)
+    (mem / "STATE.md").write_text(_STATE_MD, encoding="utf-8")
+    (mem / "DECISION_LOG.md").write_text(_DECISION_LOG_MD, encoding="utf-8")
+    (mem / "PRIORS.md").write_text(_PRIORS_MD, encoding="utf-8")
+
+    if with_sessions:
+        sessions = mem / "sessions"
+        sessions.mkdir(exist_ok=True)
+        (sessions / "session-001.md").write_text("# Session 1\n", encoding="utf-8")
+        (sessions / "session-002.md").write_text("# Session 2\n", encoding="utf-8")
+
+    if with_gate_mode:
+        (mem / "gate_mode").write_text("autonomous", encoding="utf-8")
+
+    # Plan
+    plans = zo_root / "plans"
+    plans.mkdir(parents=True, exist_ok=True)
+    (plans / f"{project}.md").write_text(
+        _PLAN_MD.format(project=project), encoding="utf-8",
+    )
+
+    # Target
+    targets = zo_root / "targets"
+    targets.mkdir(parents=True, exist_ok=True)
+    (targets / f"{project}.target.md").write_text(
+        _TARGET_FRONTMATTER.format(project=project, target_repo=str(delivery)),
+        encoding="utf-8",
+    )
+
+    # Delivery repo must exist
+    delivery.mkdir(parents=True, exist_ok=True)
+
+
+def _invoke_migrate(
+    runner: click.testing.CliRunner,
+    zo_root: Path,
+    project: str,
+    delivery: Path,
+    *,
+    clean: bool = False,
+) -> click.testing.Result:
+    """Invoke ``zo migrate`` with monkeypatched roots."""
+    args = ["migrate", project, "--repo", str(delivery)]
+    if clean:
+        args.append("--clean")
+
+    with (
+        patch("zo.cli._main_repo_root", return_value=zo_root),
+        patch("zo.cli._zo_root", return_value=zo_root),
+        patch("zo.environment.detect_environment", return_value=_mock_env()),
+    ):
+        return runner.invoke(cli, args)
+
+
+# ---------------------------------------------------------------------------
+# Tests
+# ---------------------------------------------------------------------------
+
+
+class TestMigrateCommand:
+    """Integration tests for ``zo migrate``."""
+
+    def test_migrate_copies_memory_files(
+        self, runner: click.testing.CliRunner, tmp_path: Path,
+    ) -> None:
+        """Memory files (STATE.md, DECISION_LOG.md, PRIORS.md) are copied to .zo/memory/."""
+        zo_root = tmp_path / "zo-repo"
+        delivery = tmp_path / "delivery"
+        _setup_legacy(zo_root, "test-proj", delivery)
+
+        result = _invoke_migrate(runner, zo_root, "test-proj", delivery)
+
+        assert result.exit_code == 0, result.output
+
+        zo_mem = delivery / ".zo" / "memory"
+        assert zo_mem.is_dir()
+        assert (zo_mem / "STATE.md").exists()
+        assert (zo_mem / "DECISION_LOG.md").exists()
+        assert (zo_mem / "PRIORS.md").exists()
+
+        # Verify content was actually copied, not just touched
+        assert "Phase 1" in (zo_mem / "STATE.md").read_text()
+        assert "Decision Log" in (zo_mem / "DECISION_LOG.md").read_text()
+
+    def test_migrate_copies_plan(
+        self, runner: click.testing.CliRunner, tmp_path: Path,
+    ) -> None:
+        """Plan file is copied to .zo/plans/{project}.md."""
+        zo_root = tmp_path / "zo-repo"
+        delivery = tmp_path / "delivery"
+        _setup_legacy(zo_root, "test-proj", delivery)
+
+        result = _invoke_migrate(runner, zo_root, "test-proj", delivery)
+
+        assert result.exit_code == 0, result.output
+
+        plan = delivery / ".zo" / "plans" / "test-proj.md"
+        assert plan.exists()
+        content = plan.read_text()
+        assert "# Plan: test-proj" in content
+        assert "Oracle Definition" in content
+
+    def test_migrate_creates_config_from_target(
+        self, runner: click.testing.CliRunner, tmp_path: Path,
+    ) -> None:
+        """Config.yaml is generated from the legacy target file fields."""
+        zo_root = tmp_path / "zo-repo"
+        delivery = tmp_path / "delivery"
+        _setup_legacy(zo_root, "test-proj", delivery)
+
+        result = _invoke_migrate(runner, zo_root, "test-proj", delivery)
+
+        assert result.exit_code == 0, result.output
+
+        config_path = delivery / ".zo" / "config.yaml"
+        assert config_path.exists()
+
+        data = yaml.safe_load(config_path.read_text(encoding="utf-8"))
+        assert data["project_name"] == "test-proj"
+        assert data["branch"] == "main"
+        assert "data_engineer" in data["agent_working_dirs"]
+        assert data["git_author_name"] == "ZO Agent"
+        assert data["enforce_isolation"] is True
+
+    def test_migrate_creates_local_yaml(
+        self, runner: click.testing.CliRunner, tmp_path: Path,
+    ) -> None:
+        """Local.yaml is written when gate_mode is present in legacy memory."""
+        zo_root = tmp_path / "zo-repo"
+        delivery = tmp_path / "delivery"
+        _setup_legacy(zo_root, "test-proj", delivery, with_gate_mode=True)
+
+        result = _invoke_migrate(runner, zo_root, "test-proj", delivery)
+
+        assert result.exit_code == 0, result.output
+
+        local_path = delivery / ".zo" / "local.yaml"
+        assert local_path.exists()
+
+        data = yaml.safe_load(local_path.read_text(encoding="utf-8"))
+        assert data["gate_mode"] == "autonomous"
+        # Environment detection mock returns 0 GPUs
+        assert data["gpu_count"] == 0
+
+    def test_migrate_creates_gitignore(
+        self, runner: click.testing.CliRunner, tmp_path: Path,
+    ) -> None:
+        """A .zo/.gitignore is written with local.yaml listed."""
+        zo_root = tmp_path / "zo-repo"
+        delivery = tmp_path / "delivery"
+        _setup_legacy(zo_root, "test-proj", delivery)
+
+        result = _invoke_migrate(runner, zo_root, "test-proj", delivery)
+
+        assert result.exit_code == 0, result.output
+
+        gitignore = delivery / ".zo" / ".gitignore"
+        assert gitignore.exists()
+        content = gitignore.read_text()
+        assert "local.yaml" in content
+
+    def test_migrate_copies_sessions(
+        self, runner: click.testing.CliRunner, tmp_path: Path,
+    ) -> None:
+        """Session files from memory/{project}/sessions/ appear in .zo/memory/sessions/."""
+        zo_root = tmp_path / "zo-repo"
+        delivery = tmp_path / "delivery"
+        _setup_legacy(zo_root, "test-proj", delivery, with_sessions=True)
+
+        result = _invoke_migrate(runner, zo_root, "test-proj", delivery)
+
+        assert result.exit_code == 0, result.output
+
+        sessions_dir = delivery / ".zo" / "memory" / "sessions"
+        assert sessions_dir.is_dir()
+        session_files = sorted(f.name for f in sessions_dir.iterdir())
+        assert "session-001.md" in session_files
+        assert "session-002.md" in session_files
+        assert (sessions_dir / "session-001.md").read_text().strip() == "# Session 1"
+
+    def test_migrate_idempotent(
+        self, runner: click.testing.CliRunner, tmp_path: Path,
+    ) -> None:
+        """Running migrate twice produces no errors or duplicate files."""
+        zo_root = tmp_path / "zo-repo"
+        delivery = tmp_path / "delivery"
+        _setup_legacy(zo_root, "test-proj", delivery, with_sessions=True)
+
+        result1 = _invoke_migrate(runner, zo_root, "test-proj", delivery)
+        assert result1.exit_code == 0, result1.output
+
+        result2 = _invoke_migrate(runner, zo_root, "test-proj", delivery)
+        assert result2.exit_code == 0, result2.output
+
+        # Files should still exist exactly once
+        zo_mem = delivery / ".zo" / "memory"
+        assert (zo_mem / "STATE.md").exists()
+        assert (zo_mem / "DECISION_LOG.md").exists()
+
+        # Second run should mention "already exists"
+        assert "already exists" in result2.output.lower() or "already has" in result2.output.lower()
+
+        # Session count should not double
+        sessions_dir = zo_mem / "sessions"
+        session_files = list(sessions_dir.iterdir())
+        assert len(session_files) == 2
+
+    def test_migrate_clean_removes_legacy(
+        self, runner: click.testing.CliRunner, tmp_path: Path,
+    ) -> None:
+        """Running with --clean removes the legacy memory, plan, and target files."""
+        zo_root = tmp_path / "zo-repo"
+        delivery = tmp_path / "delivery"
+        _setup_legacy(zo_root, "test-proj", delivery, with_sessions=True)
+
+        # Verify legacy files exist before migrate
+        assert (zo_root / "memory" / "test-proj" / "STATE.md").exists()
+        assert (zo_root / "plans" / "test-proj.md").exists()
+        assert (zo_root / "targets" / "test-proj.target.md").exists()
+
+        result = _invoke_migrate(
+            runner, zo_root, "test-proj", delivery, clean=True,
+        )
+
+        assert result.exit_code == 0, result.output
+
+        # Legacy artifacts should be gone
+        assert not (zo_root / "memory" / "test-proj").exists()
+        assert not (zo_root / "plans" / "test-proj.md").exists()
+        assert not (zo_root / "targets" / "test-proj.target.md").exists()
+
+        # But .zo/ should have the migrated files
+        assert (delivery / ".zo" / "memory" / "STATE.md").exists()
+        assert (delivery / ".zo" / "plans" / "test-proj.md").exists()
+        assert (delivery / ".zo" / "config.yaml").exists()

--- a/tests/integration/test_zo_dir_layout.py
+++ b/tests/integration/test_zo_dir_layout.py
@@ -1,0 +1,242 @@
+"""Integration tests for the .zo/ project discovery layer.
+
+Verifies that the CLI correctly detects .zo/config.yaml in delivery
+repos, resolves ProjectContext from either .zo/ or legacy layout, and
+produces working MemoryManager and TargetConfig instances.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+import yaml
+
+from zo.cli import ProjectContext, _detect_delivery_repo, _load_project_context
+from zo.project_config import ProjectConfig, has_zo_dir, save_project_config
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+_TARGET_FRONTMATTER = """\
+---
+project: "{project}"
+target_repo: "{target_repo}"
+target_branch: "main"
+worktree_base: "/tmp/zo-worktrees/{project}"
+git_author_name: "ZO Agent"
+git_author_email: "zo-agent@zero-operators.dev"
+agent_working_dirs:
+  data_engineer: "src/data/"
+  model_builder: "src/model/"
+zo_only_paths:
+  - ".zo/"
+  - "memory/"
+enforce_isolation: true
+---
+
+# {project} target
+"""
+
+
+def _write_config(repo: Path, project_name: str, **overrides: object) -> None:
+    """Write a .zo/config.yaml to a directory."""
+    config = ProjectConfig(project_name=project_name, **overrides)
+    save_project_config(repo, config)
+
+
+def _write_legacy_target(
+    zo_root: Path, project: str, delivery: Path,
+) -> None:
+    """Write a legacy target file at targets/{project}.target.md."""
+    targets = zo_root / "targets"
+    targets.mkdir(parents=True, exist_ok=True)
+    (targets / f"{project}.target.md").write_text(
+        _TARGET_FRONTMATTER.format(project=project, target_repo=str(delivery)),
+        encoding="utf-8",
+    )
+
+
+# ---------------------------------------------------------------------------
+# Tests — _detect_delivery_repo
+# ---------------------------------------------------------------------------
+
+
+class TestDetectDeliveryRepo:
+    """Tests for _detect_delivery_repo() — probes cwd for .zo/config.yaml."""
+
+    def test_detect_delivery_repo_finds_zo_dir(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """Returns path when .zo/config.yaml exists in cwd."""
+        _write_config(tmp_path, "myproject")
+        monkeypatch.chdir(tmp_path)
+
+        result = _detect_delivery_repo()
+
+        assert result is not None
+        assert result == tmp_path
+
+    def test_detect_delivery_repo_returns_none_without_zo(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """Returns None when no .zo/ directory exists."""
+        monkeypatch.chdir(tmp_path)
+
+        result = _detect_delivery_repo()
+
+        assert result is None
+
+    def test_detect_delivery_repo_filters_by_project_name(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """Returns None when config exists but project_name does not match."""
+        _write_config(tmp_path, "foo")
+        monkeypatch.chdir(tmp_path)
+
+        # Matching name
+        assert _detect_delivery_repo(project_name="foo") is not None
+
+        # Non-matching name
+        assert _detect_delivery_repo(project_name="bar") is None
+
+
+# ---------------------------------------------------------------------------
+# Tests — _load_project_context
+# ---------------------------------------------------------------------------
+
+
+class TestLoadProjectContext:
+    """Tests for _load_project_context() — resolves project paths."""
+
+    def test_load_project_context_zo_dir(
+        self, tmp_path: Path,
+    ) -> None:
+        """Returns ProjectContext with layout='zo-dir' when .zo/ exists."""
+        delivery = tmp_path / "delivery"
+        delivery.mkdir()
+        _write_config(delivery, "myproject")
+
+        zo_root = tmp_path / "zo-repo"
+        zo_root.mkdir()
+
+        with patch("zo.cli._zo_root", return_value=zo_root):
+            ctx = _load_project_context("myproject", delivery_repo=delivery)
+
+        assert ctx.layout == "zo-dir"
+        assert ctx.project_name == "myproject"
+        assert ctx.delivery_repo == delivery
+        assert ctx.plan_path == delivery / ".zo" / "plans" / "myproject.md"
+
+    def test_load_project_context_legacy_fallback(
+        self, tmp_path: Path,
+    ) -> None:
+        """Falls back to legacy layout when no .zo/ dir exists."""
+        zo_root = tmp_path / "zo-repo"
+        delivery = tmp_path / "delivery"
+        delivery.mkdir()
+
+        _write_legacy_target(zo_root, "myproject", delivery)
+
+        with (
+            patch("zo.cli._zo_root", return_value=zo_root),
+            patch("zo.cli._main_repo_root", return_value=zo_root),
+        ):
+            ctx = _load_project_context("myproject")
+
+        assert ctx.layout == "legacy"
+        assert ctx.project_name == "myproject"
+        assert ctx.plan_path == zo_root / "plans" / "myproject.md"
+
+
+# ---------------------------------------------------------------------------
+# Tests — ProjectContext.make_memory
+# ---------------------------------------------------------------------------
+
+
+class TestProjectContextMakeMemory:
+    """Tests for ProjectContext.make_memory() — MemoryManager factory."""
+
+    def test_project_context_make_memory_zo_dir(
+        self, tmp_path: Path,
+    ) -> None:
+        """make_memory() returns MemoryManager rooted at .zo/memory/ for zo-dir layout."""
+        delivery = tmp_path / "delivery"
+        delivery.mkdir()
+        (delivery / ".zo" / "memory").mkdir(parents=True)
+
+        ctx = ProjectContext(
+            layout="zo-dir",
+            delivery_repo=delivery,
+            plan_path=delivery / ".zo" / "plans" / "proj.md",
+            project_name="proj",
+            zo_root=tmp_path / "zo-repo",
+        )
+
+        mm = ctx.make_memory()
+
+        assert mm.memory_root == delivery / ".zo" / "memory"
+
+    def test_project_context_make_memory_legacy(
+        self, tmp_path: Path,
+    ) -> None:
+        """make_memory() returns MemoryManager at memory/{project}/ for legacy layout."""
+        zo_root = tmp_path / "zo-repo"
+        zo_root.mkdir()
+        delivery = tmp_path / "delivery"
+        delivery.mkdir()
+
+        ctx = ProjectContext(
+            layout="legacy",
+            delivery_repo=delivery,
+            plan_path=zo_root / "plans" / "proj.md",
+            project_name="proj",
+            zo_root=zo_root,
+        )
+
+        mm = ctx.make_memory()
+
+        assert mm.memory_root == zo_root / "memory" / "proj"
+
+
+# ---------------------------------------------------------------------------
+# Tests — ProjectContext.make_target
+# ---------------------------------------------------------------------------
+
+
+class TestProjectContextMakeTarget:
+    """Tests for ProjectContext.make_target() — TargetConfig factory."""
+
+    def test_project_context_make_target_zo_dir(
+        self, tmp_path: Path,
+    ) -> None:
+        """make_target() loads from .zo/config.yaml for zo-dir layout."""
+        delivery = tmp_path / "delivery"
+        delivery.mkdir()
+        _write_config(
+            delivery,
+            "myproject",
+            branch="develop",
+            agent_working_dirs={"data_engineer": "src/data/"},
+            git_author_name="ZO Agent",
+            git_author_email="zo@test.dev",
+        )
+
+        ctx = ProjectContext(
+            layout="zo-dir",
+            delivery_repo=delivery,
+            plan_path=delivery / ".zo" / "plans" / "myproject.md",
+            project_name="myproject",
+            zo_root=tmp_path / "zo-repo",
+        )
+
+        target = ctx.make_target()
+
+        assert target.project == "myproject"
+        assert target.target_branch == "develop"
+        assert target.target_repo == str(delivery)
+        assert target.git_author_name == "ZO Agent"
+        assert "data_engineer" in target.agent_working_dirs

--- a/tests/unit/test_cli.py
+++ b/tests/unit/test_cli.py
@@ -25,7 +25,7 @@ class TestCliGroup:
     """Tests for the CLI group and its registered commands."""
 
     def test_cli_group_has_all_commands(self) -> None:
-        expected = {"build", "continue", "init", "status", "draft", "preflight", "gates", "watch-training"}
+        expected = {"build", "continue", "init", "status", "draft", "preflight", "gates", "watch-training", "migrate"}
         actual = set(cli.commands.keys())
         assert expected == actual
 

--- a/tests/unit/test_memory.py
+++ b/tests/unit/test_memory.py
@@ -556,3 +556,23 @@ class TestRenderParse:
         assert len(parsed) == 1
         assert parsed[0].statement == "Learning rate 3e-4 works for BERT fine-tuning"
         assert parsed[0].superseded_by is None
+
+
+# ---------------------------------------------------------------------------
+# MemoryManager — memory_root override
+# ---------------------------------------------------------------------------
+
+
+class TestMemoryRootOverride:
+    """MemoryManager respects the optional memory_root kwarg."""
+
+    def test_custom_memory_root(self, tmp_path: Path) -> None:
+        custom_root = tmp_path / "custom" / "memory"
+        mm = MemoryManager(
+            project_dir=tmp_path, project_name="proj", memory_root=custom_root,
+        )
+        assert mm.memory_root == custom_root
+
+    def test_default_memory_root(self, tmp_path: Path) -> None:
+        mm = MemoryManager(project_dir=tmp_path, project_name="proj")
+        assert mm.memory_root == tmp_path / "memory" / "proj"

--- a/tests/unit/test_orchestrator.py
+++ b/tests/unit/test_orchestrator.py
@@ -1106,3 +1106,41 @@ class TestArtifactAndNotebookWiring:
         prompt = orchestrator.build_lead_prompt(decomp.phases[0])
         assert "docker compose" in prompt.lower()
         assert "STRUCTURE.md" in prompt
+
+
+# ---------------------------------------------------------------------------
+# plan_path override
+# ---------------------------------------------------------------------------
+
+
+class TestPlanPathOverride:
+    """Orchestrator respects the optional plan_path kwarg."""
+
+    def test_custom_plan_path_in_lead_prompt(
+        self, plan: Plan, tmp_path: Path,
+    ) -> None:
+        """When plan_path is passed, build_lead_prompt references it."""
+        custom_path = Path("/srv/plans/custom-plan.md")
+        target = _make_target()
+        memory = MemoryManager(
+            project_dir=tmp_path, project_name="test-project",
+        )
+        memory.initialize_project()
+        comms = CommsLogger(
+            log_dir=tmp_path / "logs" / "comms",
+            project="test-project",
+            session_id="test-session-001",
+        )
+        semantic = SemanticIndex(db_path=tmp_path / "index.db")
+        orch = Orchestrator(
+            plan=plan,
+            target=target,
+            memory=memory,
+            comms=comms,
+            semantic=semantic,
+            zo_root=REPO_ROOT,
+            plan_path=custom_path,
+        )
+        decomp = orch.decompose_plan()
+        prompt = orch.build_lead_prompt(decomp.phases[0])
+        assert str(custom_path) in prompt

--- a/tests/unit/test_project_config.py
+++ b/tests/unit/test_project_config.py
@@ -1,0 +1,255 @@
+"""Unit tests for zo.project_config — .zo/ config reader/writer."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+import yaml
+
+from zo.project_config import (
+    LocalConfig,
+    ProjectConfig,
+    has_zo_dir,
+    load_local_config,
+    load_project_config,
+    save_local_config,
+    save_project_config,
+    to_target_config,
+)
+
+# ---------------------------------------------------------------------------
+# Model defaults
+# ---------------------------------------------------------------------------
+
+
+class TestProjectConfigDefaults:
+    """ProjectConfig model has correct defaults."""
+
+    def test_defaults(self) -> None:
+        """All default values match the spec."""
+        cfg = ProjectConfig(project_name="my-project")
+
+        assert cfg.project_name == "my-project"
+        assert cfg.alias == ""
+        assert cfg.workflow_mode == "classical_ml"
+        assert cfg.branch == "main"
+        assert cfg.agent_working_dirs == {}
+        assert cfg.zo_only_paths == [".zo/memory/", ".zo/plans/"]
+        assert cfg.git_author_name == "ZO Agent"
+        assert cfg.git_author_email == "zo-agent@zero-operators.dev"
+        assert cfg.enforce_isolation is True
+
+
+class TestLocalConfigDefaults:
+    """LocalConfig model has correct defaults."""
+
+    def test_defaults(self) -> None:
+        """All default values match the spec."""
+        cfg = LocalConfig()
+
+        assert cfg.data_dir is None
+        assert cfg.gpu_count == 0
+        assert cfg.gpu_names == []
+        assert cfg.cuda_version is None
+        assert cfg.docker_available is False
+        assert cfg.gate_mode == "supervised"
+        assert cfg.zo_repo_path is None
+
+
+# ---------------------------------------------------------------------------
+# Round-trip: save then load
+# ---------------------------------------------------------------------------
+
+
+class TestProjectConfigRoundTrip:
+    """save_project_config + load_project_config produce identical data."""
+
+    def test_defaults_round_trip(self, tmp_path: Path) -> None:
+        """A config with only defaults survives a write-then-read cycle."""
+        original = ProjectConfig(project_name="round-trip")
+        save_project_config(tmp_path, original)
+        loaded = load_project_config(tmp_path)
+
+        assert loaded.project_name == original.project_name
+        assert loaded.alias == original.alias
+        assert loaded.workflow_mode == original.workflow_mode
+        assert loaded.branch == original.branch
+        assert loaded.agent_working_dirs == original.agent_working_dirs
+        assert loaded.zo_only_paths == original.zo_only_paths
+        assert loaded.git_author_name == original.git_author_name
+        assert loaded.git_author_email == original.git_author_email
+        assert loaded.enforce_isolation == original.enforce_isolation
+
+    def test_custom_agent_working_dirs_round_trip(self, tmp_path: Path) -> None:
+        """Config with populated agent_working_dirs survives a write-then-read cycle."""
+        original = ProjectConfig(
+            project_name="agents-test",
+            agent_working_dirs={
+                "lead_orchestrator": ".",
+                "data_engineer": "data/",
+                "model_builder": "src/models/",
+            },
+        )
+        save_project_config(tmp_path, original)
+        loaded = load_project_config(tmp_path)
+
+        assert loaded.agent_working_dirs == original.agent_working_dirs
+        assert loaded.agent_working_dirs["data_engineer"] == "data/"
+
+    def test_empty_alias_round_trip(self, tmp_path: Path) -> None:
+        """Config with empty alias string round-trips correctly."""
+        original = ProjectConfig(project_name="no-alias", alias="")
+        save_project_config(tmp_path, original)
+        loaded = load_project_config(tmp_path)
+
+        assert loaded.alias == ""
+
+
+class TestLocalConfigRoundTrip:
+    """save_local_config + load_local_config produce identical data."""
+
+    def test_full_round_trip(self, tmp_path: Path) -> None:
+        """A fully populated LocalConfig survives write-then-read."""
+        original = LocalConfig(
+            data_dir="/data/project",
+            gpu_count=4,
+            gpu_names=["A100-80GB", "A100-80GB", "A100-80GB", "A100-80GB"],
+            cuda_version="12.4",
+            docker_available=True,
+            gate_mode="autonomous",
+            zo_repo_path="/opt/zero-operators",
+        )
+        save_local_config(tmp_path, original)
+        loaded = load_local_config(tmp_path)
+
+        assert loaded is not None
+        assert loaded.data_dir == original.data_dir
+        assert loaded.gpu_count == original.gpu_count
+        assert loaded.gpu_names == original.gpu_names
+        assert loaded.cuda_version == original.cuda_version
+        assert loaded.docker_available == original.docker_available
+        assert loaded.gate_mode == original.gate_mode
+        assert loaded.zo_repo_path == original.zo_repo_path
+
+
+# ---------------------------------------------------------------------------
+# Missing file handling
+# ---------------------------------------------------------------------------
+
+
+class TestMissingFiles:
+    """Graceful handling of absent config files."""
+
+    def test_load_local_config_returns_none_when_missing(self, tmp_path: Path) -> None:
+        """load_local_config returns None for a fresh repo without .zo/local.yaml."""
+        assert load_local_config(tmp_path) is None
+
+    def test_load_project_config_raises_when_missing(self, tmp_path: Path) -> None:
+        """load_project_config raises FileNotFoundError when .zo/config.yaml is absent."""
+        with pytest.raises(FileNotFoundError):
+            load_project_config(tmp_path)
+
+
+# ---------------------------------------------------------------------------
+# has_zo_dir
+# ---------------------------------------------------------------------------
+
+
+class TestHasZoDir:
+    """Probing for .zo/config.yaml marker."""
+
+    def test_returns_true_when_present(self, tmp_path: Path) -> None:
+        """has_zo_dir is True after saving a project config."""
+        save_project_config(tmp_path, ProjectConfig(project_name="probe"))
+        assert has_zo_dir(tmp_path) is True
+
+    def test_returns_false_when_missing(self, tmp_path: Path) -> None:
+        """has_zo_dir is False on a bare directory."""
+        assert has_zo_dir(tmp_path) is False
+
+
+# ---------------------------------------------------------------------------
+# to_target_config adapter
+# ---------------------------------------------------------------------------
+
+
+class TestToTargetConfig:
+    """Backward-compat adapter to TargetConfig."""
+
+    def test_all_fields_mapped(self, tmp_path: Path) -> None:
+        """to_target_config populates every TargetConfig field from ProjectConfig."""
+        project = ProjectConfig(
+            project_name="adapter-test",
+            branch="develop",
+            git_author_name="Test Bot",
+            git_author_email="bot@test.dev",
+            agent_working_dirs={"lead": ".", "data": "data/"},
+            zo_only_paths=[".zo/memory/", ".zo/plans/", ".zo/state/"],
+            enforce_isolation=False,
+        )
+        tc = to_target_config(project, tmp_path)
+
+        assert tc.project == "adapter-test"
+        assert tc.target_repo == str(tmp_path)
+        assert tc.target_branch == "develop"
+        assert tc.worktree_base == ".worktrees"
+        assert tc.git_author_name == "Test Bot"
+        assert tc.git_author_email == "bot@test.dev"
+        assert tc.agent_working_dirs == {"lead": ".", "data": "data/"}
+        assert tc.enforce_isolation is False
+
+    def test_zo_only_paths_mapped(self, tmp_path: Path) -> None:
+        """zo_only_paths from ProjectConfig land in TargetConfig unchanged."""
+        custom_paths = [".zo/memory/", ".zo/plans/", "internal/"]
+        project = ProjectConfig(
+            project_name="paths-test",
+            zo_only_paths=custom_paths,
+        )
+        tc = to_target_config(project, tmp_path)
+
+        assert tc.zo_only_paths == custom_paths
+
+
+# ---------------------------------------------------------------------------
+# Directory creation
+# ---------------------------------------------------------------------------
+
+
+class TestDirectoryCreation:
+    """save functions create .zo/ when it does not exist."""
+
+    def test_save_project_config_creates_zo_dir(self, tmp_path: Path) -> None:
+        """Saving a project config on a bare repo root creates .zo/ automatically."""
+        assert not (tmp_path / ".zo").exists()
+        save_project_config(tmp_path, ProjectConfig(project_name="fresh"))
+        assert (tmp_path / ".zo").is_dir()
+        assert (tmp_path / ".zo" / "config.yaml").is_file()
+
+
+# ---------------------------------------------------------------------------
+# YAML output quality
+# ---------------------------------------------------------------------------
+
+
+class TestYamlOutput:
+    """The persisted YAML is human-readable, not Python repr."""
+
+    def test_yaml_is_readable(self, tmp_path: Path) -> None:
+        """Saved config.yaml uses block style and contains no Python-specific tokens."""
+        config = ProjectConfig(
+            project_name="readable",
+            agent_working_dirs={"lead": ".", "data": "data/"},
+            zo_only_paths=[".zo/memory/", ".zo/plans/"],
+        )
+        save_project_config(tmp_path, config)
+
+        raw = (tmp_path / ".zo" / "config.yaml").read_text(encoding="utf-8")
+
+        # Should look like block-style YAML, not a Python dict repr
+        assert "project_name: readable" in raw
+        assert "{" not in raw, "YAML should use block style, not inline/flow style"
+        # Verify it round-trips through plain yaml.safe_load
+        data = yaml.safe_load(raw)
+        assert data["project_name"] == "readable"
+        assert isinstance(data["agent_working_dirs"], dict)

--- a/tests/unit/test_scaffold.py
+++ b/tests/unit/test_scaffold.py
@@ -1,0 +1,48 @@
+"""Unit tests for zo.scaffold — delivery repo scaffolding."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from zo.scaffold import scaffold_delivery
+
+
+class TestZoDirectory:
+    """Tests for .zo/ directory support in scaffold."""
+
+    def test_zo_directories_created(self, tmp_path: Path) -> None:
+        """scaffold_delivery creates .zo/ and its subdirectories."""
+        scaffold_delivery(tmp_path, "test-project")
+
+        assert (tmp_path / ".zo").is_dir()
+        assert (tmp_path / ".zo" / "memory").is_dir()
+        assert (tmp_path / ".zo" / "memory" / "sessions").is_dir()
+        assert (tmp_path / ".zo" / "plans").is_dir()
+
+    def test_zo_gitignore_written(self, tmp_path: Path) -> None:
+        """.zo/.gitignore is written with correct content."""
+        scaffold_delivery(tmp_path, "test-project")
+
+        gitignore = tmp_path / ".zo" / ".gitignore"
+        assert gitignore.exists()
+        content = gitignore.read_text()
+        assert "local.yaml" in content
+        assert "memory/index.db" in content
+        assert "memory/draft_index.db" in content
+
+    def test_zo_directories_created_in_adaptive_mode(
+        self, tmp_path: Path,
+    ) -> None:
+        """.zo/ directories are created even in adaptive layout mode."""
+        scaffold_delivery(tmp_path, "test-project", layout_mode="adaptive")
+
+        assert (tmp_path / ".zo").is_dir()
+        assert (tmp_path / ".zo" / "memory").is_dir()
+        assert (tmp_path / ".zo" / "memory" / "sessions").is_dir()
+        assert (tmp_path / ".zo" / "plans").is_dir()
+
+        # .zo/.gitignore should also be written in adaptive mode
+        gitignore = tmp_path / ".zo" / ".gitignore"
+        assert gitignore.exists()
+        content = gitignore.read_text()
+        assert "local.yaml" in content


### PR DESCRIPTION
## Summary
- Project state (STATE.md, DECISION_LOG, PRIORS, sessions, plans, config) moves from ZO repo to delivery repo under `.zo/`, making projects portable across machines via `git pull`
- New `zo migrate` command copies legacy project state into `.zo/` directory
- `zo continue --repo` reconnects to a project on a new machine with auto-environment detection
- `zo status --repo` and optional project_name auto-detected from `.zo/config.yaml`
- ZO public repo retains only platform-level memory (`memory/zo-platform/`)
- Backward compatible — legacy layout (targets/, plans/, memory/) still works
- Sanitised all client references from tracked files (PR-024 enforcement)

## Changes
- **New**: `src/zo/project_config.py` — ProjectConfig + LocalConfig Pydantic models, YAML I/O, TargetConfig adapter
- **New**: `zo migrate` CLI command, `tests/integration/test_migrate.py` (8 tests)
- **New**: `tests/integration/test_zo_dir_layout.py` (8 tests), `tests/unit/test_project_config.py` (14 tests)
- **Modified**: `memory.py` (memory_root override), `orchestrator.py` (plan_path override), `scaffold.py` (.zo/ dirs)
- **Modified**: `cli.py` — discovery layer, updated build/continue/status/gates/watch-training commands
- **Docs**: README, COMMANDS.md, specs/architecture.md, specs/memory.md updated
- **Memory**: PR-028 added to PRIORS, architecture decision logged, STATE.md updated

## Test plan
- [x] 521 tests passing (36 new), 7 skipped
- [x] `ruff check src/zo/` clean
- [x] `validate-docs.sh` 9 passed, 0 failed
- [x] `zo migrate ivl_f5 --repo ~/ivl_f5` successfully migrated prod-001 state
- [x] No client names in tracked files (grep verified)
- [ ] `zo continue --repo` on GPU server (blocked on merge)

🤖 Generated with [Claude Code](https://claude.com/claude-code)