### PR TITLE
fix(memory+wrapper): robust STATE.md parsing + TUI readiness polling

### DIFF
--- a/src/zo/_memory_formats.py
+++ b/src/zo/_memory_formats.py
@@ -120,10 +120,18 @@ _PHASE_LINE_RE = re.compile(r"^(phase_\d+):\s*(\w+)\s*(.*)")
 def parse_state(text: str) -> SessionState:
     """Parse STATE.md text into a SessionState model.
 
+    Supports two list formats:
+    - Bracket: ``next_steps: [a, b, c]``
+    - YAML multi-line: ``next_steps:\\n  - a\\n  - b\\n  - c``
+
     Raises:
         ValueError: If the text cannot be parsed.
     """
     kv: dict[str, str] = {}
+    # Multi-line YAML list accumulation: when a key has an empty value
+    # and subsequent lines start with "- ", collect them into the key.
+    yaml_list_items: dict[str, list[str]] = {}
+    current_list_key: str | None = None
     phase_states: dict[str, str] = {}
     completed_by_phase: dict[str, list[str]] = {}
     in_phases_section = False
@@ -132,6 +140,7 @@ def parse_state(text: str) -> SessionState:
         stripped = line.strip()
         if stripped == "## Phases":
             in_phases_section = True
+            current_list_key = None
             continue
         if stripped.startswith("## ") and in_phases_section:
             in_phases_section = False
@@ -143,11 +152,26 @@ def parse_state(text: str) -> SessionState:
                 completed_by_phase[pid] = _parse_bracket_list(rest)
             continue
         if stripped.startswith("#") or not stripped:
+            current_list_key = None
             continue
+
+        # Collect YAML multi-line list items (lines starting with "- ")
+        if stripped.startswith("- ") and current_list_key is not None:
+            item = stripped[2:].strip()
+            if item:
+                yaml_list_items.setdefault(current_list_key, []).append(item)
+            continue
+
         if ":" not in stripped:
+            current_list_key = None
             continue
         key, _, value = stripped.partition(":")
-        kv[key.strip()] = value.strip()
+        key = key.strip()
+        value = value.strip()
+        kv[key] = value
+
+        # If value is empty, the next lines might be YAML list items
+        current_list_key = key if not value or value == "[]" else None
 
     if not kv:
         raise ValueError("STATE.md contains no parseable key-value pairs")
@@ -163,7 +187,11 @@ def parse_state(text: str) -> SessionState:
         kwargs["last_completed_subtask"] = None if val == "null" else val
     for list_key in ("active_blockers", "next_steps", "active_agents"):
         if list_key in kv:
-            kwargs[list_key] = _parse_bracket_list(kv[list_key])
+            parsed = _parse_bracket_list(kv[list_key])
+            # Fall back to YAML multi-line items if bracket parse was empty
+            if not parsed and list_key in yaml_list_items:
+                parsed = yaml_list_items[list_key]
+            kwargs[list_key] = parsed
     if "git_head" in kv:
         val = kv["git_head"]
         kwargs["git_head"] = None if val == "null" else val

--- a/tests/unit/test_memory.py
+++ b/tests/unit/test_memory.py
@@ -563,6 +563,101 @@ class TestRenderParse:
 # ---------------------------------------------------------------------------
 
 
+class TestParseStateYamlLists:
+    """parse_state handles both bracket and YAML multi-line list formats."""
+
+    def test_bracket_format_next_steps(self) -> None:
+        text = (
+            "# STATE\n"
+            "timestamp: 2026-04-15T10:00:00Z\n"
+            "mode: build\n"
+            "phase: phase_2\n"
+            "last_completed_subtask: gate_close\n"
+            "active_blockers: []\n"
+            "next_steps: [Do thing A, Do thing B, Do thing C]\n"
+            "active_agents: []\n"
+            "git_head: abc123\n"
+        )
+        state = _parse_state(text)
+        assert state.next_steps == ["Do thing A", "Do thing B", "Do thing C"]
+
+    def test_yaml_multiline_next_steps(self) -> None:
+        text = (
+            "# STATE\n"
+            "timestamp: 2026-04-15T10:00:00Z\n"
+            "mode: build\n"
+            "phase: phase_2\n"
+            "last_completed_subtask: gate_close\n"
+            "active_blockers: []\n"
+            "next_steps:\n"
+            "  - Do thing A\n"
+            "  - Do thing B\n"
+            "  - Do thing C\n"
+            "active_agents: []\n"
+            "git_head: abc123\n"
+        )
+        state = _parse_state(text)
+        assert state.next_steps == ["Do thing A", "Do thing B", "Do thing C"]
+
+    def test_yaml_multiline_blockers(self) -> None:
+        text = (
+            "# STATE\n"
+            "timestamp: 2026-04-15T10:00:00Z\n"
+            "mode: build\n"
+            "phase: phase_2\n"
+            "last_completed_subtask: gate_close\n"
+            "active_blockers:\n"
+            "  - gpu_server_setup\n"
+            "  - data_not_transferred\n"
+            "next_steps: [stuff]\n"
+            "active_agents: []\n"
+            "git_head: abc123\n"
+        )
+        state = _parse_state(text)
+        assert state.active_blockers == ["gpu_server_setup", "data_not_transferred"]
+
+    def test_mixed_formats(self) -> None:
+        """Bracket blockers + YAML next_steps in the same file."""
+        text = (
+            "# STATE\n"
+            "timestamp: 2026-04-15T10:00:00Z\n"
+            "mode: build\n"
+            "phase: phase_2\n"
+            "last_completed_subtask: gate_close\n"
+            "active_blockers: [gpu_setup]\n"
+            "next_steps:\n"
+            "  - Docker build\n"
+            "  - Re-align data\n"
+            "active_agents: []\n"
+            "git_head: abc123\n"
+        )
+        state = _parse_state(text)
+        assert state.active_blockers == ["gpu_setup"]
+        assert state.next_steps == ["Docker build", "Re-align data"]
+
+    def test_round_trip_preserves_yaml_input(self) -> None:
+        """YAML multi-line input → parse → render → parse gives same data."""
+        text = (
+            "# STATE\n"
+            "timestamp: 2026-04-15T10:00:00Z\n"
+            "mode: build\n"
+            "phase: phase_2\n"
+            "last_completed_subtask: gate_close\n"
+            "active_blockers: [gpu_setup]\n"
+            "next_steps:\n"
+            "  - Docker build\n"
+            "  - Re-align data\n"
+            "  - Run tests\n"
+            "active_agents: []\n"
+            "git_head: abc123\n"
+        )
+        state1 = _parse_state(text)
+        rendered = _render_state(state1)
+        state2 = _parse_state(rendered)
+        assert state2.next_steps == state1.next_steps
+        assert state2.active_blockers == state1.active_blockers
+
+
 class TestMemoryRootOverride:
     """MemoryManager respects the optional memory_root kwarg."""
 


### PR DESCRIPTION
## Summary
Two systemic fixes for GPU server portability:

1. **STATE.md parser handles both list formats** — bracket `[a, b, c]` AND YAML multi-line `- a\n- b`. Previously YAML multi-line silently returned empty, then `start_session()` overwrote the file with empty `next_steps`. This caused `zo status` to show "Next Steps: none" after machine transfer.

2. **Poll-based TUI readiness** replaces `time.sleep(8)` — polls `tmux capture-pane` every 1s for up to 30s until TUI has >100 chars of stable content. Retries paste once if it misses. Adapts to any machine speed automatically.

## Self-evolution
- PR-031: never use fixed sleeps for external process readiness — poll instead

## Test plan
- [x] 529 tests passing (5 new parser tests), 7 skipped
- [x] `ruff check` clean
- [x] `validate-docs.sh` 10/0 (Check 8 confidentiality clean)
- [ ] Live test on GPU server (blocked on merge)

🤖 Generated with [Claude Code](https://claude.com/claude-code)