### PR TITLE
fix(docs): MDX 2 parser kills cost-benchmark page on '<1 pp' prose

### DIFF
--- a/docs/reference/cost-benchmark.mdx
+++ b/docs/reference/cost-benchmark.mdx
@@ -98,7 +98,7 @@ The 30% breaks down across the preset's seven knobs:
 | Phase-4 `max_iterations` 10 → 2 | Caps iteration count | **~2-5 pp** (MNIST converges in 1, so cap doesn't bite) |
 | `stop_on_tier` `must_pass` → `could_pass` | Earlier termination | **~1-3 pp** (same as above for MNIST) |
 | Drop `research-scout` cross-cutting | ~6 spawns × small contracts | **~1-2 pp** |
-| No Haiku headline ticker | ~60 small calls/hour | **<1 pp** (~\$0.01) |
+| No Haiku headline ticker | ~60 small calls/hour | **under 1 pp** (~\$0.01) |
 | Default gate-mode `full-auto` | No human-loop wall-time overhead | wall-time only, not token |
 | `CLAUDE_AUTOCOMPACT_PCT_OVERRIDE=60` | Earlier auto-compaction | indirect (cleaner reasoning, no direct \$ saving) |
 


### PR DESCRIPTION
## Summary

Mintlify's deploy of PR #60 (commit 6fe485a) failed with **\"Encountered syntax error(s). Deployment not updated\"** — the live docs at docs.zerooperators.com stayed on the pre-PR-#60 cached version (still showing the \`(pending)\` tracking table row instead of the measured \`\$7.75 / 30%\` values).

Same class of bug as PR #58 commit 10c492c (the-team page 404 root cause): **MDX 2 treats \`<\` followed by any non-whitespace character — including digits — as the start of a JSX opening tag**. Line 101 of \`docs/reference/cost-benchmark.mdx\` had \`**<1 pp**\` in prose. The \`<1\` was parsed as a malformed JSX attempt, the file failed compilation, Mintlify silently dropped the deploy.

## Fix

One-line: replace \`<1 pp\` with \`under 1 pp\`. Natural prose, preserves semantic meaning, no MDX gotcha. Same fix pattern as PR #58.

## Sweep

Repo-wide regex sweep (\`grep -E '<[0-9]|<[a-zA-Z]' docs/**/*.mdx\`) confirmed this is the only remaining unescaped \`<digit\` or \`<letter\` pattern in tracked \`.mdx\` files outside of code fences and valid Mintlify components (\`<Note>\`, \`<Warning>\`, \`<Tabs>\`, etc.).

## Test plan

- [x] Diff is one line in one file
- [x] No code changes — Mintlify will redeploy automatically on merge
- [x] After merge: \`curl -s https://docs.zerooperators.com/reference/cost-benchmark | grep -A 1 \"1.0.2\"\` should show measured values, not \`(pending)\`

🤖 Generated with [Claude Code](https://claude.com/claude-code)