### PR TITLE
feat(website): diagnosis · unlock · origin sections + acknowledgements

### DIFF
--- a/README.md
+++ b/README.md
@@ -553,6 +553,20 @@ External CLI tools that fit ZO's launcher architecture and are being evaluated f
 
 ---
 
+## Acknowledgements
+
+No tool ships alone. With thanks to the *AI specialists, researchers and engineers* who tested, guided, broke things, and made ZO sharper:
+
+- [Arjun Agrawal](https://www.linkedin.com/in/arjunagraw/)
+- [Callum Adamson](https://www.linkedin.com/in/callumadamson/)
+- [Harry Davies](https://www.linkedin.com/in/harrydavies1/)
+- [Ken Chatfield](https://www.linkedin.com/in/kchatfield/)
+- [Nick Imrie](https://www.linkedin.com/in/nickimrie/)
+- [Sergey Podatelev](https://www.linkedin.com/in/sergey-podatelev/)
+- [Tianhong Dai](https://www.linkedin.com/in/tianhong-dai-71b166117/)
+
+---
+
 <div align="center">
 <br/>
 

--- a/docs/acknowledgements.mdx
+++ b/docs/acknowledgements.mdx
@@ -1,0 +1,16 @@
+---
+title: "Acknowledgements"
+description: "No tool ships alone. The AI specialists, researchers, and engineers who tested, guided, broke things, and made ZO sharper."
+---
+
+No tool ships alone. With thanks to the *AI specialists, researchers and engineers* who tested, guided, broke things, and made ZO sharper.
+
+- [Arjun Agrawal](https://www.linkedin.com/in/arjunagraw/)
+- [Callum Adamson](https://www.linkedin.com/in/callumadamson/)
+- [Harry Davies](https://www.linkedin.com/in/harrydavies1/)
+- [Ken Chatfield](https://www.linkedin.com/in/kchatfield/)
+- [Nick Imrie](https://www.linkedin.com/in/nickimrie/)
+- [Sergey Podatelev](https://www.linkedin.com/in/sergey-podatelev/)
+- [Tianhong Dai](https://www.linkedin.com/in/tianhong-dai-71b166117/)
+
+ZO also stands on a foundation of open-source work — the runtimes, libraries, and tooling listed in the [project README](https://github.com/SamPlvs/zero-operators#built-on).

--- a/docs/mint.json
+++ b/docs/mint.json
@@ -78,7 +78,8 @@
     {
       "group": "Project",
       "pages": [
-        "roadmap"
+        "roadmap",
+        "acknowledgements"
       ]
     }
   ],

--- a/website/public/styles.css
+++ b/website/public/styles.css
@@ -1869,3 +1869,294 @@ em, .it {
   .btn { min-height: 44px; }
   .theme-toggle, .nav-burger, .md-close { min-width: 40px; min-height: 40px; }
 }
+
+/* =====================================================================
+   v2 additions — new opener sections (02 · 03 · 04)
+   Tokens, .section, .section-head/title/lede, .reveal, .container etc
+   come from the rules above — only the new visual classes live here.
+   ===================================================================== */
+    /* =====================================================================
+       v2 additions — new opener sections (02 · 03 · 04)
+       Tokens, .section, .section-head/title/lede, .reveal, .container etc
+       all come from styles.css — only the new visual classes live here.
+       ===================================================================== */
+
+    .subhead {
+      font-family: var(--mono); font-size: 10px; color: var(--dim);
+      letter-spacing: 0.22em; text-transform: uppercase;
+      margin: 0 0 18px;
+      display: flex; align-items: center; gap: 12px;
+    }
+    .subhead::before { content: ""; width: 12px; height: 1px; background: var(--coral); }
+
+    /* designer-note frame (kept subtle — used to mark new sections during review) */
+    .v2-tag {
+      display: inline-block;
+      font-family: var(--mono); font-size: 9px; color: var(--coral);
+      letter-spacing: 0.22em; text-transform: uppercase;
+      padding: 4px 10px;
+      border: 1px solid var(--coral);
+      border-radius: 999px;
+      margin-bottom: 18px;
+    }
+
+    /* ---------- Sculley diagram ---------- */
+    .sculley-frame { background: var(--canvas-2); border: 1px solid var(--rule); border-radius: 10px; padding: 28px 28px 24px; margin-bottom: 14px; }
+    .sculley { display: grid; grid-template-columns: repeat(8, 1fr); grid-template-rows: 88px 88px 88px; gap: 6px; margin-bottom: 18px; }
+    .sk-box { background: var(--canvas); border: 1px solid var(--rule-2); padding: 12px 14px; display: flex; flex-direction: column; gap: 8px; position: relative; min-height: 0; overflow: hidden; }
+    .sk-box .sk-label { font: 10px/1.2 var(--mono); color: var(--cream-2); letter-spacing: 0.16em; text-transform: uppercase; }
+    .sk-stuff { display: flex; flex-direction: column; gap: 5px; }
+    .sk-stuff i { display: block; height: 1px; background: var(--rule-2); }
+    .sk-stuff i:nth-child(1) { width: 72%; }
+    .sk-stuff i:nth-child(2) { width: 48%; }
+    .sk-stuff i:nth-child(3) { width: 64%; }
+    .sk-stuff i:nth-child(4) { width: 38%; }
+    .sk-config   { grid-column: 1 / 3; grid-row: 1; }
+    .sk-collect  { grid-column: 3 / 6; grid-row: 1; }
+    .sk-verify   { grid-column: 6 / 8; grid-row: 1; }
+    .sk-machine  { grid-column: 8 / 9; grid-row: 1 / 3; }
+    .sk-feature  { grid-column: 1 / 4; grid-row: 2; }
+    .sk-mlcode {
+      grid-column: 4; grid-row: 2;
+      background: var(--coral-soft); border-color: var(--coral);
+      align-self: center; justify-self: center;
+      width: 92px; min-height: 44px; padding: 8px 10px;
+      box-shadow: 0 0 0 4px var(--canvas-2), 0 0 24px var(--coral-ring);
+      z-index: 2;
+    }
+    .sk-mlcode .sk-label { color: var(--coral); font-weight: 500; }
+    .sk-mlcode .sk-stuff i { background: oklch(0.74 0.14 35 / 0.4); }
+    .sk-mlcode .sk-stuff i:nth-child(1) { width: 60%; }
+    .sk-mlcode .sk-stuff i:nth-child(2) { width: 40%; }
+    .sk-analysis { grid-column: 5 / 8; grid-row: 2; }
+    .sk-serving  { grid-column: 1 / 5; grid-row: 3; }
+    .sk-process  { grid-column: 5 / 7; grid-row: 3; }
+    .sk-monitor  { grid-column: 7 / 9; grid-row: 3; }
+    .sculley-cap { display: flex; justify-content: space-between; gap: 24px; font-family: var(--mono); font-size: 10px; color: var(--dim); letter-spacing: 0.14em; text-transform: uppercase; padding-top: 14px; border-top: 1px dashed var(--rule); }
+    .sculley-cap .cap-r { text-align: right; }
+    .sculley-cap a { color: var(--cream-2); border-bottom: 1px solid var(--rule-2); }
+    .sculley-cap a:hover { color: var(--coral); border-bottom-color: var(--coral); }
+    .sculley-cap em { font-family: var(--italic); font-style: italic; color: var(--coral); font-size: 1.15em; line-height: 0.95; }
+
+    /* ---------- 14-week timeline ---------- */
+    .timeline { background: var(--canvas-2); border: 1px solid var(--rule); border-radius: 10px; padding: 28px 28px 22px; margin-bottom: 14px; }
+    .tl-grid { display: grid; grid-template-columns: 124px 1fr; gap: 16px; align-items: center; }
+    .tl-annot-row { display: grid; grid-template-columns: 124px 1fr; gap: 16px; margin-bottom: 4px; min-height: 36px; }
+    .tl-annot-track { display: grid; grid-template-columns: repeat(10, 1fr); position: relative; align-items: end; }
+    .tl-annot { grid-column: var(--col, 6) / span 1; position: relative; height: 36px; }
+    .tl-annot-text { position: absolute; bottom: 16px; left: 50%; transform: translateX(-50%); font-family: var(--mono); font-size: 10px; color: var(--coral); letter-spacing: 0.06em; white-space: nowrap; }
+    .tl-annot-line { position: absolute; bottom: 0; left: 50%; width: 1px; height: 12px; background: var(--coral); }
+    .tl-row-label { font: 10px/1.3 var(--mono); color: var(--dim); letter-spacing: 0.18em; text-transform: uppercase; text-align: right; }
+    .tl-bar { display: grid; grid-template-columns: repeat(10, 1fr); height: 44px; border-radius: 4px; overflow: hidden; border: 1px solid var(--rule); }
+    .tl-seg { display: flex; align-items: center; padding: 0 12px; font: 10px/1 var(--mono); letter-spacing: 0.04em; white-space: nowrap; overflow: hidden; text-overflow: ellipsis; border-right: 1px solid var(--canvas); position: relative; }
+    .tl-seg:last-child { border-right: none; }
+    .tl-seg-cool { background: var(--canvas-3); color: var(--cream-2); }
+    .tl-seg-cool-2 { background: var(--canvas-3); color: var(--dim); }
+    .tl-seg-coral { background: var(--coral-soft); color: var(--coral); border-right-color: oklch(0.74 0.14 35 / 0.06); }
+    .tl-seg-coral.is-key { background: oklch(0.74 0.14 35 / 0.22); }
+    .tl-seg-dim { background: var(--canvas-3); color: var(--ghost); }
+    .tl-ticks { display: grid; grid-template-columns: repeat(10, 1fr); margin-top: 8px; border-top: 1px dashed var(--rule); padding-top: 8px; }
+    .tl-tick { font: 9px/1 var(--mono); color: var(--ghost); text-align: center; letter-spacing: 0.1em; border-left: 1px solid transparent; }
+    .tl-tick:nth-child(5n+1) { color: var(--dim); }
+    .tl-tick.is-pivot { color: var(--coral); }
+    /* — group bracket row (sits above the bar) — */
+    .tl-groups-row { margin-bottom: 6px; }
+    .tl-groups { display: grid; grid-template-columns: repeat(10, 1fr); gap: 4px; }
+    .tl-group { font-family: var(--mono); font-size: 10px; letter-spacing: 0.2em; text-transform: uppercase; padding: 6px 10px 8px; border-bottom: 1px solid currentColor; display: flex; align-items: baseline; justify-content: space-between; gap: 10px; opacity: .85; }
+    .tl-group .tl-group-weeks { font-size: 9px; opacity: .7; letter-spacing: 0.14em; }
+    .tl-group-cool { color: var(--cream-2); }
+    .tl-group-coral { color: var(--coral); }
+    .tl-group-dim { color: var(--ghost); justify-content: center; padding-left: 4px; padding-right: 4px; }
+
+    .tl-legend { display: flex; gap: 24px; font-family: var(--mono); font-size: 10px; color: var(--dim); letter-spacing: 0.14em; text-transform: uppercase; margin-top: 16px; padding-top: 14px; border-top: 1px dashed var(--rule); flex-wrap: wrap; }
+    .tl-legend .lg-item { display: inline-flex; align-items: center; gap: 8px; }
+    .tl-legend .lg-swatch { width: 14px; height: 8px; border-radius: 2px; border: 1px solid var(--rule-2); }
+    .tl-legend .lg-swatch.cool  { background: var(--canvas-3); }
+    .tl-legend .lg-swatch.coral { background: var(--coral-soft); border-color: var(--coral); }
+    .tl-legend .lg-swatch.dim   { background: var(--canvas); border-color: var(--ghost); }
+
+    /* ---------- task litany ---------- */
+    .litany-frame { background: var(--canvas-2); border: 1px solid var(--rule); border-radius: 10px; padding: 24px 28px 8px; position: relative; overflow: hidden; margin-bottom: 14px; }
+    .litany-label { font-family: var(--mono); font-size: 10px; color: var(--dim); letter-spacing: 0.22em; text-transform: uppercase; margin-bottom: 14px; display: flex; align-items: center; gap: 12px; }
+    .litany-label::before { content: ""; width: 12px; height: 1px; background: var(--coral); }
+    .litany {
+      font-family: var(--mono); font-size: 11.5px; line-height: 1.85;
+      color: var(--dim); letter-spacing: 0.02em;
+      max-height: 130px; overflow: hidden; position: relative;
+      -webkit-mask-image: linear-gradient(180deg, #000 30%, transparent 100%);
+      mask-image: linear-gradient(180deg, #000 30%, transparent 100%);
+      word-break: keep-all; margin-bottom: 12px;
+    }
+    .litany .l-sep { color: var(--ghost); margin: 0 6px; }
+    .litany .l-end { color: var(--coral); margin-left: 6px; }
+
+    /* ---------- citations ---------- */
+    .cites { display: grid; grid-template-columns: 1fr 1fr 1fr; gap: 1px; background: var(--rule); border: 1px solid var(--rule); border-radius: 8px; overflow: hidden; margin-top: 32px; }
+    .cite { background: var(--canvas-2); padding: 22px 24px; }
+    .cite .ct-quote { font-size: 14px; color: var(--cream); font-weight: 300; line-height: 1.5; margin-bottom: 14px; text-wrap: balance; }
+    .cite .ct-quote .ct-num { font-family: var(--mono); font-weight: 500; font-size: 1.08em; color: var(--coral); }
+    .cite .ct-source { font-family: var(--mono); font-size: 10px; color: var(--dim); letter-spacing: 0.08em; display: flex; flex-direction: column; gap: 2px; }
+    .cite .ct-source a { color: var(--cream-2); border-bottom: 1px solid var(--rule-2); }
+    .cite .ct-source a:hover { color: var(--coral); border-bottom-color: var(--coral); }
+
+    /* ---------- §03 lanes ---------- */
+    .lanes-frame { background: var(--canvas-2); border: 1px solid var(--rule); border-radius: 10px; padding: 36px 32px 28px; }
+    .lanes-grid { display: grid; grid-template-columns: 124px 1fr; gap: 16px; }
+    .lane-row { display: contents; }
+    .lane-label { font: 10px/1.3 var(--mono); color: var(--dim); letter-spacing: 0.18em; text-transform: uppercase; text-align: right; align-self: center; padding-top: 4px; }
+    .lane-label em { font-size: 1.15em; line-height: 1; }
+    .lane-label .lane-sub { display: block; color: var(--ghost); letter-spacing: 0.1em; margin-top: 2px; font-size: 9px; text-transform: uppercase; }
+    .zo-lane { display: grid; grid-template-columns: repeat(10, 1fr); height: 56px; border-radius: 4px; overflow: hidden; background: var(--coral-soft); border: 1px solid var(--coral-ring); }
+    .zo-seg { display: flex; align-items: center; padding: 0 14px; font: 11px/1 var(--mono); color: var(--coral); letter-spacing: 0.04em; border-right: 1px solid oklch(0.74 0.14 35 / 0.18); }
+    .zo-seg:last-child { border-right: none; }
+    .zo-seg.is-active { background: oklch(0.74 0.14 35 / 0.22); }
+    .zo-seg.is-active::before { content: ""; width: 6px; height: 6px; background: var(--coral); border-radius: 50%; margin-right: 8px; box-shadow: 0 0 8px var(--coral-ring); animation: zo-pulse 2.4s var(--ease) infinite; }
+    @keyframes zo-pulse { 0%, 100% { opacity: 0.5; transform: scale(1); } 50% { opacity: 1; transform: scale(1.4); } }
+    .between-row { display: contents; }
+    .between-spacer {}
+    .between-label { font-family: var(--italic); font-style: italic; color: var(--coral); font-size: 14px; padding: 16px 0 16px 4px; display: flex; align-items: center; gap: 14px; }
+    .between-label::before { content: ""; height: 1px; background: linear-gradient(90deg, var(--coral), transparent); flex: 0 0 80px; }
+    .between-note { font-family: var(--sans); font-style: normal; color: var(--cream-2); font-size: 13px; font-weight: 300; margin-left: 4px; }
+    .human-lane { position: relative; height: 110px; display: grid; grid-template-columns: repeat(10, 1fr); }
+    .human-baseline { position: absolute; left: 0; right: 0; top: 50%; height: 1px; background: repeating-linear-gradient(90deg, var(--coral) 0 6px, transparent 6px 12px); opacity: 0.45; }
+    .human-pin { grid-column: var(--col) / span 1; position: relative; }
+    .pin-mark { width: 14px; height: 14px; background: var(--coral); transform: rotate(45deg); position: absolute; top: 50%; left: 50%; margin: -7px 0 0 -7px; z-index: 2; box-shadow: 0 0 0 4px var(--canvas-2), 0 0 18px var(--coral-ring); }
+    .pin-mark.is-optional { background: transparent; border: 1.5px solid var(--coral); box-shadow: 0 0 0 4px var(--canvas-2); }
+    .pin-label { position: absolute; bottom: calc(50% + 16px); left: 50%; transform: translateX(-50%); white-space: nowrap; text-align: center; display: flex; flex-direction: column; align-items: center; gap: 3px; }
+    .pin-label .pl-name { font: 9.5px/1.1 var(--mono); color: var(--cream); letter-spacing: 0.16em; text-transform: uppercase; }
+    .pin-label .pl-dur { font-family: var(--italic); font-style: italic; font-size: 14px; line-height: 1; color: var(--coral); }
+    .pin-time { position: absolute; top: calc(50% + 16px); left: 50%; transform: translateX(-50%); font: 9px/1 var(--mono); color: var(--dim); letter-spacing: 0.18em; text-transform: uppercase; white-space: nowrap; }
+    .human-pin.pin-edge-l .pin-label, .human-pin.pin-edge-l .pin-time { left: 0; transform: none; align-items: flex-start; text-align: left; }
+    .human-pin.pin-edge-r .pin-label, .human-pin.pin-edge-r .pin-time { left: auto; right: 0; transform: none; align-items: flex-end; text-align: right; }
+    .lanes-ticks { display: grid; grid-template-columns: repeat(10, 1fr); margin-top: 12px; padding-top: 10px; border-top: 1px dashed var(--rule); }
+    .lanes-ticks .tl-tick { color: var(--ghost); }
+    .lanes-ticks .tl-tick:nth-child(5n+1) { color: var(--dim); }
+    .lanes-cap { display: flex; justify-content: space-between; gap: 18px; font-family: var(--mono); font-size: 10px; color: var(--dim); letter-spacing: 0.14em; text-transform: uppercase; margin-top: 22px; padding-top: 14px; border-top: 1px dashed var(--rule); flex-wrap: wrap; }
+    .lanes-pretitle { font-family: var(--mono); font-size: 10px; color: var(--coral); letter-spacing: 0.22em; text-transform: uppercase; margin-bottom: 22px; display: flex; align-items: center; gap: 14px; }
+    .lanes-pretitle::before { content: ""; width: 28px; height: 1px; background: var(--coral); }
+
+    /* ---------- §04 founder origin ---------- */
+    .origin-frame { max-width: 720px; margin: 0 auto; border-left: 1px solid var(--coral); padding: 6px 0 6px 36px; }
+    .origin-frame .o-tag { font-family: var(--mono); font-size: 10px; color: var(--coral); letter-spacing: 0.22em; text-transform: uppercase; margin-bottom: 24px; display: block; }
+    .origin-frame p { font-size: 18px; font-weight: 300; color: var(--cream); line-height: 1.65; margin-bottom: 22px; text-wrap: pretty; }
+    .origin-frame p:last-of-type { margin-bottom: 0; }
+    .origin-frame em { color: var(--coral); font-size: 1.08em; }
+    .origin-attr { font-family: var(--mono); font-size: 11px; color: var(--dim); letter-spacing: 0.16em; text-transform: uppercase; margin-top: 36px; padding-top: 22px; border-top: 1px dashed var(--rule); display: flex; gap: 14px; flex-wrap: wrap; align-items: center; }
+    .origin-attr .o-name { color: var(--cream); }
+    .origin-attr .o-sep { color: var(--ghost); }
+    .origin-attr a { color: var(--cream-2); border-bottom: 1px solid var(--rule-2); }
+    .origin-attr a:hover { color: var(--coral); border-bottom-color: var(--coral); }
+
+    /* ---------- reveal anims for new sections ---------- */
+    .sculley .sk-box { opacity: 0; transform: translateY(8px); }
+    .sculley.is-visible .sk-box { animation: sk-rise .7s var(--ease) forwards; }
+    .sculley.is-visible .sk-box:nth-child(1) { animation-delay: 0ms; }
+    .sculley.is-visible .sk-box:nth-child(2) { animation-delay: 60ms; }
+    .sculley.is-visible .sk-box:nth-child(3) { animation-delay: 120ms; }
+    .sculley.is-visible .sk-box:nth-child(4) { animation-delay: 180ms; }
+    .sculley.is-visible .sk-box:nth-child(5) { animation-delay: 240ms; }
+    .sculley.is-visible .sk-box:nth-child(6) { animation-delay: 300ms; }
+    .sculley.is-visible .sk-box:nth-child(7) { animation-delay: 360ms; }
+    .sculley.is-visible .sk-box:nth-child(8) { animation-delay: 420ms; }
+    .sculley.is-visible .sk-box:nth-child(9) { animation-delay: 480ms; }
+    .sculley.is-visible .sk-mlcode { animation: sk-rise-glow 1s var(--ease) 620ms forwards; }
+    @keyframes sk-rise { to { opacity: 1; transform: translateY(0); } }
+    @keyframes sk-rise-glow {
+      0%   { opacity: 0; transform: translateY(0) scale(0.6);  box-shadow: 0 0 0 4px var(--canvas-2), 0 0 0 var(--coral-ring); }
+      60%  { opacity: 1; transform: translateY(0) scale(1.15); box-shadow: 0 0 0 4px var(--canvas-2), 0 0 32px var(--coral-ring); }
+      100% { opacity: 1; transform: translateY(0) scale(1);    box-shadow: 0 0 0 4px var(--canvas-2), 0 0 24px var(--coral-ring); }
+    }
+    .tl-bar { clip-path: inset(0 100% 0 0); transition: clip-path 1.4s var(--ease) .2s; }
+    .tl-bar.is-visible { clip-path: inset(0 0 0 0); }
+    .tl-annot { opacity: 0; transition: opacity .5s var(--ease) 1.3s; }
+    .tl-annot.is-visible { opacity: 1; }
+    .tl-tick.is-pivot { animation: tick-pulse 2.4s var(--ease) 1.8s infinite; }
+    @keyframes tick-pulse { 0%, 100% { opacity: .55; } 50% { opacity: 1; } }
+    .cite { opacity: 0; transform: translateY(10px); transition: opacity .7s var(--ease), transform .7s var(--ease); }
+    .cites.is-visible .cite { opacity: 1; transform: none; }
+    .cites.is-visible .cite:nth-child(2) { transition-delay: 120ms; }
+    .cites.is-visible .cite:nth-child(3) { transition-delay: 240ms; }
+    .litany-frame { opacity: 0; transform: translateY(10px); transition: opacity .9s var(--ease), transform .9s var(--ease); }
+    .litany-frame.is-visible { opacity: 1; transform: none; }
+    .zo-lane { clip-path: inset(0 100% 0 0); transition: clip-path 1.6s var(--ease) .2s; }
+    .zo-lane.is-visible { clip-path: inset(0 0 0 0); }
+    .between-label { opacity: 0; transition: opacity .7s var(--ease) 1.3s; }
+    .between-label.is-visible { opacity: 1; }
+    .human-baseline { clip-path: inset(0 100% 0 0); transition: clip-path 1.6s var(--ease) .4s; }
+    .human-lane.is-visible .human-baseline { clip-path: inset(0 0 0 0); }
+    .human-pin { opacity: 0; transform: scale(0.6); transition: opacity .5s var(--ease), transform .5s var(--ease); }
+    .human-lane.is-visible .human-pin { opacity: 1; transform: scale(1); }
+    .human-lane.is-visible .human-pin:nth-of-type(2) { transition-delay: 1.30s; }
+    .human-lane.is-visible .human-pin:nth-of-type(3) { transition-delay: 1.50s; }
+    .human-lane.is-visible .human-pin:nth-of-type(4) { transition-delay: 1.70s; }
+    .human-lane.is-visible .human-pin:nth-of-type(5) { transition-delay: 1.90s; }
+    .human-lane.is-visible .pin-mark { animation: pin-pulse 3.2s var(--ease) 2.4s infinite; }
+    @keyframes pin-pulse {
+      0%, 100% { box-shadow: 0 0 0 4px var(--canvas-2), 0 0 14px var(--coral-ring); }
+      50%      { box-shadow: 0 0 0 4px var(--canvas-2), 0 0 24px var(--coral-ring); }
+    }
+    @media (prefers-reduced-motion: reduce) {
+      .sculley .sk-box, .cite, .litany-frame, .between-label, .human-pin { opacity: 1 !important; transform: none !important; }
+      .tl-bar, .zo-lane, .human-baseline { clip-path: none !important; }
+    }
+    @media (max-width: 880px) {
+      .sculley { grid-template-rows: 72px 72px 72px; }
+      .cites { grid-template-columns: 1fr; }
+      .lanes-grid, .tl-grid, .tl-annot-row { grid-template-columns: 80px 1fr; }
+    }
+
+    /* Hero headline override — keep italic em flowing inline so longer
+       headlines wrap naturally instead of each em jumping to its own line. */
+    .hero .display em { display: inline; }
+    .hero .display { font-size: clamp(38px, 5vw, 64px); line-height: 1.05; letter-spacing: -0.02em; }
+
+    /* ---------- Footer thanks strip ---------- */
+    .footer-thanks {
+      border-top: 1px dashed var(--rule);
+      padding: 44px 0 36px;
+      display: grid;
+      grid-template-columns: 1fr;
+      gap: 22px;
+    }
+    .footer-thanks .ft-kicker {
+      font-family: var(--mono); font-size: 10px; color: var(--coral);
+      letter-spacing: 0.24em; text-transform: uppercase;
+      display: flex; align-items: center; gap: 14px;
+    }
+    .footer-thanks .ft-kicker::before {
+      content: ""; width: 28px; height: 1px; background: var(--coral);
+    }
+    .footer-thanks .ft-statement {
+      font-family: var(--sans); font-size: 17px; font-weight: 300;
+      color: var(--cream); line-height: 1.55; max-width: 720px;
+      text-wrap: pretty; margin: 0;
+    }
+    .footer-thanks .ft-statement em {
+      font-family: var(--italic); font-style: italic;
+      color: var(--coral); font-size: 1.05em;
+    }
+    .footer-thanks .ft-names {
+      display: flex; flex-wrap: wrap; gap: 0 14px; row-gap: 10px;
+      margin: 6px 0 0; padding: 0; list-style: none;
+      font-size: 14px; color: var(--cream-2); font-weight: 400;
+    }
+    .footer-thanks .ft-names li {
+      display: inline-flex; align-items: center; gap: 14px;
+    }
+    .footer-thanks .ft-names li + li::before {
+      content: "·"; color: var(--ghost); margin-right: 0;
+    }
+    .footer-thanks .ft-names a {
+      color: var(--cream-2);
+      border-bottom: 1px solid var(--rule-2);
+      padding-bottom: 1px;
+      transition: color .2s var(--ease), border-color .2s var(--ease);
+    }
+    .footer-thanks .ft-names a:hover {
+      color: var(--coral); border-bottom-color: var(--coral);
+    }
+    @media (max-width: 720px) {
+      .footer-thanks .ft-statement { font-size: 15px; }
+      .footer-thanks .ft-names { font-size: 13px; }
+    }
+  

--- a/website/public/styles.css
+++ b/website/public/styles.css
@@ -2104,6 +2104,75 @@ em, .it {
       .cites { grid-template-columns: 1fr; }
       .lanes-grid, .tl-grid, .tl-annot-row { grid-template-columns: 80px 1fr; }
     }
+    /* Tablet / small-desktop — pin labels in §03 lanes overlap once the
+       human-lane is narrower than ~900px. Drop the descriptive name
+       (the pin-time below the diamond — "week 1", "week 3", etc — keeps
+       the label addressable). */
+    @media (max-width: 900px) {
+      .pin-label .pl-name { display: none; }
+      .pin-label .pl-dur { font-size: 12px; }
+    }
+    /* Narrow tablet / mobile — the Sculley 8-col grid and the timeline group
+       brackets can't fit. Reflow Sculley to 2 columns with ML CODE spanning
+       full width as the focal point; compact timeline group labels and segments. */
+    @media (max-width: 720px) {
+      /* Sculley — 2-col reflow, ML CODE prominent */
+      .sculley-frame { padding: 22px 18px 18px; }
+      .sculley {
+        grid-template-columns: repeat(2, 1fr);
+        grid-template-rows: auto;
+        gap: 6px;
+      }
+      .sk-config, .sk-collect, .sk-verify, .sk-machine,
+      .sk-feature, .sk-analysis, .sk-serving, .sk-process, .sk-monitor {
+        grid-column: auto;
+        grid-row: auto;
+      }
+      .sk-mlcode {
+        grid-column: 1 / -1;
+        width: auto;
+        min-height: 52px;
+        padding: 12px 14px;
+      }
+      .sk-box { min-height: 56px; padding: 10px 12px; }
+      .sk-box .sk-label { font-size: 9px; letter-spacing: 0.1em; }
+      .sk-stuff { gap: 4px; }
+      .sculley-cap { flex-direction: column; gap: 6px; }
+      .sculley-cap .cap-r { text-align: left; }
+
+      /* Timeline group brackets — reduce font + drop wks count
+         (the legend below already lists "plumbing · 3 weeks", etc). */
+      .tl-group {
+        font-size: 8.5px;
+        letter-spacing: 0.08em;
+        padding: 5px 4px 6px;
+        gap: 4px;
+      }
+      .tl-group .tl-group-weeks { display: none; }
+      .tl-seg { font-size: 9px; padding: 0 6px; letter-spacing: 0.02em; }
+      .tl-annot-text { font-size: 9px; }
+
+      /* §03 ZO lane — tighten padding/font so 6 phases fit in 10 cols
+         at narrow widths. */
+      .zo-seg { padding: 0 6px; font-size: 9px; letter-spacing: 0.01em; }
+      .zo-seg.is-active::before { width: 4px; height: 4px; margin-right: 4px; }
+
+      /* §03 Human pins — pin-time labels ("WEEK 1") sit closer than the
+         column width allows; tighten font and stack tighter. */
+      .pin-time { font-size: 8px; letter-spacing: 0.1em; }
+      .pin-label .pl-dur { font-size: 11px; }
+
+      /* Lane row label column — shrink so the lanes get more room. */
+      .lanes-grid, .tl-grid, .tl-annot-row { grid-template-columns: 56px 1fr; }
+      .lanes-frame { padding: 24px 18px 22px; }
+      .timeline { padding: 22px 16px 18px; }
+      .between-label { font-size: 12px; padding: 12px 0 12px 4px; }
+      .between-note { font-size: 11px; }
+      .between-label::before { flex: 0 0 40px; }
+
+      /* Lanes caption stacks vertically on mobile. */
+      .lanes-cap { flex-direction: column; gap: 4px; font-size: 9px; }
+    }
 
     /* Hero headline override — keep italic em flowing inline so longer
        headlines wrap naturally instead of each em jumping to its own line. */

--- a/website/src/pages/index.html
+++ b/website/src/pages/index.html
@@ -1071,20 +1071,38 @@
   <!-- v2 reveal observer for new section visuals (sculley · timeline · lanes · cites · litany) -->
   <script>
   (function () {
-    var SELECTORS = '.sculley, .tl-bar, .tl-annot, .zo-lane, .human-lane, .between-label, .litany-frame, .cites';
+    // Direct targets — pre-reveal CSS uses opacity/transform, which IntersectionObserver
+    // ignores, so these elements report intersection normally.
+    var DIRECT = '.sculley, .tl-annot, .human-lane, .between-label, .litany-frame, .cites';
+    // Wrapped targets — pre-reveal `clip-path: inset(0 100% 0 0)` collapses the element's
+    // intersection rect to zero so the observer never fires for it. Observe the wrapper
+    // (which has natural geometry) and reveal the inner clipped element on intersect.
+    var WRAPPED = [
+      { wrapper: '.timeline', inner: '.tl-bar' },
+      { wrapper: '.lanes-frame', inner: '.zo-lane' }
+    ];
+    function reveal(el) { el.classList.add('is-visible'); }
     if (!('IntersectionObserver' in window)) {
-      document.querySelectorAll(SELECTORS).forEach(function (el) { el.classList.add('is-visible'); });
+      document.querySelectorAll(DIRECT).forEach(reveal);
+      WRAPPED.forEach(function (w) { document.querySelectorAll(w.inner).forEach(reveal); });
       return;
     }
     var obs = new IntersectionObserver(function (entries) {
       entries.forEach(function (e) {
-        if (e.isIntersecting) {
-          e.target.classList.add('is-visible');
-          obs.unobserve(e.target);
-        }
+        if (!e.isIntersecting) return;
+        reveal(e.target);
+        WRAPPED.forEach(function (w) {
+          if (e.target.matches(w.wrapper)) {
+            e.target.querySelectorAll(w.inner).forEach(reveal);
+          }
+        });
+        obs.unobserve(e.target);
       });
     }, { threshold: 0.18, rootMargin: '0px 0px -8% 0px' });
-    document.querySelectorAll(SELECTORS).forEach(function (el) { obs.observe(el); });
+    document.querySelectorAll(DIRECT).forEach(function (el) { obs.observe(el); });
+    WRAPPED.forEach(function (w) {
+      document.querySelectorAll(w.wrapper).forEach(function (el) { obs.observe(el); });
+    });
   })();
   </script>
 

--- a/website/src/pages/index.html
+++ b/website/src/pages/index.html
@@ -3,8 +3,8 @@
 <head>
   <meta charset="utf-8"/>
   <meta name="viewport" content="width=device-width, initial-scale=1"/>
-  <title>Zero Operators — You write the plan. We ship the model.</title>
-  <meta name="description" content="The autonomous research team for production ML. You define the oracle on your data — Zero Operators delivers an audit-ready trained model your domain expert will sign off on."/>
+  <title>Zero Operators — An autonomous AI research team. You stay the director.</title>
+  <meta name="description" content="An autonomous AI research team for production ML. You define the oracle on your data — Zero Operators delivers an audit-ready trained model your domain expert will sign off on."/>
   <link rel="preconnect" href="https://fonts.googleapis.com"/>
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin/>
   <link href="https://fonts.googleapis.com/css2?family=Geist:wght@300;400;500;600;700&family=Cormorant+Garamond:ital,wght@0,400;0,500;1,400;1,500&family=JetBrains+Mono:wght@400;500&display=swap" rel="stylesheet"/>
@@ -21,8 +21,8 @@
         <span class="wordmark">Zero<em>Operators</em></span>
       </a>
       <div class="nav-right">
+        <a class="nav-link" href="#diagnosis">The diagnosis</a>
         <a class="nav-link" href="#idea">The idea</a>
-        <a class="nav-link" href="#handoff">Handoff</a>
         <a class="nav-link" href="#team">The team</a>
         <a class="nav-link" href="#how">How it works</a>
         <a class="nav-link" href="#different">Different</a>
@@ -56,13 +56,16 @@
         </button>
       </div>
       <nav class="md-links">
-        <a href="#idea" class="md-link" data-md-close><span class="md-num">02</span><span class="md-label">The idea</span></a>
-        <a href="#handoff" class="md-link" data-md-close><span class="md-num">03</span><span class="md-label">Handoff</span></a>
-        <a href="#team" class="md-link" data-md-close><span class="md-num">04</span><span class="md-label">The team</span></a>
-        <a href="#how" class="md-link" data-md-close><span class="md-num">05</span><span class="md-label">How it works</span></a>
-        <a href="#oracle" class="md-link" data-md-close><span class="md-num">06</span><span class="md-label">Oracle &amp; memory</span></a>
-        <a href="#different" class="md-link" data-md-close><span class="md-num">07</span><span class="md-label">Different</span></a>
-        <a href="#start" class="md-link" data-md-close><span class="md-num">08</span><span class="md-label">Quick start</span></a>
+        <a href="#diagnosis" class="md-link" data-md-close><span class="md-num">02</span><span class="md-label">The diagnosis</span></a>
+        <a href="#unlock" class="md-link" data-md-close><span class="md-num">03</span><span class="md-label">The unlock</span></a>
+        <a href="#origin" class="md-link" data-md-close><span class="md-num">04</span><span class="md-label">Why I built it</span></a>
+        <a href="#idea" class="md-link" data-md-close><span class="md-num">05</span><span class="md-label">The idea</span></a>
+        <a href="#handoff" class="md-link" data-md-close><span class="md-num">06</span><span class="md-label">Handoff</span></a>
+        <a href="#team" class="md-link" data-md-close><span class="md-num">07</span><span class="md-label">The team</span></a>
+        <a href="#how" class="md-link" data-md-close><span class="md-num">08</span><span class="md-label">How it works</span></a>
+        <a href="#oracle" class="md-link" data-md-close><span class="md-num">09</span><span class="md-label">Oracle &amp; memory</span></a>
+        <a href="#different" class="md-link" data-md-close><span class="md-num">10</span><span class="md-label">Different</span></a>
+        <a href="#start" class="md-link" data-md-close><span class="md-num">11</span><span class="md-label">Quick start</span></a>
       </nav>
       <div class="md-foot">
         <a class="btn btn-ghost-sm md-docs" href="https://docs.zerooperators.com" target="_blank" rel="noopener">Docs →</a>
@@ -72,7 +75,7 @@
     </aside>
   </div>
 
-  <!-- HERO -->
+  <!-- HERO — original visual, new headline + lede -->
   <header class="hero" id="top">
     <div class="container hero-inner">
       <div class="hero-copy">
@@ -81,13 +84,15 @@
           <span>Zero Operators · v1.0.2 · by <a href="https://samtukra.com/" target="_blank" rel="noopener" class="author-link"><em>Samyakh (Sam) Tukra</em></a></span>
         </div>
         <h1 class="display reveal" data-delay="120">
-          You write the plan.<br/>
-          <em>We ship the model.</em>
+          An autonomous AI <em>research team.</em><br/>
+          You stay the <em>director.</em>
         </h1>
         <p class="lede reveal" data-delay="260">
-          The autonomous research <em>team</em> for production ML. You define the oracle
-          on your data — Zero Operators delivers an audit-ready trained model your
-          domain expert will sign off on. <em>Built by specialised agents that cross-check each other.</em>
+          Most of building a model <em>isn't the model</em>. Three weeks understanding the data,
+          two weeks cleaning, one on infra — by the time you're modelling, the deadline is
+          breathing down your neck. Zero Operators runs that pipeline as a <em>full production-grade
+          AI research team</em>. You stay where you add value: reading results, choosing the next
+          experiment, deciding when to pivot.
         </p>
         <div class="ctas reveal" data-delay="400">
           <a class="btn btn-primary" href="#start">
@@ -126,11 +131,296 @@
     </div>
   </header>
 
-  <!-- SECTION 02 · THE IDEA -->
+  <!-- =================================================================
+       §02 · THE DIAGNOSIS  (NEW)
+       ================================================================= -->
+  <section class="section" id="diagnosis">
+    <div class="container">
+      <div class="section-head reveal">
+        <span class="section-num">02<span class="section-kind">The diagnosis</span></span>
+        <h2 class="section-title">
+          Most of building a model <em>isn't the model.</em>
+        </h2>
+        <p class="section-lede">
+          Three weeks understanding the data. Two weeks cleaning it. One on
+          scaffolding and training infra. <em>Then</em> — finally — three on model
+          experiments, four on iteration, one on packaging. By the time you're
+          modelling, the deadline is breathing down your neck.
+        </p>
+      </div>
+
+      <!-- Visual A · Sculley -->
+      <div class="subhead reveal">System level · the canonical diagram</div>
+      <div class="sculley-frame">
+        <div class="sculley">
+          <div class="sk-box sk-config"><span class="sk-label">Configuration</span><div class="sk-stuff"><i></i><i></i><i></i><i></i></div></div>
+          <div class="sk-box sk-collect"><span class="sk-label">Data Collection</span><div class="sk-stuff"><i></i><i></i><i></i><i></i></div></div>
+          <div class="sk-box sk-verify"><span class="sk-label">Data Verification</span><div class="sk-stuff"><i></i><i></i><i></i></div></div>
+          <div class="sk-box sk-machine"><span class="sk-label">Machine<br/>Resource<br/>Mgmt</span></div>
+          <div class="sk-box sk-feature"><span class="sk-label">Feature Extraction</span><div class="sk-stuff"><i></i><i></i><i></i></div></div>
+          <div class="sk-box sk-mlcode"><span class="sk-label">ML Code</span><div class="sk-stuff"><i></i><i></i></div></div>
+          <div class="sk-box sk-analysis"><span class="sk-label">Analysis Tools</span><div class="sk-stuff"><i></i><i></i><i></i></div></div>
+          <div class="sk-box sk-serving"><span class="sk-label">Serving Infrastructure</span><div class="sk-stuff"><i></i><i></i><i></i><i></i></div></div>
+          <div class="sk-box sk-process"><span class="sk-label">Process Management Tools</span><div class="sk-stuff"><i></i><i></i><i></i></div></div>
+          <div class="sk-box sk-monitor"><span class="sk-label">Monitoring</span><div class="sk-stuff"><i></i><i></i><i></i></div></div>
+        </div>
+        <div class="sculley-cap">
+          <span>↑ &nbsp;<em>~5%</em>&nbsp; of code is the model. The rest is plumbing.</span>
+          <span class="cap-r">After Sculley et al. · <a href="https://papers.nips.cc/paper/5656-hidden-technical-debt-in-machine-learning-systems.pdf" target="_blank" rel="noopener">NIPS 2015 paper</a></span>
+        </div>
+      </div>
+
+      <!-- Visual B · Timeline -->
+      <div class="subhead reveal" style="margin-top: 36px;">Project level · 10 weeks of a real ML delivery</div>
+      <div class="timeline">
+        <div class="tl-annot-row">
+          <div></div>
+          <div class="tl-annot-track">
+            <div class="tl-annot" style="--col: 4">
+              <span class="tl-annot-text">first line of model code · week 4</span>
+              <span class="tl-annot-line"></span>
+            </div>
+          </div>
+        </div>
+        <div class="tl-grid tl-groups-row">
+          <span class="tl-row-label">Type →</span>
+          <div class="tl-groups">
+            <div class="tl-group tl-group-cool" style="grid-column: span 3"><span>Plumbing</span><span class="tl-group-weeks">3 wks</span></div>
+            <div class="tl-group tl-group-coral" style="grid-column: span 4"><span>Model</span><span class="tl-group-weeks">4 wks</span></div>
+            <div class="tl-group tl-group-dim" style="grid-column: span 3"><span>Packaging</span><span class="tl-group-weeks">3 wks</span></div>
+          </div>
+        </div>
+        <div class="tl-grid">
+          <span class="tl-row-label">Phases →</span>
+          <div class="tl-bar">
+            <div class="tl-seg tl-seg-cool" style="grid-column: span 1">data</div>
+            <div class="tl-seg tl-seg-cool-2" style="grid-column: span 1">clean</div>
+            <div class="tl-seg tl-seg-cool-2" style="grid-column: span 1">scaffold</div>
+            <div class="tl-seg tl-seg-coral is-key" style="grid-column: span 2">model exp.</div>
+            <div class="tl-seg tl-seg-coral" style="grid-column: span 2">iteration</div>
+            <div class="tl-seg tl-seg-dim" style="grid-column: span 1">package</div>
+            <div class="tl-seg tl-seg-dim" style="grid-column: span 1">test</div>
+            <div class="tl-seg tl-seg-dim" style="grid-column: span 1">deploy</div>
+          </div>
+        </div>
+        <div class="tl-grid">
+          <span class="tl-row-label" style="visibility: hidden">.</span>
+          <div class="tl-ticks">
+            <span class="tl-tick">w1</span><span class="tl-tick">2</span><span class="tl-tick">3</span>
+            <span class="tl-tick is-pivot">4</span>
+            <span class="tl-tick">5</span><span class="tl-tick">6</span><span class="tl-tick">7</span><span class="tl-tick">8</span><span class="tl-tick">9</span><span class="tl-tick">10</span>
+          </div>
+        </div>
+        <div class="tl-legend">
+          <span class="lg-item"><span class="lg-swatch cool"></span> plumbing · 3 weeks</span>
+          <span class="lg-item"><span class="lg-swatch coral"></span> model · 4 weeks (squeezed in the middle)</span>
+          <span class="lg-item"><span class="lg-swatch dim"></span> packaging · 3 weeks</span>
+        </div>
+      </div>
+
+      <!-- Visual C · Litany -->
+      <div class="subhead reveal" style="margin-top: 36px;">Individual level · what you actually do all day</div>
+      <div class="litany-frame">
+        <span class="litany-label">before you touch the model</span>
+        <div class="litany">
+          load data<span class="l-sep">·</span> validate schema<span class="l-sep">·</span>
+          reconcile timestamps<span class="l-sep">·</span> handle missing values<span class="l-sep">·</span>
+          check class balance<span class="l-sep">·</span> dedupe records<span class="l-sep">·</span>
+          outlier detection<span class="l-sep">·</span> stratify train/val/test<span class="l-sep">·</span>
+          build DataLoader<span class="l-sep">·</span> caching layer<span class="l-sep">·</span>
+          write augmentation<span class="l-sep">·</span> version data<span class="l-sep">·</span>
+          DVC<span class="l-sep">·</span> S3 bucket policy<span class="l-sep">·</span>
+          build training loop<span class="l-sep">·</span> configure logger<span class="l-sep">·</span>
+          wandb integration<span class="l-sep">·</span> checkpoint logic<span class="l-sep">·</span>
+          LR scheduling<span class="l-sep">·</span> gradient clipping<span class="l-sep">·</span>
+          mixed precision<span class="l-sep">·</span> DDP setup<span class="l-sep">·</span>
+          config management<span class="l-sep">·</span> hydra<span class="l-sep">·</span>
+          eval scripts<span class="l-sep">·</span> metric tracking<span class="l-sep">·</span>
+          confusion matrix<span class="l-sep">·</span> error analysis<span class="l-sep">·</span>
+          slice metrics<span class="l-sep">·</span> calibration<span class="l-sep">·</span>
+          inference scripts<span class="l-sep">·</span> ONNX export<span class="l-sep">·</span>
+          model serving<span class="l-sep">·</span> FastAPI endpoint<span class="l-sep">·</span>
+          Docker image<span class="l-sep">·</span> deployment config<span class="l-sep">·</span>
+          load testing<span class="l-sep">·</span> monitoring<span class="l-sep">·</span>
+          drift detection<span class="l-sep">·</span> alerting<span class="l-sep">·</span>
+          rollback plan<span class="l-sep">·</span> audit logging<span class="l-sep">·</span>
+          compliance review<span class="l-sep">·</span> handoff doc<span class="l-end">…</span>
+        </div>
+      </div>
+
+      <!-- citations -->
+      <div class="subhead reveal" style="margin-top: 36px;">Backed by the literature</div>
+      <div class="cites">
+        <article class="cite">
+          <p class="ct-quote"><span class="ct-num">~5%</span> of a mature ML system's code is the model itself. The rest is glue.</p>
+          <div class="ct-source">
+            <span>Sculley et al. · NIPS 2015</span>
+            <span><a href="https://papers.nips.cc/paper/5656-hidden-technical-debt-in-machine-learning-systems.pdf" target="_blank" rel="noopener">paper ↗</a></span>
+          </div>
+        </article>
+        <article class="cite">
+          <p class="ct-quote"><span class="ct-num">3 of 5</span> data scientists spend most of their day cleaning data — not modelling.</p>
+          <div class="ct-source"><span>CrowdFlower 2016 · Forbes coverage</span></div>
+        </article>
+        <article class="cite">
+          <p class="ct-quote"><span class="ct-num">47%</span> of ML teams take 4–6 months to ship a single model. <span class="ct-num">68%</span> abandon experiments.</p>
+          <div class="ct-source"><span>Comet 2021 · ML Practitioner Survey</span></div>
+        </article>
+      </div>
+    </div>
+  </section>
+
+  <!-- =================================================================
+       §03 · THE UNLOCK  (NEW)
+       ================================================================= -->
+  <section class="section" id="unlock">
+    <div class="container">
+      <div class="section-head reveal">
+        <span class="section-num">03<span class="section-kind">The unlock</span></span>
+        <h2 class="section-title">
+          Same six phases. <em>Now autonomous.</em>
+        </h2>
+        <p class="section-lede">
+          Data engineering, cleaning, scaffolding, training infra, eval scripts,
+          packaging — the work that used to consume your weeks runs autonomously.
+          You stay the researcher: <em>reading results, choosing the next experiment,
+          deciding when to pivot.</em>
+        </p>
+      </div>
+
+      <div class="lanes-pretitle reveal">10 weeks · same axis as above</div>
+
+      <div class="lanes-frame">
+        <div class="lanes-grid">
+          <div class="lane-row">
+            <span class="lane-label">
+              <em>ZO</em>
+              <span class="lane-sub">runs the cycle</span>
+            </span>
+            <div class="zo-lane">
+              <div class="zo-seg" style="grid-column: span 1">data</div>
+              <div class="zo-seg" style="grid-column: span 1">clean</div>
+              <div class="zo-seg" style="grid-column: span 1">scaffold</div>
+              <div class="zo-seg is-active" style="grid-column: span 2">model exp.</div>
+              <div class="zo-seg" style="grid-column: span 2">iteration</div>
+              <div class="zo-seg" style="grid-column: span 3">package · test · deploy</div>
+            </div>
+          </div>
+
+          <div class="between-row">
+            <div class="between-spacer"></div>
+            <div class="between-label">
+              <em>continuous direction</em>
+              <span class="between-note">— reading results, choosing the next experiment, deciding when to pivot</span>
+            </div>
+          </div>
+
+          <div class="lane-row">
+            <span class="lane-label">
+              <em>You</em>
+              <span class="lane-sub">direct</span>
+            </span>
+            <div class="human-lane">
+              <div class="human-baseline"></div>
+              <div class="human-pin pin-edge-l" style="--col: 1">
+                <span class="pin-label">
+                  <span class="pl-name">approve plan</span>
+                  <span class="pl-dur">~30 min</span>
+                </span>
+                <span class="pin-mark"></span>
+                <span class="pin-time">week 1</span>
+              </div>
+              <div class="human-pin" style="--col: 3">
+                <span class="pin-label">
+                  <span class="pl-name">gate 2 · features</span>
+                  <span class="pl-dur">~30 min</span>
+                </span>
+                <span class="pin-mark"></span>
+                <span class="pin-time">week 3</span>
+              </div>
+              <div class="human-pin" style="--col: 6">
+                <span class="pin-label">
+                  <span class="pl-name">oracle plateau</span>
+                  <span class="pl-dur">~15 min</span>
+                </span>
+                <span class="pin-mark is-optional"></span>
+                <span class="pin-time">if needed</span>
+              </div>
+              <div class="human-pin pin-edge-r" style="--col: 9">
+                <span class="pin-label">
+                  <span class="pl-name">gate 4 · analysis</span>
+                  <span class="pl-dur">~45 min</span>
+                </span>
+                <span class="pin-mark"></span>
+                <span class="pin-time">week 9</span>
+              </div>
+            </div>
+          </div>
+
+          <div class="lane-row">
+            <span class="lane-label" style="visibility: hidden">.</span>
+            <div class="lanes-ticks">
+              <span class="tl-tick">w1</span><span class="tl-tick">2</span><span class="tl-tick">3</span><span class="tl-tick">4</span><span class="tl-tick">5</span><span class="tl-tick">6</span><span class="tl-tick">7</span><span class="tl-tick">8</span><span class="tl-tick">9</span><span class="tl-tick">10</span>
+            </div>
+          </div>
+        </div>
+
+        <div class="lanes-cap">
+          <span>2 hours of human attention · across 10 weeks of work</span>
+          <span>full audit trail · oracle-gated · reproducible</span>
+        </div>
+      </div>
+    </div>
+  </section>
+
+  <!-- =================================================================
+       §04 · WHY I BUILT IT (founder origin)  (NEW)
+       ================================================================= -->
+  <section class="section" id="origin">
+    <div class="container">
+      <div class="section-head reveal" style="max-width: 720px; margin: 0 auto 56px;">
+        <span class="section-num">04<span class="section-kind">The proof</span></span>
+        <h2 class="section-title">Why I built it.</h2>
+      </div>
+
+      <div class="origin-frame reveal r-d1">
+        <span class="o-tag">Creator note</span>
+        <p>
+          I had an 8-week project: a high-stakes client needed a model to optimise
+          their power plant. <em>Eight weeks</em> to do all of it — data understanding,
+          cleaning, scaffolding, training, iteration, packaging — and a model
+          delivered to production. The math didn't work.
+        </p>
+        <p>
+          So I asked the obvious question: <em>what if I had a digital research
+          team at my fingertips,</em> doing all the manual work, while I acted
+          as the research director — validating, checking results, choosing
+          what to try next?
+        </p>
+        <p>
+          That's what ZO is. A full production-grade AI research team. Tied to
+          a fixed, repeatable, reproducible workflow. ZO tokens cost a
+          <em>fraction of one percent</em> of the project budget. Best ROI I've
+          ever made on a tool.
+        </p>
+        <div class="origin-attr">
+          <span class="o-name">Samyakh (Sam) Tukra</span>
+          <span class="o-sep">·</span>
+          <span>creator</span>
+          <span class="o-sep">·</span>
+          <a href="https://samtukra.com/" target="_blank" rel="noopener">samtukra.com ↗</a>
+        </div>
+      </div>
+    </div>
+  </section>
+
+  <!-- =================================================================
+       §05 · THE IDEA (was §02 — copy trimmed; diagram unchanged)
+       ================================================================= -->
   <section class="section" id="idea">
     <div class="container">
       <div class="section-head reveal">
-        <span class="section-num">02<span class="section-kind">The idea</span></span>
+        <span class="section-num">05<span class="section-kind">The idea</span></span>
         <h2 class="section-title">
           Write one file. <em>Walk away.</em><br/>
           Come back to verified work.
@@ -140,15 +430,10 @@
       <div class="idea-grid">
         <div class="idea-copy reveal">
           <p>
-            Most AI tools help you <em>write code</em>. Zero Operators delivers a
-            <em>trained model</em> — and the recipe to reproduce it.
-          </p>
-          <p>
             You write a <span class="mono-inline">plan.md</span> with your data, your
             metrics, your tiered success criteria. A lead orchestrator decomposes it.
             Specialist agents — data engineer, model builder, oracle, domain evaluator,
             code reviewer — run the work in parallel and check each other's output.
-            Memory persists across sessions, so the same mistake can't happen twice.
           </p>
           <p>
             Your part is the <em>research direction</em>, not the typing. You approve the
@@ -160,13 +445,10 @@
 
         <div class="idea-diagram reveal" aria-hidden="true">
           <svg viewBox="-40 0 560 440" class="flow" id="flow-svg" preserveAspectRatio="xMidYMid meet">
-            <!-- side labels (in left gutter, positioned at the gap between boxes
-                 so each labels the ACTION — fanout, fan-in, delivery) -->
             <text x="-32" y="148" class="flow-sub flow-it">decompose</text>
             <text x="-32" y="243" class="flow-sub flow-it">verify</text>
             <text x="-32" y="341" class="flow-sub flow-it">ship</text>
 
-            <!-- TOP: plan.md document -->
             <g class="flow-node" data-step="1" transform="translate(176, 16)">
               <rect width="128" height="92" rx="3" fill="var(--canvas-2)" stroke="var(--rule-2)" stroke-width="1"/>
               <text x="64" y="22" text-anchor="middle" class="flow-label">plan.md</text>
@@ -177,7 +459,6 @@
               <line x1="14" y1="84" x2="100" y2="84" stroke="var(--rule-2)" stroke-width="1"/>
             </g>
 
-            <!-- Decompose fanout: plan → 6 phases (terminate at top of chips, y=180) -->
             <path class="flow-arrow flow-fan" d="M 240 108 L 78 180" />
             <path class="flow-arrow flow-fan" d="M 240 108 L 144 180" />
             <path class="flow-arrow flow-fan" d="M 240 108 L 208 180" />
@@ -185,35 +466,15 @@
             <path class="flow-arrow flow-fan" d="M 240 108 L 338 180" />
             <path class="flow-arrow flow-fan" d="M 240 108 L 404 180" />
 
-            <!-- MIDDLE: 6 phase chips (with 2px gaps, centered on x=240) -->
             <g class="flow-node" data-step="2">
-              <g class="phase-chip" transform="translate(46, 180)">
-                <rect width="64" height="28" rx="3" fill="var(--canvas-2)" stroke="var(--rule-2)"/>
-                <text x="32" y="18" text-anchor="middle" class="flow-sub">data</text>
-              </g>
-              <g class="phase-chip" transform="translate(112, 180)">
-                <rect width="64" height="28" rx="3" fill="var(--canvas-2)" stroke="var(--rule-2)"/>
-                <text x="32" y="18" text-anchor="middle" class="flow-sub">features</text>
-              </g>
-              <g class="phase-chip" transform="translate(178, 180)">
-                <rect width="60" height="28" rx="3" fill="var(--canvas-2)" stroke="var(--rule-2)"/>
-                <text x="30" y="18" text-anchor="middle" class="flow-sub">model</text>
-              </g>
-              <g class="phase-chip is-active" transform="translate(240, 180)">
-                <rect width="64" height="28" rx="3" fill="var(--coral-soft)" stroke="var(--coral)"/>
-                <text x="32" y="18" text-anchor="middle" class="flow-sub flow-it">training</text>
-              </g>
-              <g class="phase-chip" transform="translate(306, 180)">
-                <rect width="64" height="28" rx="3" fill="var(--canvas-2)" stroke="var(--rule-2)"/>
-                <text x="32" y="18" text-anchor="middle" class="flow-sub">analysis</text>
-              </g>
-              <g class="phase-chip" transform="translate(372, 180)">
-                <rect width="64" height="28" rx="3" fill="var(--canvas-2)" stroke="var(--rule-2)"/>
-                <text x="32" y="18" text-anchor="middle" class="flow-sub">package</text>
-              </g>
+              <g class="phase-chip" transform="translate(46, 180)"><rect width="64" height="28" rx="3" fill="var(--canvas-2)" stroke="var(--rule-2)"/><text x="32" y="18" text-anchor="middle" class="flow-sub">data</text></g>
+              <g class="phase-chip" transform="translate(112, 180)"><rect width="64" height="28" rx="3" fill="var(--canvas-2)" stroke="var(--rule-2)"/><text x="32" y="18" text-anchor="middle" class="flow-sub">features</text></g>
+              <g class="phase-chip" transform="translate(178, 180)"><rect width="60" height="28" rx="3" fill="var(--canvas-2)" stroke="var(--rule-2)"/><text x="30" y="18" text-anchor="middle" class="flow-sub">model</text></g>
+              <g class="phase-chip is-active" transform="translate(240, 180)"><rect width="64" height="28" rx="3" fill="var(--coral-soft)" stroke="var(--coral)"/><text x="32" y="18" text-anchor="middle" class="flow-sub flow-it">training</text></g>
+              <g class="phase-chip" transform="translate(306, 180)"><rect width="64" height="28" rx="3" fill="var(--canvas-2)" stroke="var(--rule-2)"/><text x="32" y="18" text-anchor="middle" class="flow-sub">analysis</text></g>
+              <g class="phase-chip" transform="translate(372, 180)"><rect width="64" height="28" rx="3" fill="var(--canvas-2)" stroke="var(--rule-2)"/><text x="32" y="18" text-anchor="middle" class="flow-sub">package</text></g>
             </g>
 
-            <!-- Oracle gate: phases bottom (y=208) → oracle top (y=270) -->
             <path class="flow-arrow" d="M 78 208 L 240 270" />
             <path class="flow-arrow" d="M 144 208 L 240 270" />
             <path class="flow-arrow" d="M 208 208 L 240 270" />
@@ -221,17 +482,14 @@
             <path class="flow-arrow" d="M 338 208 L 240 270" />
             <path class="flow-arrow" d="M 404 208 L 240 270" />
 
-            <!-- Oracle box (170 wide, centered at x=240 → translate 155) -->
             <g class="flow-node" data-step="3" transform="translate(155, 270)">
               <rect width="170" height="44" rx="3" fill="var(--canvas)" stroke="var(--coral)" stroke-width="1.4"/>
               <text x="85" y="20" text-anchor="middle" class="flow-label">oracle</text>
               <text x="85" y="34" text-anchor="middle" class="flow-sub">must · should · could</text>
             </g>
 
-            <!-- Oracle → delivery -->
             <path class="flow-arrow" d="M 240 314 L 240 360" />
 
-            <!-- BOTTOM: trained model delivery -->
             <g class="flow-node" data-step="4" transform="translate(140, 360)">
               <rect width="200" height="60" rx="3" fill="var(--canvas-2)" stroke="var(--coral)" stroke-width="1.4"/>
               <text x="24" y="26" class="flow-tick">✓</text>
@@ -244,11 +502,13 @@
     </div>
   </section>
 
-  <!-- SECTION 03 · WHAT YOU GIVE / WHAT YOU GET -->
+  <!-- =================================================================
+       §06 · HANDOFF (was §03)
+       ================================================================= -->
   <section class="section section-handoff" id="handoff">
     <div class="container">
       <div class="section-head reveal">
-        <span class="section-num">03<span class="section-kind">The handoff</span></span>
+        <span class="section-num">06<span class="section-kind">The handoff</span></span>
         <h2 class="section-title">
           You bring two things. <em>You get four.</em>
         </h2>
@@ -258,7 +518,6 @@
       </div>
 
       <div class="handoff-grid reveal">
-        <!-- INPUT -->
         <div class="handoff-col handoff-in">
           <div class="hc-head">
             <span class="hc-kind">You provide</span>
@@ -276,7 +535,6 @@
           </ul>
         </div>
 
-        <!-- ARROW / ENGINE -->
         <div class="handoff-engine">
           <div class="he-pulse"></div>
           <div class="he-label">Zero<em>Operators</em></div>
@@ -286,7 +544,6 @@
           </svg>
         </div>
 
-        <!-- OUTPUT -->
         <div class="handoff-col handoff-out">
           <div class="hc-head">
             <span class="hc-kind">You receive</span>
@@ -315,11 +572,13 @@
     </div>
   </section>
 
-  <!-- SECTION 03 · DIGITAL RESEARCH TEAM (tmux live view) -->
+  <!-- =================================================================
+       §07 · DIGITAL RESEARCH TEAM (tmux) (was §04)
+       ================================================================= -->
   <section class="section section-team" id="team">
     <div class="container">
       <div class="section-head reveal">
-        <span class="section-num">04<span class="section-kind">A digital research team</span></span>
+        <span class="section-num">07<span class="section-kind">A digital research team</span></span>
         <h2 class="section-title">
           A <em>team</em>, not a single agent.
         </h2>
@@ -331,80 +590,39 @@
         </p>
       </div>
 
-      <!-- Peer-to-peer team diagram -->
       <div class="team-diagram reveal" aria-hidden="true">
         <svg viewBox="0 0 880 360" preserveAspectRatio="xMidYMid meet" class="team-svg">
-          <!-- Lead at top -->
           <g class="td-node td-lead">
             <rect x="320" y="20" width="240" height="48" rx="4" fill="var(--coral-soft)" stroke="var(--coral)" stroke-width="1.4"/>
             <text x="440" y="42" text-anchor="middle" class="td-label td-label-lg">Lead orchestrator</text>
             <text x="440" y="58" text-anchor="middle" class="td-sub">spawn · assign · gate</text>
           </g>
-
-          <!-- Lead → shared task list -->
           <path class="td-arrow" d="M 440 68 L 440 110" />
           <text x="450" y="92" class="td-edge">spawn &amp; assign</text>
-
-          <!-- Shared task list -->
           <g class="td-node">
             <rect x="180" y="110" width="520" height="40" rx="4" fill="var(--canvas-2)" stroke="var(--dusk)" stroke-width="1.2" stroke-dasharray="4 3"/>
             <text x="440" y="128" text-anchor="middle" class="td-label">Shared task list</text>
             <text x="440" y="142" text-anchor="middle" class="td-sub">claim · update · gate-check</text>
           </g>
-
-          <!-- Task list → 5 teammates -->
           <path class="td-arrow td-claim" d="M 230 150 L 110 220" />
           <path class="td-arrow td-claim" d="M 320 150 L 270 220" />
           <path class="td-arrow td-claim" d="M 440 150 L 440 220" />
           <path class="td-arrow td-claim" d="M 560 150 L 610 220" />
           <path class="td-arrow td-claim" d="M 650 150 L 770 220" />
-
-          <!-- Teammate row -->
           <g class="td-team">
-            <!-- 1 Data engineer -->
-            <g class="td-node td-mate">
-              <rect x="40" y="220" width="140" height="48" rx="4" fill="var(--canvas-2)" stroke="var(--rule-2)"/>
-              <text x="110" y="242" text-anchor="middle" class="td-label">Data engineer</text>
-              <text x="110" y="258" text-anchor="middle" class="td-sub">data · features</text>
-            </g>
-            <!-- 2 Model builder -->
-            <g class="td-node td-mate">
-              <rect x="200" y="220" width="140" height="48" rx="4" fill="var(--canvas-2)" stroke="var(--rule-2)"/>
-              <text x="270" y="242" text-anchor="middle" class="td-label">Model builder</text>
-              <text x="270" y="258" text-anchor="middle" class="td-sub">arch · train</text>
-            </g>
-            <!-- 3 Oracle / QA -->
-            <g class="td-node td-mate td-mate-oracle">
-              <rect x="370" y="220" width="140" height="48" rx="4" fill="var(--coral-soft)" stroke="var(--coral)" stroke-width="1.2"/>
-              <text x="440" y="242" text-anchor="middle" class="td-label">Oracle / QA</text>
-              <text x="440" y="258" text-anchor="middle" class="td-sub">verify · gate</text>
-            </g>
-            <!-- 4 Domain evaluator -->
-            <g class="td-node td-mate">
-              <rect x="540" y="220" width="140" height="48" rx="4" fill="var(--canvas-2)" stroke="var(--rule-2)"/>
-              <text x="610" y="242" text-anchor="middle" class="td-label">Domain evaluator</text>
-              <text x="610" y="258" text-anchor="middle" class="td-sub">sign-off · context</text>
-            </g>
-            <!-- 5 Code reviewer -->
-            <g class="td-node td-mate">
-              <rect x="700" y="220" width="140" height="48" rx="4" fill="var(--canvas-2)" stroke="var(--rule-2)"/>
-              <text x="770" y="242" text-anchor="middle" class="td-label">Code reviewer</text>
-              <text x="770" y="258" text-anchor="middle" class="td-sub">audit · clean</text>
-            </g>
+            <g class="td-node td-mate"><rect x="40" y="220" width="140" height="48" rx="4" fill="var(--canvas-2)" stroke="var(--rule-2)"/><text x="110" y="242" text-anchor="middle" class="td-label">Data engineer</text><text x="110" y="258" text-anchor="middle" class="td-sub">data · features</text></g>
+            <g class="td-node td-mate"><rect x="200" y="220" width="140" height="48" rx="4" fill="var(--canvas-2)" stroke="var(--rule-2)"/><text x="270" y="242" text-anchor="middle" class="td-label">Model builder</text><text x="270" y="258" text-anchor="middle" class="td-sub">arch · train</text></g>
+            <g class="td-node td-mate td-mate-oracle"><rect x="370" y="220" width="140" height="48" rx="4" fill="var(--coral-soft)" stroke="var(--coral)" stroke-width="1.2"/><text x="440" y="242" text-anchor="middle" class="td-label">Oracle / QA</text><text x="440" y="258" text-anchor="middle" class="td-sub">verify · gate</text></g>
+            <g class="td-node td-mate"><rect x="540" y="220" width="140" height="48" rx="4" fill="var(--canvas-2)" stroke="var(--rule-2)"/><text x="610" y="242" text-anchor="middle" class="td-label">Domain evaluator</text><text x="610" y="258" text-anchor="middle" class="td-sub">sign-off · context</text></g>
+            <g class="td-node td-mate"><rect x="700" y="220" width="140" height="48" rx="4" fill="var(--canvas-2)" stroke="var(--rule-2)"/><text x="770" y="242" text-anchor="middle" class="td-label">Code reviewer</text><text x="770" y="258" text-anchor="middle" class="td-sub">audit · clean</text></g>
           </g>
-
-          <!-- Peer-to-peer communication arrows (between adjacent teammates) -->
           <g class="td-peer">
             <path d="M 180 244 L 200 244" />
             <path d="M 340 244 L 370 244" />
             <path d="M 510 244 L 540 244" />
             <path d="M 680 244 L 700 244" />
           </g>
-
-          <!-- "communicate" label centered -->
           <text x="440" y="290" text-anchor="middle" class="td-edge td-edge-it">peers communicate directly</text>
-
-          <!-- Output: each does work -->
           <g class="td-work">
             <text x="110" y="322" text-anchor="middle" class="td-sub">↓ work</text>
             <text x="270" y="322" text-anchor="middle" class="td-sub">↓ work</text>
@@ -421,7 +639,6 @@
         Cross-checking is built into the topology, not asked of one model.
       </p>
 
-      <!-- Tmux subhead -->
       <div class="section-subhead reveal">
         <h3 class="section-subtitle">
           Live session — <em>the team in motion.</em>
@@ -434,7 +651,6 @@
       </div>
 
       <div class="tmux-stage reveal">
-        <!-- Real tmux window bar: session name + tab list in tmux format -->
         <div class="tmux-winbar">
           <span class="wb-session">[zo]</span>
           <span class="wb-tab">0:bash-1.1<span class="wb-sep">*</span></span>
@@ -448,9 +664,7 @@
           <span class="wb-host">"zo-build"  sam@zo  <span id="wb-date">19:45 26-Apr-26</span></span>
         </div>
 
-        <!-- Two-pane split: lead orchestrator (left, with chat input) + stacked agent panes (right) -->
         <div class="tmux-split">
-          <!-- LEFT PANE · Lead orchestrator -->
           <div class="tmux-pane tmux-lead">
             <div class="pane-head">
               <span class="ph-dot"></span>
@@ -495,7 +709,6 @@
               <div class="tmx-line t-p">▪ hook <span class="t-dim">— tmuxmate running</span></div>
             </div>
 
-            <!-- Chat input docked at bottom -->
             <div class="pane-chat">
               <div class="chat-prompt">
                 <span class="t-g">&gt;</span>
@@ -512,9 +725,7 @@
             </div>
           </div>
 
-          <!-- RIGHT PANE · stacked agent boxes -->
           <div class="tmux-pane tmux-right">
-            <!-- Agent 1: research-scout -->
             <div class="agent-box agent-active">
               <div class="pane-head">
                 <span class="ph-dot ph-dot-blue"></span>
@@ -531,7 +742,6 @@
               </div>
             </div>
 
-            <!-- Agent 2: data-engineer -->
             <div class="agent-box">
               <div class="pane-head">
                 <span class="ph-dot ph-dot-green"></span>
@@ -547,7 +757,6 @@
               </div>
             </div>
 
-            <!-- Agent 3: oracle (idle) -->
             <div class="agent-box agent-idle">
               <div class="pane-head">
                 <span class="ph-dot ph-dot-dim"></span>
@@ -562,7 +771,6 @@
           </div>
         </div>
 
-        <!-- Green tmux status bar (full width) -->
         <div class="tmux-status">
           <span class="ts-left">[zo] <span class="ts-dim">0:bash-1.1 1:lead-2.1* 2:scout-3.1 3:engineer-4.1</span></span>
           <span class="ts-right"><span class="ts-dim">"RL experiment orchestration"</span> <span class="ts-clock" id="tmux-time">19:45 26-Apr-26</span></span>
@@ -577,11 +785,13 @@
     </div>
   </section>
 
-  <!-- SECTION 04 · HOW IT WORKS -->
+  <!-- =================================================================
+       §08 · HOW IT WORKS (was §05)
+       ================================================================= -->
   <section class="section section-pipeline" id="how">
     <div class="container">
       <div class="section-head reveal">
-        <span class="section-num">05<span class="section-kind">How it works</span></span>
+        <span class="section-num">08<span class="section-kind">How it works</span></span>
         <h2 class="section-title">
           Six phases. <em>Gated at every transition.</em>
         </h2>
@@ -594,56 +804,38 @@
 
       <ol class="pipeline">
         <li class="phase reveal" data-phase="1" data-delay="0">
-          <div class="phase-head">
-            <span class="phase-num">01</span>
-            <span class="phase-kind phase-auto">Auto</span>
-          </div>
+          <div class="phase-head"><span class="phase-num">01</span><span class="phase-kind phase-auto">Auto</span></div>
           <h3 class="phase-name">Data</h3>
           <p class="phase-body">Source, validate, version. Nothing leaves this phase unlabelled, unseeded, or un-hashed.</p>
           <span class="phase-tag">agents · data-engineer · scout</span>
         </li>
         <li class="phase reveal" data-phase="2" data-delay="80">
-          <div class="phase-head">
-            <span class="phase-num">02</span>
-            <span class="phase-kind phase-human">Human gate</span>
-          </div>
+          <div class="phase-head"><span class="phase-num">02</span><span class="phase-kind phase-human">Human gate</span></div>
           <h3 class="phase-name">Features</h3>
           <p class="phase-body">Proposals from the feature bench. You approve the set. This is the only place the agents wait on you.</p>
           <span class="phase-tag">agents · feature-synth · statistician</span>
         </li>
         <li class="phase reveal" data-phase="3" data-delay="160">
-          <div class="phase-head">
-            <span class="phase-num">03</span>
-            <span class="phase-kind phase-auto">Auto</span>
-          </div>
+          <div class="phase-head"><span class="phase-num">03</span><span class="phase-kind phase-auto">Auto</span></div>
           <h3 class="phase-name">Model</h3>
           <p class="phase-body">Architecture drafted, hyperparameters defined, baselines proposed. Contract spawned for training.</p>
           <span class="phase-tag">agents · model-builder · architect</span>
         </li>
         <li class="phase reveal phase-active" data-phase="4" data-delay="240">
-          <div class="phase-head">
-            <span class="phase-num">04</span>
-            <span class="phase-kind phase-auto">Auto <span class="loop">↻ iterates</span></span>
-          </div>
+          <div class="phase-head"><span class="phase-num">04</span><span class="phase-kind phase-auto">Auto <span class="loop">↻ iterates</span></span></div>
           <h3 class="phase-name">Training</h3>
           <p class="phase-body">Run, evaluate, learn, retry. The oracle decides when a model is done — not the model.</p>
           <span class="phase-tag">agents · trainer · oracle · analyst</span>
           <div class="phase-glow"></div>
         </li>
         <li class="phase reveal" data-phase="5" data-delay="320">
-          <div class="phase-head">
-            <span class="phase-num">05</span>
-            <span class="phase-kind phase-human">Human gate</span>
-          </div>
+          <div class="phase-head"><span class="phase-num">05</span><span class="phase-kind phase-human">Human gate</span></div>
           <h3 class="phase-name">Analysis</h3>
           <p class="phase-body">Results, failures, confusion. You read the report. You approve the narrative. You decide if it ships.</p>
           <span class="phase-tag">agents · analyst · writer</span>
         </li>
         <li class="phase reveal" data-phase="6" data-delay="400">
-          <div class="phase-head">
-            <span class="phase-num">06</span>
-            <span class="phase-kind phase-auto">Auto</span>
-          </div>
+          <div class="phase-head"><span class="phase-num">06</span><span class="phase-kind phase-auto">Auto</span></div>
           <h3 class="phase-name">Packaging</h3>
           <p class="phase-body">Clean delivery repo. Zero infrastructure artifacts. A bundle your team can deploy without reading our docs.</p>
           <span class="phase-tag">agents · packager · release-eng</span>
@@ -661,11 +853,13 @@
     </div>
   </section>
 
-  <!-- SECTION 05 · ORACLE & MEMORY -->
+  <!-- =================================================================
+       §09 · ORACLE & MEMORY (was §06)
+       ================================================================= -->
   <section class="section section-split" id="oracle">
     <div class="container">
       <div class="section-head reveal">
-        <span class="section-num">06<span class="section-kind">Oracle &amp; memory</span></span>
+        <span class="section-num">09<span class="section-kind">Oracle &amp; memory</span></span>
         <h2 class="section-title">
           <em>Every claim</em> verified. <em>Every failure</em> remembered.
         </h2>
@@ -684,36 +878,17 @@
             </span>
           </div>
           <h3 class="split-title">The source of truth.</h3>
-
           <p class="oracle-intro">
             Every phase ends with a verdict. <em>Must-pass</em> gates block delivery.
             <em>Should-pass</em> flag concerns. <em>Could-pass</em> surface warnings.
             Your targets, not ours.
           </p>
-
           <ul class="oracle-checks" aria-label="verification tiers">
-            <li data-check="1">
-              <span class="check-tier">Must-pass</span>
-              <span class="check-name">meets target metric</span>
-              <span class="check-state" data-state="pending">pending</span>
-            </li>
-            <li data-check="2">
-              <span class="check-tier">Must-pass</span>
-              <span class="check-name">reproducible from seed</span>
-              <span class="check-state" data-state="pending">pending</span>
-            </li>
-            <li data-check="3">
-              <span class="check-tier">Should-pass</span>
-              <span class="check-name">coverage threshold</span>
-              <span class="check-state" data-state="pending">pending</span>
-            </li>
-            <li data-check="4">
-              <span class="check-tier">Could-pass</span>
-              <span class="check-name">statistical significance</span>
-              <span class="check-state" data-state="pending">pending</span>
-            </li>
+            <li data-check="1"><span class="check-tier">Must-pass</span><span class="check-name">meets target metric</span><span class="check-state" data-state="pending">pending</span></li>
+            <li data-check="2"><span class="check-tier">Must-pass</span><span class="check-name">reproducible from seed</span><span class="check-state" data-state="pending">pending</span></li>
+            <li data-check="3"><span class="check-tier">Should-pass</span><span class="check-name">coverage threshold</span><span class="check-state" data-state="pending">pending</span></li>
+            <li data-check="4"><span class="check-tier">Could-pass</span><span class="check-name">statistical significance</span><span class="check-state" data-state="pending">pending</span></li>
           </ul>
-
           <p class="split-foot">
             Tiered. Deterministic. <em>Your targets become the oracle's contract.</em>
             No agent marks its own homework.
@@ -726,41 +901,18 @@
             <span class="badge b-dusk">portable · persistent</span>
           </div>
           <h3 class="split-title">It never forgets.</h3>
-
           <p class="oracle-intro">
             The entire project state lives in a portable <span class="mono-inline">.zo/</span>
             directory. <em>Pause here, resume anywhere.</em> Laptop to cloud, GPU rig to CI
             runner — the context moves with the work.
           </p>
-
           <div class="memory-stream" id="memory-stream">
-            <div class="mem-line" data-t="0">
-              <span class="mem-stamp">14:02</span>
-              <span class="mem-kind mem-decision">DECISION</span>
-              <span class="mem-text">Architecture: <em>hybrid orchestration model</em></span>
-            </div>
-            <div class="mem-line" data-t="1">
-              <span class="mem-stamp">14:47</span>
-              <span class="mem-kind mem-gate">GATE</span>
-              <span class="mem-text">Phase 01 complete — context snapshot saved</span>
-            </div>
-            <div class="mem-line" data-t="2">
-              <span class="mem-stamp">15:12</span>
-              <span class="mem-kind mem-error">ERROR</span>
-              <span class="mem-text">Doc-codebase drift — 10 files stale</span>
-            </div>
-            <div class="mem-line" data-t="3">
-              <span class="mem-stamp">15:14</span>
-              <span class="mem-kind mem-prior">PRIOR</span>
-              <span class="mem-text">PR-005 · <em>aspirational rules without enforcement are dead letter</em></span>
-            </div>
-            <div class="mem-line" data-t="4">
-              <span class="mem-stamp">09:30</span>
-              <span class="mem-kind mem-resume">RESUME</span>
-              <span class="mem-text">session-020 · resumed on <em>gpu-server-03</em> — full context restored</span>
-            </div>
+            <div class="mem-line" data-t="0"><span class="mem-stamp">14:02</span><span class="mem-kind mem-decision">DECISION</span><span class="mem-text">Architecture: <em>hybrid orchestration model</em></span></div>
+            <div class="mem-line" data-t="1"><span class="mem-stamp">14:47</span><span class="mem-kind mem-gate">GATE</span><span class="mem-text">Phase 01 complete — context snapshot saved</span></div>
+            <div class="mem-line" data-t="2"><span class="mem-stamp">15:12</span><span class="mem-kind mem-error">ERROR</span><span class="mem-text">Doc-codebase drift — 10 files stale</span></div>
+            <div class="mem-line" data-t="3"><span class="mem-stamp">15:14</span><span class="mem-kind mem-prior">PRIOR</span><span class="mem-text">PR-005 · <em>aspirational rules without enforcement are dead letter</em></span></div>
+            <div class="mem-line" data-t="4"><span class="mem-stamp">09:30</span><span class="mem-kind mem-resume">RESUME</span><span class="mem-text">session-020 · resumed on <em>gpu-server-03</em> — full context restored</span></div>
           </div>
-
           <p class="split-foot">
             STATE · DECISION_LOG · PRIORS · semantic recall.
             <em>Same mistake? Literally cannot happen twice.</em>
@@ -770,11 +922,13 @@
     </div>
   </section>
 
-  <!-- SECTION 06 · WHAT MAKES IT DIFFERENT -->
+  <!-- =================================================================
+       §10 · WHAT MAKES IT DIFFERENT (was §07)
+       ================================================================= -->
   <section class="section" id="different">
     <div class="container">
       <div class="section-head reveal">
-        <span class="section-num">07<span class="section-kind">What makes it different</span></span>
+        <span class="section-num">10<span class="section-kind">What makes it different</span></span>
         <h2 class="section-title">
           Three tools. <em>Three units of work.</em><br/>
           Only one ships <em>a trained model.</em>
@@ -798,7 +952,6 @@
             <li><span>Delivery</span><em>code in your editor</em></li>
           </ul>
         </div>
-
         <div class="col">
           <span class="col-kind">Agent frameworks</span>
           <h3 class="col-name">CrewAI · AutoGen · LangGraph</h3>
@@ -810,7 +963,6 @@
             <li><span>Delivery</span><em>output files</em></li>
           </ul>
         </div>
-
         <div class="col col-feat">
           <span class="col-kind">Zero Operators</span>
           <h3 class="col-name">Zero<em>Operators</em></h3>
@@ -826,11 +978,13 @@
     </div>
   </section>
 
-  <!-- SECTION 07 · QUICK START -->
+  <!-- =================================================================
+       §11 · QUICK START (was §08)
+       ================================================================= -->
   <section class="section section-start" id="start">
     <div class="container">
       <div class="section-head reveal">
-        <span class="section-num">08<span class="section-kind">Quick start</span></span>
+        <span class="section-num">11<span class="section-kind">Quick start</span></span>
         <h2 class="section-title">
           Four commands. <em>Then walk away.</em>
         </h2>
@@ -882,12 +1036,29 @@
         <div class="fm-row"><span>Source</span><a href="https://github.com/SamPlvs/zero-operators" target="_blank" rel="noopener">GitHub →</a></div>
       </div>
       <div class="footer-links">
+        <a href="#diagnosis">The diagnosis</a>
         <a href="#idea">The idea</a>
         <a href="#how">How it works</a>
         <a href="#oracle">Oracle &amp; memory</a>
         <a href="#different">Different</a>
         <a href="#start">Quick start</a>
       </div>
+    </div>
+    <div class="container footer-thanks">
+      <span class="ft-kicker">Acknowledgements</span>
+      <p class="ft-statement">
+        No tool ships alone. With thanks to the <em>AI specialists, researchers and engineers</em>
+        who tested, guided, broke things, and made ZO sharper.
+      </p>
+      <ul class="ft-names">
+        <li><a href="https://www.linkedin.com/in/arjunagraw/" target="_blank" rel="noopener">Arjun Agrawal</a></li>
+        <li><a href="https://www.linkedin.com/in/callumadamson/" target="_blank" rel="noopener">Callum Adamson</a></li>
+        <li><a href="https://www.linkedin.com/in/harrydavies1/" target="_blank" rel="noopener">Harry Davies</a></li>
+        <li><a href="https://www.linkedin.com/in/kchatfield/" target="_blank" rel="noopener">Ken Chatfield</a></li>
+        <li><a href="https://www.linkedin.com/in/nickimrie/" target="_blank" rel="noopener">Nick Imrie</a></li>
+        <li><a href="https://www.linkedin.com/in/sergey-podatelev/?skipRedirect=true" target="_blank" rel="noopener">Sergey Podatelev</a></li>
+        <li><a href="https://www.linkedin.com/in/tianhong-dai-71b166117/" target="_blank" rel="noopener">Tianhong Dai</a></li>
+      </ul>
     </div>
     <div class="container footer-bottom">
       <span>© 2026 · Created by <a href="https://samtukra.com/" target="_blank" rel="noopener" class="author-link"><em>Samyakh (Sam) Tukra</em></a></span>
@@ -896,6 +1067,26 @@
   </footer>
 
   <script src="app.js"></script>
+
+  <!-- v2 reveal observer for new section visuals (sculley · timeline · lanes · cites · litany) -->
+  <script>
+  (function () {
+    var SELECTORS = '.sculley, .tl-bar, .tl-annot, .zo-lane, .human-lane, .between-label, .litany-frame, .cites';
+    if (!('IntersectionObserver' in window)) {
+      document.querySelectorAll(SELECTORS).forEach(function (el) { el.classList.add('is-visible'); });
+      return;
+    }
+    var obs = new IntersectionObserver(function (entries) {
+      entries.forEach(function (e) {
+        if (e.isIntersecting) {
+          e.target.classList.add('is-visible');
+          obs.unobserve(e.target);
+        }
+      });
+    }, { threshold: 0.18, rootMargin: '0px 0px -8% 0px' });
+    document.querySelectorAll(SELECTORS).forEach(function (el) { obs.observe(el); });
+  })();
+  </script>
 
 </body>
 </html>


### PR DESCRIPTION
## Summary

Homepage refresh applied from offline-prepared files in `~/Downloads/proposals/commit/`. Substantial new content + supporting CSS, plus a small JS reveal observer.

- **New §02 The diagnosis** — Sculley "Hidden Technical Debt" diagram, 10-week timeline (plumbing → model → packaging), scrolling task litany, and 3 cited stats (Sculley NIPS 2015, CrowdFlower 2016, Comet 2021).
- **New §03 The unlock** — same 10-week axis as a dual-lane diagram: ZO running the cycle vs. ~2 hours of human direction across 4 gates.
- **New §04 Why I built it** — founder origin note (8-week project anecdote, signed by `samtukra.com`).
- **Hero rewrite** — `"An autonomous AI research team. You stay the director."` (replaces `"You write the plan. We ship the model."`).
- **Section renumber** — existing §02 idea → §05, …, §08 quick start → §11. Nav, mobile drawer, and footer-links updated.
- **Footer Acknowledgements** strip with 7 collaborators (Arjun Agrawal, Callum Adamson, Harry Davies, Ken Chatfield, Nick Imrie, Sergey Podatelev, Tianhong Dai).
- **Inline IntersectionObserver** before `</body>` toggles `.is-visible` on the new visual elements for scroll-reveal; fallback adds the class immediately if `IntersectionObserver` is unavailable.

`styles.css` change is purely additive (~290 lines appended after the existing rules — no existing CSS modified). `app.js`, `hero-workshop.png`, and `favicon.svg` were unchanged or only differed in self-closing-tag style and were not touched, keeping the diff minimal.

Confidentiality (per `CLAUDE.md`): only personal names already on the site (Sam Tukra) plus 7 collaborators framed as AI specialists/researchers/engineers — no client/company names introduced.

## Test plan

- [x] `npm run build` exits 0 (Astro 5 static, 1 page, 256 ms)
- [x] `scripts/validate-docs.sh` 10 passed / 0 failed / 1 warning (pre-existing test-count tolerance)
- [x] Visual smoke test via dev server at desktop (1280×900):
  - [x] §02 Diagnosis renders with Sculley diagram + timeline + litany + 3 citation cards
  - [x] §03 Unlock renders ZO lane (6 phases, "model exp." active) + 4 human pins (~2 hrs total)
  - [x] §04 Why I built it renders with creator note + Sam Tukra byline
  - [x] Desktop nav shows: The diagnosis · The idea · The team · How it works · Different · Quick start · Docs → · GitHub →
  - [x] Mobile drawer shows entries 02–11 in order
  - [x] Footer Acknowledgements shows all 7 names as clickable links
  - [x] Scroll-reveal triggers via real-user scroll (sculley, tl-annot, litany, cites, between-label, human-lane all gain `.is-visible`)
  - [x] No console errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)