### PR TITLE
fix(website): cache-bust styles.css/app.js + lower asset cache TTL

### DIFF
--- a/website/public/_headers
+++ b/website/public/_headers
@@ -1,0 +1,12 @@
+# Cloudflare Pages cache-control overrides.
+#
+# CSS and JS live at unhashed URLs (styles.css, app.js) so we cache them only
+# for 5 minutes — long enough to absorb a refresh storm, short enough that a
+# CSS-only fix lands quickly even for users whose browsers have the previous
+# build cached. The HTML already revalidates every load (max-age=0), so the
+# updated `?v=` query string in <link>/<script> picks up the new asset on the
+# next page load once the cache TTL expires.
+/styles.css
+  Cache-Control: public, max-age=300, must-revalidate
+/app.js
+  Cache-Control: public, max-age=300, must-revalidate

--- a/website/src/pages/index.html
+++ b/website/src/pages/index.html
@@ -8,7 +8,7 @@
   <link rel="preconnect" href="https://fonts.googleapis.com"/>
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin/>
   <link href="https://fonts.googleapis.com/css2?family=Geist:wght@300;400;500;600;700&family=Cormorant+Garamond:ital,wght@0,400;0,500;1,400;1,500&family=JetBrains+Mono:wght@400;500&display=swap" rel="stylesheet"/>
-  <link rel="stylesheet" href="styles.css"/>
+  <link rel="stylesheet" href="styles.css?v=2"/>
   <link rel="icon" type="image/svg+xml" href="favicon.svg"/>
 </head>
 <body>
@@ -1066,7 +1066,7 @@
     </div>
   </footer>
 
-  <script src="app.js"></script>
+  <script src="app.js?v=2"></script>
 
   <!-- v2 reveal observer for new section visuals (sculley · timeline · lanes · cites · litany) -->
   <script>


### PR DESCRIPTION
## Summary

PR [#68](https://github.com/SamPlvs/zero-operators/pull/68) added Sculley diagram, lanes, and footer-acknowledgements styles to `styles.css`. Cloudflare Pages was serving CSS with `Cache-Control: public, max-age=14400, must-revalidate` (4 hours), so users who'd visited the site before the merge loaded the new HTML against their OLD cached CSS:

- Sculley diagram rendered as a plain title-case list (no grid, no boxes)
- Hero headline used the default font size on mobile, wrapping each word onto its own line
- All v2 `text-transform: uppercase`, grid, and clip-path rules were missing

The HTML itself revalidated every load (max-age=0), which is why the new section structure showed up but unstyled.

## Fix

1. **Cache-bust the asset URLs** — `styles.css?v=2` and `app.js?v=2` in [index.html](website/src/pages/index.html). Browsers key the cache on the full URL including the query string, so this forces a re-fetch on the next page load.

2. **Lower the asset cache TTL** — new [website/public/_headers](website/public/_headers) overrides the default to `max-age=300, must-revalidate` (5 minutes) for `/styles.css` and `/app.js`. Future CSS-only fixes will propagate within minutes instead of hours.

Astro emits `_headers` to `dist/` so Cloudflare Pages picks it up on the next deploy.

## Test plan

- [x] `npm run build` exits 0 — `_headers` lands in `dist/` and `?v=2` is in the built HTML (`grep -c styles.css?v=2 dist/index.html` = 1).
- [x] `validate-docs.sh` 10/10.
- [x] Local dev verified at 375×812: hero wraps cleanly to 3 lines (`An autonomous AI / research team. / You stay the director.`), Sculley grid renders with ML CODE prominent.

## Rollout

After this lands and Pages redeploys:
- Anyone who visits the site does an HTML revalidation, sees `?v=2`, and re-fetches CSS/JS — they get the corrected render immediately, no manual hard-refresh needed.
- The `_headers` change takes effect for all subsequent CSS/JS responses; future CSS-only fixes propagate in ≤5 minutes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)