### PR TITLE
copy(website): AI model framing + rename Diagnosis to Problem + move Origin to §10

### DIFF
--- a/website/public/styles.css
+++ b/website/public/styles.css
@@ -2116,11 +2116,16 @@ em, .it {
        brackets can't fit. Reflow Sculley to 2 columns with ML CODE spanning
        full width as the focal point; compact timeline group labels and segments. */
     @media (max-width: 720px) {
-      /* Sculley — 2-col reflow, ML CODE prominent */
+      /* ----------------------------------------------------------------
+         Sculley — 2-col reflow with ML CODE pinned full-width on the top
+         row as the focal block. The base rule's `width: 92px;
+         justify-self: center;` left it floating awkwardly between rows;
+         here we force it to span both columns and stretch.
+         ---------------------------------------------------------------- */
       .sculley-frame { padding: 22px 18px 18px; }
       .sculley {
         grid-template-columns: repeat(2, 1fr);
-        grid-template-rows: auto;
+        grid-auto-rows: auto;
         gap: 6px;
       }
       .sk-config, .sk-collect, .sk-verify, .sk-machine,
@@ -2130,9 +2135,12 @@ em, .it {
       }
       .sk-mlcode {
         grid-column: 1 / -1;
+        grid-row: 1;
+        justify-self: stretch;
+        align-self: stretch;
         width: auto;
-        min-height: 52px;
-        padding: 12px 14px;
+        min-height: 56px;
+        padding: 14px 16px;
       }
       .sk-box { min-height: 56px; padding: 10px 12px; }
       .sk-box .sk-label { font-size: 9px; letter-spacing: 0.1em; }
@@ -2140,35 +2148,147 @@ em, .it {
       .sculley-cap { flex-direction: column; gap: 6px; }
       .sculley-cap .cap-r { text-align: left; }
 
-      /* Timeline group brackets — reduce font + drop wks count
-         (the legend below already lists "plumbing · 3 weeks", etc). */
-      .tl-group {
-        font-size: 8.5px;
-        letter-spacing: 0.08em;
-        padding: 5px 4px 6px;
-        gap: 4px;
-      }
-      .tl-group .tl-group-weeks { display: none; }
-      .tl-seg { font-size: 9px; padding: 0 6px; letter-spacing: 0.02em; }
-      .tl-annot-text { font-size: 9px; }
-
-      /* §03 ZO lane — tighten padding/font so 6 phases fit in 10 cols
-         at narrow widths. */
-      .zo-seg { padding: 0 6px; font-size: 9px; letter-spacing: 0.01em; }
-      .zo-seg.is-active::before { width: 4px; height: 4px; margin-right: 4px; }
-
-      /* §03 Human pins — pin-time labels ("WEEK 1") sit closer than the
-         column width allows; tighten font and stack tighter. */
-      .pin-time { font-size: 8px; letter-spacing: 0.1em; }
-      .pin-label .pl-dur { font-size: 11px; }
-
-      /* Lane row label column — shrink so the lanes get more room. */
-      .lanes-grid, .tl-grid, .tl-annot-row { grid-template-columns: 56px 1fr; }
-      .lanes-frame { padding: 24px 18px 22px; }
+      /* ----------------------------------------------------------------
+         §02 timeline — go VERTICAL on mobile. Horizontal 10-col bar
+         can't fit 8 phase labels on a phone (model exp/iteration text
+         overlap). Stack each phase as a full-width row, drop the ticks
+         and group brackets row (the legend below already lists the
+         3-week breakdown), and override the left→right clip-path
+         reveal with an opacity fade so the vertical bar still animates.
+         ---------------------------------------------------------------- */
       .timeline { padding: 22px 16px 18px; }
-      .between-label { font-size: 12px; padding: 12px 0 12px 4px; }
-      .between-note { font-size: 11px; }
-      .between-label::before { flex: 0 0 40px; }
+      /* Hide horizontal-only apparatus: annotation row, group brackets,
+         label column, and the ticks row. Specificity matters — the
+         groups row has both `.tl-grid` and `.tl-groups-row`, so the
+         hide rule needs both classes to win against `.tl-grid` below. */
+      .tl-grid { display: block; }
+      .tl-annot-row,
+      .tl-grid.tl-groups-row,
+      .tl-grid:has(.tl-ticks) { display: none; }
+      .tl-row-label { display: none; }
+
+      /* Vertical bar: each .tl-seg becomes a full-width row. The base
+         rule has `grid-column: span N` — we need to neutralise that
+         when the parent flips from grid to flex-column. */
+      .tl-bar {
+        display: flex;
+        flex-direction: column;
+        height: auto;
+        border-radius: 4px;
+        clip-path: none;
+      }
+      .tl-bar.is-visible { clip-path: none; opacity: 1; }
+      .tl-bar { opacity: 0; transition: opacity .8s var(--ease) .1s; }
+      .tl-seg {
+        height: 32px;
+        padding: 0 14px;
+        border-right: none;
+        border-bottom: 1px solid var(--canvas);
+        font-size: 11px;
+        letter-spacing: 0.02em;
+      }
+      .tl-seg:last-child { border-bottom: none; }
+
+      /* Legend stacks already (flex-wrap) — ensure swatches line up. */
+      .tl-legend { gap: 8px 18px; }
+
+      /* ----------------------------------------------------------------
+         §03 ZO lane — same vertical stack treatment so 6 phases fit
+         readably and the "package · test · deploy" cell stops wrapping
+         mid-word.
+         ---------------------------------------------------------------- */
+      .lanes-frame { padding: 24px 18px 22px; }
+      /* Hide the lane row label ("ZO RUNS THE CYCLE", "YOU DIRECT")
+         and the bottom tick row — they assume a horizontal axis. */
+      .lanes-grid { grid-template-columns: 1fr; gap: 14px; }
+      .lane-label { display: none; }
+      .lanes-ticks { display: none; }
+      .between-row { display: block; }
+      .between-spacer { display: none; }
+
+      .zo-lane {
+        display: flex;
+        flex-direction: column;
+        height: auto;
+        border-radius: 4px;
+        clip-path: none;
+        opacity: 0;
+        transition: opacity .8s var(--ease) .1s;
+      }
+      .zo-lane.is-visible { clip-path: none; opacity: 1; }
+      .zo-seg {
+        padding: 10px 14px;
+        font-size: 11px;
+        letter-spacing: 0.01em;
+        border-right: none;
+        border-bottom: 1px solid oklch(0.74 0.14 35 / 0.18);
+      }
+      .zo-seg:last-child { border-bottom: none; }
+      .zo-seg.is-active::before { width: 5px; height: 5px; margin-right: 8px; }
+
+      /* "continuous direction" between-label — flow inline, drop the
+         leading dash since there's no horizontal bar to terminate. */
+      .between-label {
+        font-size: 13px;
+        padding: 6px 0;
+        gap: 8px;
+      }
+      .between-label::before { flex: 0 0 18px; }
+      .between-note { font-size: 12px; }
+
+      /* §03 You-direct lane — stack the 4 pins as a vertical checklist
+         instead of plotting them on a horizontal week axis. */
+      .human-lane {
+        height: auto;
+        display: flex;
+        flex-direction: column;
+        gap: 10px;
+      }
+      .human-baseline { display: none; }
+      .human-pin {
+        position: relative;
+        display: grid;
+        grid-template-columns: 28px 1fr auto;
+        grid-template-areas: "mark name time";
+        align-items: center;
+        gap: 12px;
+        padding: 4px 0;
+      }
+      .human-pin .pin-mark {
+        position: static;
+        margin: 0;
+        grid-area: mark;
+        width: 12px;
+        height: 12px;
+      }
+      .human-pin .pin-label {
+        position: static;
+        transform: none;
+        grid-area: name;
+        flex-direction: row;
+        flex-wrap: wrap;
+        align-items: baseline;
+        gap: 6px 10px;
+        white-space: normal;
+        text-align: left;
+      }
+      .pin-label .pl-name { display: inline; font-size: 10px; }
+      .pin-label .pl-dur { font-size: 12px; }
+      .human-pin .pin-time {
+        position: static;
+        transform: none;
+        grid-area: time;
+        font-size: 9px;
+      }
+      .human-pin.pin-edge-l .pin-label,
+      .human-pin.pin-edge-r .pin-label,
+      .human-pin.pin-edge-l .pin-time,
+      .human-pin.pin-edge-r .pin-time {
+        position: static;
+        transform: none;
+        text-align: left;
+        align-items: baseline;
+      }
 
       /* Lanes caption stacks vertically on mobile. */
       .lanes-cap { flex-direction: column; gap: 4px; font-size: 9px; }

--- a/website/src/pages/index.html
+++ b/website/src/pages/index.html
@@ -8,7 +8,7 @@
   <link rel="preconnect" href="https://fonts.googleapis.com"/>
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin/>
   <link href="https://fonts.googleapis.com/css2?family=Geist:wght@300;400;500;600;700&family=Cormorant+Garamond:ital,wght@0,400;0,500;1,400;1,500&family=JetBrains+Mono:wght@400;500&display=swap" rel="stylesheet"/>
-  <link rel="stylesheet" href="styles.css?v=2"/>
+  <link rel="stylesheet" href="styles.css?v=3"/>
   <link rel="icon" type="image/svg+xml" href="favicon.svg"/>
 </head>
 <body>

--- a/website/src/pages/index.html
+++ b/website/src/pages/index.html
@@ -8,7 +8,7 @@
   <link rel="preconnect" href="https://fonts.googleapis.com"/>
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin/>
   <link href="https://fonts.googleapis.com/css2?family=Geist:wght@300;400;500;600;700&family=Cormorant+Garamond:ital,wght@0,400;0,500;1,400;1,500&family=JetBrains+Mono:wght@400;500&display=swap" rel="stylesheet"/>
-  <link rel="stylesheet" href="styles.css?v=3"/>
+  <link rel="stylesheet" href="styles.css?v=4"/>
   <link rel="icon" type="image/svg+xml" href="favicon.svg"/>
 </head>
 <body>
@@ -21,7 +21,7 @@
         <span class="wordmark">Zero<em>Operators</em></span>
       </a>
       <div class="nav-right">
-        <a class="nav-link" href="#diagnosis">The diagnosis</a>
+        <a class="nav-link" href="#problem">Problem</a>
         <a class="nav-link" href="#idea">The idea</a>
         <a class="nav-link" href="#team">The team</a>
         <a class="nav-link" href="#how">How it works</a>
@@ -56,15 +56,15 @@
         </button>
       </div>
       <nav class="md-links">
-        <a href="#diagnosis" class="md-link" data-md-close><span class="md-num">02</span><span class="md-label">The diagnosis</span></a>
+        <a href="#problem" class="md-link" data-md-close><span class="md-num">02</span><span class="md-label">Problem</span></a>
         <a href="#unlock" class="md-link" data-md-close><span class="md-num">03</span><span class="md-label">The unlock</span></a>
-        <a href="#origin" class="md-link" data-md-close><span class="md-num">04</span><span class="md-label">Why I built it</span></a>
-        <a href="#idea" class="md-link" data-md-close><span class="md-num">05</span><span class="md-label">The idea</span></a>
-        <a href="#handoff" class="md-link" data-md-close><span class="md-num">06</span><span class="md-label">Handoff</span></a>
-        <a href="#team" class="md-link" data-md-close><span class="md-num">07</span><span class="md-label">The team</span></a>
-        <a href="#how" class="md-link" data-md-close><span class="md-num">08</span><span class="md-label">How it works</span></a>
-        <a href="#oracle" class="md-link" data-md-close><span class="md-num">09</span><span class="md-label">Oracle &amp; memory</span></a>
-        <a href="#different" class="md-link" data-md-close><span class="md-num">10</span><span class="md-label">Different</span></a>
+        <a href="#idea" class="md-link" data-md-close><span class="md-num">04</span><span class="md-label">The idea</span></a>
+        <a href="#handoff" class="md-link" data-md-close><span class="md-num">05</span><span class="md-label">Handoff</span></a>
+        <a href="#team" class="md-link" data-md-close><span class="md-num">06</span><span class="md-label">The team</span></a>
+        <a href="#how" class="md-link" data-md-close><span class="md-num">07</span><span class="md-label">How it works</span></a>
+        <a href="#oracle" class="md-link" data-md-close><span class="md-num">08</span><span class="md-label">Oracle &amp; memory</span></a>
+        <a href="#different" class="md-link" data-md-close><span class="md-num">09</span><span class="md-label">Different</span></a>
+        <a href="#origin" class="md-link" data-md-close><span class="md-num">10</span><span class="md-label">Why I built it</span></a>
         <a href="#start" class="md-link" data-md-close><span class="md-num">11</span><span class="md-label">Quick start</span></a>
       </nav>
       <div class="md-foot">
@@ -88,7 +88,7 @@
           You stay the <em>director.</em>
         </h1>
         <p class="lede reveal" data-delay="260">
-          Most of building a model <em>isn't the model</em>. Three weeks understanding the data,
+          Most of building an <em>AI model</em> isn't the model. Three weeks understanding the data,
           two weeks cleaning, one on infra — by the time you're modelling, the deadline is
           breathing down your neck. Zero Operators runs that pipeline as a <em>full production-grade
           AI research team</em>. You stay where you add value: reading results, choosing the next
@@ -132,14 +132,14 @@
   </header>
 
   <!-- =================================================================
-       §02 · THE DIAGNOSIS  (NEW)
+       §02 · PROBLEM  (NEW)
        ================================================================= -->
-  <section class="section" id="diagnosis">
+  <section class="section" id="problem">
     <div class="container">
       <div class="section-head reveal">
-        <span class="section-num">02<span class="section-kind">The diagnosis</span></span>
+        <span class="section-num">02<span class="section-kind">Problem</span></span>
         <h2 class="section-title">
-          Most of building a model <em>isn't the model.</em>
+          Most of building an <em>AI model</em> isn't the model.
         </h2>
         <p class="section-lede">
           Three weeks understanding the data. Two weeks cleaning it. One on
@@ -374,53 +374,12 @@
   </section>
 
   <!-- =================================================================
-       §04 · WHY I BUILT IT (founder origin)  (NEW)
-       ================================================================= -->
-  <section class="section" id="origin">
-    <div class="container">
-      <div class="section-head reveal" style="max-width: 720px; margin: 0 auto 56px;">
-        <span class="section-num">04<span class="section-kind">The proof</span></span>
-        <h2 class="section-title">Why I built it.</h2>
-      </div>
-
-      <div class="origin-frame reveal r-d1">
-        <span class="o-tag">Creator note</span>
-        <p>
-          I had an 8-week project: a high-stakes client needed a model to optimise
-          their power plant. <em>Eight weeks</em> to do all of it — data understanding,
-          cleaning, scaffolding, training, iteration, packaging — and a model
-          delivered to production. The math didn't work.
-        </p>
-        <p>
-          So I asked the obvious question: <em>what if I had a digital research
-          team at my fingertips,</em> doing all the manual work, while I acted
-          as the research director — validating, checking results, choosing
-          what to try next?
-        </p>
-        <p>
-          That's what ZO is. A full production-grade AI research team. Tied to
-          a fixed, repeatable, reproducible workflow. ZO tokens cost a
-          <em>fraction of one percent</em> of the project budget. Best ROI I've
-          ever made on a tool.
-        </p>
-        <div class="origin-attr">
-          <span class="o-name">Samyakh (Sam) Tukra</span>
-          <span class="o-sep">·</span>
-          <span>creator</span>
-          <span class="o-sep">·</span>
-          <a href="https://samtukra.com/" target="_blank" rel="noopener">samtukra.com ↗</a>
-        </div>
-      </div>
-    </div>
-  </section>
-
-  <!-- =================================================================
-       §05 · THE IDEA (was §02 — copy trimmed; diagram unchanged)
+       §04 · THE IDEA (was §02 — copy trimmed; diagram unchanged)
        ================================================================= -->
   <section class="section" id="idea">
     <div class="container">
       <div class="section-head reveal">
-        <span class="section-num">05<span class="section-kind">The idea</span></span>
+        <span class="section-num">04<span class="section-kind">The idea</span></span>
         <h2 class="section-title">
           Write one file. <em>Walk away.</em><br/>
           Come back to verified work.
@@ -503,12 +462,12 @@
   </section>
 
   <!-- =================================================================
-       §06 · HANDOFF (was §03)
+       §05 · HANDOFF (was §03)
        ================================================================= -->
   <section class="section section-handoff" id="handoff">
     <div class="container">
       <div class="section-head reveal">
-        <span class="section-num">06<span class="section-kind">The handoff</span></span>
+        <span class="section-num">05<span class="section-kind">The handoff</span></span>
         <h2 class="section-title">
           You bring two things. <em>You get four.</em>
         </h2>
@@ -573,12 +532,12 @@
   </section>
 
   <!-- =================================================================
-       §07 · DIGITAL RESEARCH TEAM (tmux) (was §04)
+       §06 · DIGITAL RESEARCH TEAM (tmux) (was §04)
        ================================================================= -->
   <section class="section section-team" id="team">
     <div class="container">
       <div class="section-head reveal">
-        <span class="section-num">07<span class="section-kind">A digital research team</span></span>
+        <span class="section-num">06<span class="section-kind">A digital research team</span></span>
         <h2 class="section-title">
           A <em>team</em>, not a single agent.
         </h2>
@@ -786,12 +745,12 @@
   </section>
 
   <!-- =================================================================
-       §08 · HOW IT WORKS (was §05)
+       §07 · HOW IT WORKS (was §05)
        ================================================================= -->
   <section class="section section-pipeline" id="how">
     <div class="container">
       <div class="section-head reveal">
-        <span class="section-num">08<span class="section-kind">How it works</span></span>
+        <span class="section-num">07<span class="section-kind">How it works</span></span>
         <h2 class="section-title">
           Six phases. <em>Gated at every transition.</em>
         </h2>
@@ -854,12 +813,12 @@
   </section>
 
   <!-- =================================================================
-       §09 · ORACLE & MEMORY (was §06)
+       §08 · ORACLE & MEMORY (was §06)
        ================================================================= -->
   <section class="section section-split" id="oracle">
     <div class="container">
       <div class="section-head reveal">
-        <span class="section-num">09<span class="section-kind">Oracle &amp; memory</span></span>
+        <span class="section-num">08<span class="section-kind">Oracle &amp; memory</span></span>
         <h2 class="section-title">
           <em>Every claim</em> verified. <em>Every failure</em> remembered.
         </h2>
@@ -923,12 +882,12 @@
   </section>
 
   <!-- =================================================================
-       §10 · WHAT MAKES IT DIFFERENT (was §07)
+       §09 · WHAT MAKES IT DIFFERENT (was §07)
        ================================================================= -->
   <section class="section" id="different">
     <div class="container">
       <div class="section-head reveal">
-        <span class="section-num">10<span class="section-kind">What makes it different</span></span>
+        <span class="section-num">09<span class="section-kind">What makes it different</span></span>
         <h2 class="section-title">
           Three tools. <em>Three units of work.</em><br/>
           Only one ships <em>a trained model.</em>
@@ -973,6 +932,47 @@
             <li><span>Memory</span><em>persistent · <span class="nobreak">self-evolving</span></em></li>
             <li><span>Delivery</span><em>checkpoint, recipe, audit log</em></li>
           </ul>
+        </div>
+      </div>
+    </div>
+  </section>
+
+  <!-- =================================================================
+       §10 · WHY I BUILT IT (founder origin)
+       ================================================================= -->
+  <section class="section" id="origin">
+    <div class="container">
+      <div class="section-head reveal" style="max-width: 720px; margin: 0 auto 56px;">
+        <span class="section-num">10<span class="section-kind">Origin</span></span>
+        <h2 class="section-title">Why I built it.</h2>
+      </div>
+
+      <div class="origin-frame reveal r-d1">
+        <span class="o-tag">Creator note</span>
+        <p>
+          I had an 8-week project: a high-stakes client needed a model to optimise
+          their power plant. <em>Eight weeks</em> to do all of it — data understanding,
+          cleaning, scaffolding, training, iteration, packaging — and a model
+          delivered to production. The math didn't work.
+        </p>
+        <p>
+          So I asked the obvious question: <em>what if I had a digital research
+          team at my fingertips,</em> doing all the manual work, while I acted
+          as the research director — validating, checking results, choosing
+          what to try next?
+        </p>
+        <p>
+          That's what ZO is. A full production-grade AI research team. Tied to
+          a fixed, repeatable, reproducible workflow. ZO tokens cost a
+          <em>fraction of one percent</em> of the project budget. Best ROI I've
+          ever made on a tool.
+        </p>
+        <div class="origin-attr">
+          <span class="o-name">Samyakh (Sam) Tukra</span>
+          <span class="o-sep">·</span>
+          <span>creator</span>
+          <span class="o-sep">·</span>
+          <a href="https://samtukra.com/" target="_blank" rel="noopener">samtukra.com ↗</a>
         </div>
       </div>
     </div>
@@ -1036,7 +1036,7 @@
         <div class="fm-row"><span>Source</span><a href="https://github.com/SamPlvs/zero-operators" target="_blank" rel="noopener">GitHub →</a></div>
       </div>
       <div class="footer-links">
-        <a href="#diagnosis">The diagnosis</a>
+        <a href="#problem">Problem</a>
         <a href="#idea">The idea</a>
         <a href="#how">How it works</a>
         <a href="#oracle">Oracle &amp; memory</a>


### PR DESCRIPTION
## Summary

Four targeted copy/structure changes after live review on top of [#70](https://github.com/SamPlvs/zero-operators/pull/70):

| # | Change | Where |
|---|---|---|
| 1 | "Most of building a model" → "Most of building an **AI model**" | Hero lede + §02 title (first mention only — anaphoric "the model" / "model code" downstream unchanged so prose stays light) |
| 2 | "The diagnosis" → "**Problem**" | §02 section-kind label, section id (`#diagnosis` → `#problem`), desktop nav link, mobile drawer entry, footer-links |
| 3 | Moved "Why I built it" from §04 → **§10** (just before Quick start) | Sat awkwardly close to the Diagnosis/Unlock opener as a third intro; now reads as the personal-note close. §05–§10 decrement to §04–§09; `#origin` id stays the same so any external links survive |
| 4 | "The proof" → "**Origin**" subhead | Misleading label (section is founder origin, not proof); now matches content + the existing one-or-two-word section-kind style |

Final section order:
```
01 Hero · 02 Problem · 03 The unlock · 04 The idea · 05 The handoff
06 A digital research team · 07 How it works · 08 Oracle & memory
09 What makes it different · 10 Origin · 11 Quick start
```

Cache version bumped `styles.css?v=3` → `?v=4` so users with the previous CSS cached pick up the v=3 fix from #70.

## Branch base

Branched off [#70](https://github.com/SamPlvs/zero-operators/pull/70) (`claude/website-mobile-vertical`), so this PR's diff against `main` includes both the mobile vertical layout fix and these copy changes. If you merge #70 first, GitHub will auto-rebase this to show only the copy diff. Either order works.

## Test plan

- [x] `npm run build` clean (Astro 5 static, 1 page, ~290 ms).
- [x] `validate-docs.sh` 10/10.
- [x] Programmatic structure check — section ids/numbers/labels all in correct new order, no stray `diagnosis` references in the DOM, all 10 drawer entries renumbered correctly.
- [x] **Desktop 1280×900** — §02 Problem renders with "AI model" italic coral, nav shows "Problem" (replacing "The diagnosis"). §10 Origin renders with founder note + byline.
- [x] **Mobile 375×812** — §02 title wraps cleanly to 2 lines, ML CODE focal block at the top of the Sculley grid (full-width). Drawer numbers 02–11 in the new order.

🤖 Generated with [Claude Code](https://claude.com/claude-code)