### PR TITLE
copy: 'The people behind it.' — honour contributors with display title

### DIFF
--- a/README.md
+++ b/README.md
@@ -553,9 +553,9 @@ External CLI tools that fit ZO's launcher architecture and are being evaluated f
 
 ---
 
-## Acknowledgements
+## The people behind it
 
-No tool ships alone. With thanks to the *AI specialists, researchers and engineers* who tested, guided, broke things, and made ZO sharper:
+No tool ships alone. With thanks to the *specialists, researchers and engineers* who tested, broke things, pushed back when it counted, and made ZO sharper:
 
 - [Arjun Agrawal](https://www.linkedin.com/in/arjunagraw/)
 - [Callum Adamson](https://www.linkedin.com/in/callumadamson/)

--- a/docs/acknowledgements.mdx
+++ b/docs/acknowledgements.mdx
@@ -1,9 +1,9 @@
 ---
-title: "Acknowledgements"
-description: "No tool ships alone. The AI specialists, researchers, and engineers who tested, guided, broke things, and made ZO sharper."
+title: "The people behind it"
+description: "No tool ships alone. The specialists, researchers and engineers who tested, broke things, pushed back when it counted, and made ZO sharper."
 ---
 
-No tool ships alone. With thanks to the *AI specialists, researchers and engineers* who tested, guided, broke things, and made ZO sharper.
+No tool ships alone. With thanks to the *specialists, researchers and engineers* who tested, broke things, pushed back when it counted, and made ZO sharper.
 
 - [Arjun Agrawal](https://www.linkedin.com/in/arjunagraw/)
 - [Callum Adamson](https://www.linkedin.com/in/callumadamson/)

--- a/website/public/styles.css
+++ b/website/public/styles.css
@@ -2006,18 +2006,20 @@ em, .it {
     .lane-label { font: 10px/1.3 var(--mono); color: var(--dim); letter-spacing: 0.18em; text-transform: uppercase; text-align: right; align-self: center; padding-top: 4px; }
     .lane-label em { font-size: 1.15em; line-height: 1; }
     .lane-label .lane-sub { display: block; color: var(--ghost); letter-spacing: 0.1em; margin-top: 2px; font-size: 9px; text-transform: uppercase; }
-    .zo-lane { display: grid; grid-template-columns: repeat(10, 1fr); height: 56px; border-radius: 4px; overflow: hidden; background: var(--coral-soft); border: 1px solid var(--coral-ring); }
+    .zo-lane { display: grid; grid-template-columns: repeat(7, 1fr); height: 56px; border-radius: 4px; overflow: hidden; background: var(--coral-soft); border: 1px solid var(--coral-ring); }
     .zo-seg { display: flex; align-items: center; padding: 0 14px; font: 11px/1 var(--mono); color: var(--coral); letter-spacing: 0.04em; border-right: 1px solid oklch(0.74 0.14 35 / 0.18); }
     .zo-seg:last-child { border-right: none; }
     .zo-seg.is-active { background: oklch(0.74 0.14 35 / 0.22); }
     .zo-seg.is-active::before { content: ""; width: 6px; height: 6px; background: var(--coral); border-radius: 50%; margin-right: 8px; box-shadow: 0 0 8px var(--coral-ring); animation: zo-pulse 2.4s var(--ease) infinite; }
+    /* Weekend cell — visually distinct from work cells (no work happening). */
+    .zo-seg-weekend { background: var(--canvas); color: var(--ghost); font-family: var(--italic); font-style: italic; font-size: 13px; letter-spacing: 0; justify-content: center; border-left: 1px dashed var(--rule); }
     @keyframes zo-pulse { 0%, 100% { opacity: 0.5; transform: scale(1); } 50% { opacity: 1; transform: scale(1.4); } }
     .between-row { display: contents; }
     .between-spacer {}
     .between-label { font-family: var(--italic); font-style: italic; color: var(--coral); font-size: 14px; padding: 16px 0 16px 4px; display: flex; align-items: center; gap: 14px; }
     .between-label::before { content: ""; height: 1px; background: linear-gradient(90deg, var(--coral), transparent); flex: 0 0 80px; }
     .between-note { font-family: var(--sans); font-style: normal; color: var(--cream-2); font-size: 13px; font-weight: 300; margin-left: 4px; }
-    .human-lane { position: relative; height: 110px; display: grid; grid-template-columns: repeat(10, 1fr); }
+    .human-lane { position: relative; height: 110px; display: grid; grid-template-columns: repeat(7, 1fr); }
     .human-baseline { position: absolute; left: 0; right: 0; top: 50%; height: 1px; background: repeating-linear-gradient(90deg, var(--coral) 0 6px, transparent 6px 12px); opacity: 0.45; }
     .human-pin { grid-column: var(--col) / span 1; position: relative; }
     .pin-mark { width: 14px; height: 14px; background: var(--coral); transform: rotate(45deg); position: absolute; top: 50%; left: 50%; margin: -7px 0 0 -7px; z-index: 2; box-shadow: 0 0 0 4px var(--canvas-2), 0 0 18px var(--coral-ring); }
@@ -2028,10 +2030,13 @@ em, .it {
     .pin-time { position: absolute; top: calc(50% + 16px); left: 50%; transform: translateX(-50%); font: 9px/1 var(--mono); color: var(--dim); letter-spacing: 0.18em; text-transform: uppercase; white-space: nowrap; }
     .human-pin.pin-edge-l .pin-label, .human-pin.pin-edge-l .pin-time { left: 0; transform: none; align-items: flex-start; text-align: left; }
     .human-pin.pin-edge-r .pin-label, .human-pin.pin-edge-r .pin-time { left: auto; right: 0; transform: none; align-items: flex-end; text-align: right; }
-    .lanes-ticks { display: grid; grid-template-columns: repeat(10, 1fr); margin-top: 12px; padding-top: 10px; border-top: 1px dashed var(--rule); }
-    .lanes-ticks .tl-tick { color: var(--ghost); }
-    .lanes-ticks .tl-tick:nth-child(5n+1) { color: var(--dim); }
-    .lanes-cap { display: flex; justify-content: space-between; gap: 18px; font-family: var(--mono); font-size: 10px; color: var(--dim); letter-spacing: 0.14em; text-transform: uppercase; margin-top: 22px; padding-top: 14px; border-top: 1px dashed var(--rule); flex-wrap: wrap; }
+    .lanes-ticks { display: grid; grid-template-columns: repeat(7, 1fr); margin-top: 12px; padding-top: 10px; border-top: 1px dashed var(--rule); }
+    .lanes-ticks .tl-tick { color: var(--dim); }
+    .lanes-ticks .tl-tick.is-weekend { color: var(--ghost); font-family: var(--italic); font-style: italic; text-transform: lowercase; letter-spacing: 0; }
+    .lanes-cap { display: flex; flex-direction: column; gap: 8px; margin-top: 22px; padding-top: 14px; border-top: 1px dashed var(--rule); }
+    .lanes-cap > span { font-family: var(--mono); font-size: 10px; color: var(--dim); letter-spacing: 0.14em; text-transform: uppercase; }
+    .lanes-cap .lanes-cap-headline { font-family: var(--sans); font-size: 17px; font-weight: 300; color: var(--cream); letter-spacing: 0; text-transform: none; line-height: 1.45; text-wrap: balance; }
+    .lanes-cap .lanes-cap-headline em { font-family: var(--italic); font-style: italic; color: var(--coral); font-weight: 400; font-size: 1.05em; }
     .lanes-pretitle { font-family: var(--mono); font-size: 10px; color: var(--coral); letter-spacing: 0.22em; text-transform: uppercase; margin-bottom: 22px; display: flex; align-items: center; gap: 14px; }
     .lanes-pretitle::before { content: ""; width: 28px; height: 1px; background: var(--coral); }
 
@@ -2290,8 +2295,14 @@ em, .it {
         align-items: baseline;
       }
 
-      /* Lanes caption stacks vertically on mobile. */
-      .lanes-cap { flex-direction: column; gap: 4px; font-size: 9px; }
+      /* Lanes caption — already stacks vertically. Tighten the
+         meta line on mobile and rebalance the headline size. */
+      .lanes-cap { gap: 8px; }
+      .lanes-cap > span { font-size: 9px; }
+      .lanes-cap .lanes-cap-headline { font-size: 14px; }
+
+      /* Weekend cell on mobile — center the italic label as a row. */
+      .zo-seg-weekend { padding: 12px 14px; }
     }
 
     /* Hero headline override — keep italic em flowing inline so longer

--- a/website/public/styles.css
+++ b/website/public/styles.css
@@ -2318,13 +2318,18 @@ em, .it {
       grid-template-columns: 1fr;
       gap: 22px;
     }
-    .footer-thanks .ft-kicker {
-      font-family: var(--mono); font-size: 10px; color: var(--coral);
-      letter-spacing: 0.24em; text-transform: uppercase;
-      display: flex; align-items: center; gap: 14px;
-    }
-    .footer-thanks .ft-kicker::before {
-      content: ""; width: 28px; height: 1px; background: var(--coral);
+    /* Section title — italic Cormorant display treatment, matching the
+       hero/section-title em pattern used elsewhere on the site. Honours
+       contributors with display weight rather than a bureaucratic kicker. */
+    .footer-thanks .ft-title {
+      font-family: var(--italic); font-style: italic;
+      font-size: clamp(28px, 3.6vw, 38px);
+      font-weight: 400;
+      color: var(--coral);
+      letter-spacing: -0.005em;
+      line-height: 1.1;
+      margin: 0;
+      text-wrap: balance;
     }
     .footer-thanks .ft-statement {
       font-family: var(--sans); font-size: 17px; font-weight: 300;
@@ -2356,6 +2361,7 @@ em, .it {
       color: var(--coral); border-bottom-color: var(--coral);
     }
     @media (max-width: 720px) {
+      .footer-thanks .ft-title { font-size: 26px; }
       .footer-thanks .ft-statement { font-size: 15px; }
       .footer-thanks .ft-names { font-size: 13px; }
     }

--- a/website/public/styles.css
+++ b/website/public/styles.css
@@ -2116,11 +2116,16 @@ em, .it {
        brackets can't fit. Reflow Sculley to 2 columns with ML CODE spanning
        full width as the focal point; compact timeline group labels and segments. */
     @media (max-width: 720px) {
-      /* Sculley — 2-col reflow, ML CODE prominent */
+      /* ----------------------------------------------------------------
+         Sculley — 2-col reflow with ML CODE pinned full-width on the top
+         row as the focal block. The base rule's `width: 92px;
+         justify-self: center;` left it floating awkwardly between rows;
+         here we force it to span both columns and stretch.
+         ---------------------------------------------------------------- */
       .sculley-frame { padding: 22px 18px 18px; }
       .sculley {
         grid-template-columns: repeat(2, 1fr);
-        grid-template-rows: auto;
+        grid-auto-rows: auto;
         gap: 6px;
       }
       .sk-config, .sk-collect, .sk-verify, .sk-machine,
@@ -2130,9 +2135,12 @@ em, .it {
       }
       .sk-mlcode {
         grid-column: 1 / -1;
+        grid-row: 1;
+        justify-self: stretch;
+        align-self: stretch;
         width: auto;
-        min-height: 52px;
-        padding: 12px 14px;
+        min-height: 56px;
+        padding: 14px 16px;
       }
       .sk-box { min-height: 56px; padding: 10px 12px; }
       .sk-box .sk-label { font-size: 9px; letter-spacing: 0.1em; }
@@ -2140,35 +2148,147 @@ em, .it {
       .sculley-cap { flex-direction: column; gap: 6px; }
       .sculley-cap .cap-r { text-align: left; }
 
-      /* Timeline group brackets — reduce font + drop wks count
-         (the legend below already lists "plumbing · 3 weeks", etc). */
-      .tl-group {
-        font-size: 8.5px;
-        letter-spacing: 0.08em;
-        padding: 5px 4px 6px;
-        gap: 4px;
-      }
-      .tl-group .tl-group-weeks { display: none; }
-      .tl-seg { font-size: 9px; padding: 0 6px; letter-spacing: 0.02em; }
-      .tl-annot-text { font-size: 9px; }
-
-      /* §03 ZO lane — tighten padding/font so 6 phases fit in 10 cols
-         at narrow widths. */
-      .zo-seg { padding: 0 6px; font-size: 9px; letter-spacing: 0.01em; }
-      .zo-seg.is-active::before { width: 4px; height: 4px; margin-right: 4px; }
-
-      /* §03 Human pins — pin-time labels ("WEEK 1") sit closer than the
-         column width allows; tighten font and stack tighter. */
-      .pin-time { font-size: 8px; letter-spacing: 0.1em; }
-      .pin-label .pl-dur { font-size: 11px; }
-
-      /* Lane row label column — shrink so the lanes get more room. */
-      .lanes-grid, .tl-grid, .tl-annot-row { grid-template-columns: 56px 1fr; }
-      .lanes-frame { padding: 24px 18px 22px; }
+      /* ----------------------------------------------------------------
+         §02 timeline — go VERTICAL on mobile. Horizontal 10-col bar
+         can't fit 8 phase labels on a phone (model exp/iteration text
+         overlap). Stack each phase as a full-width row, drop the ticks
+         and group brackets row (the legend below already lists the
+         3-week breakdown), and override the left→right clip-path
+         reveal with an opacity fade so the vertical bar still animates.
+         ---------------------------------------------------------------- */
       .timeline { padding: 22px 16px 18px; }
-      .between-label { font-size: 12px; padding: 12px 0 12px 4px; }
-      .between-note { font-size: 11px; }
-      .between-label::before { flex: 0 0 40px; }
+      /* Hide horizontal-only apparatus: annotation row, group brackets,
+         label column, and the ticks row. Specificity matters — the
+         groups row has both `.tl-grid` and `.tl-groups-row`, so the
+         hide rule needs both classes to win against `.tl-grid` below. */
+      .tl-grid { display: block; }
+      .tl-annot-row,
+      .tl-grid.tl-groups-row,
+      .tl-grid:has(.tl-ticks) { display: none; }
+      .tl-row-label { display: none; }
+
+      /* Vertical bar: each .tl-seg becomes a full-width row. The base
+         rule has `grid-column: span N` — we need to neutralise that
+         when the parent flips from grid to flex-column. */
+      .tl-bar {
+        display: flex;
+        flex-direction: column;
+        height: auto;
+        border-radius: 4px;
+        clip-path: none;
+      }
+      .tl-bar.is-visible { clip-path: none; opacity: 1; }
+      .tl-bar { opacity: 0; transition: opacity .8s var(--ease) .1s; }
+      .tl-seg {
+        height: 32px;
+        padding: 0 14px;
+        border-right: none;
+        border-bottom: 1px solid var(--canvas);
+        font-size: 11px;
+        letter-spacing: 0.02em;
+      }
+      .tl-seg:last-child { border-bottom: none; }
+
+      /* Legend stacks already (flex-wrap) — ensure swatches line up. */
+      .tl-legend { gap: 8px 18px; }
+
+      /* ----------------------------------------------------------------
+         §03 ZO lane — same vertical stack treatment so 6 phases fit
+         readably and the "package · test · deploy" cell stops wrapping
+         mid-word.
+         ---------------------------------------------------------------- */
+      .lanes-frame { padding: 24px 18px 22px; }
+      /* Hide the lane row label ("ZO RUNS THE CYCLE", "YOU DIRECT")
+         and the bottom tick row — they assume a horizontal axis. */
+      .lanes-grid { grid-template-columns: 1fr; gap: 14px; }
+      .lane-label { display: none; }
+      .lanes-ticks { display: none; }
+      .between-row { display: block; }
+      .between-spacer { display: none; }
+
+      .zo-lane {
+        display: flex;
+        flex-direction: column;
+        height: auto;
+        border-radius: 4px;
+        clip-path: none;
+        opacity: 0;
+        transition: opacity .8s var(--ease) .1s;
+      }
+      .zo-lane.is-visible { clip-path: none; opacity: 1; }
+      .zo-seg {
+        padding: 10px 14px;
+        font-size: 11px;
+        letter-spacing: 0.01em;
+        border-right: none;
+        border-bottom: 1px solid oklch(0.74 0.14 35 / 0.18);
+      }
+      .zo-seg:last-child { border-bottom: none; }
+      .zo-seg.is-active::before { width: 5px; height: 5px; margin-right: 8px; }
+
+      /* "continuous direction" between-label — flow inline, drop the
+         leading dash since there's no horizontal bar to terminate. */
+      .between-label {
+        font-size: 13px;
+        padding: 6px 0;
+        gap: 8px;
+      }
+      .between-label::before { flex: 0 0 18px; }
+      .between-note { font-size: 12px; }
+
+      /* §03 You-direct lane — stack the 4 pins as a vertical checklist
+         instead of plotting them on a horizontal week axis. */
+      .human-lane {
+        height: auto;
+        display: flex;
+        flex-direction: column;
+        gap: 10px;
+      }
+      .human-baseline { display: none; }
+      .human-pin {
+        position: relative;
+        display: grid;
+        grid-template-columns: 28px 1fr auto;
+        grid-template-areas: "mark name time";
+        align-items: center;
+        gap: 12px;
+        padding: 4px 0;
+      }
+      .human-pin .pin-mark {
+        position: static;
+        margin: 0;
+        grid-area: mark;
+        width: 12px;
+        height: 12px;
+      }
+      .human-pin .pin-label {
+        position: static;
+        transform: none;
+        grid-area: name;
+        flex-direction: row;
+        flex-wrap: wrap;
+        align-items: baseline;
+        gap: 6px 10px;
+        white-space: normal;
+        text-align: left;
+      }
+      .pin-label .pl-name { display: inline; font-size: 10px; }
+      .pin-label .pl-dur { font-size: 12px; }
+      .human-pin .pin-time {
+        position: static;
+        transform: none;
+        grid-area: time;
+        font-size: 9px;
+      }
+      .human-pin.pin-edge-l .pin-label,
+      .human-pin.pin-edge-r .pin-label,
+      .human-pin.pin-edge-l .pin-time,
+      .human-pin.pin-edge-r .pin-time {
+        position: static;
+        transform: none;
+        text-align: left;
+        align-items: baseline;
+      }
 
       /* Lanes caption stacks vertically on mobile. */
       .lanes-cap { flex-direction: column; gap: 4px; font-size: 9px; }

--- a/website/src/pages/index.html
+++ b/website/src/pages/index.html
@@ -8,7 +8,7 @@
   <link rel="preconnect" href="https://fonts.googleapis.com"/>
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin/>
   <link href="https://fonts.googleapis.com/css2?family=Geist:wght@300;400;500;600;700&family=Cormorant+Garamond:ital,wght@0,400;0,500;1,400;1,500&family=JetBrains+Mono:wght@400;500&display=swap" rel="stylesheet"/>
-  <link rel="stylesheet" href="styles.css?v=2"/>
+  <link rel="stylesheet" href="styles.css?v=3"/>
   <link rel="icon" type="image/svg+xml" href="favicon.svg"/>
 </head>
 <body>

--- a/website/src/pages/index.html
+++ b/website/src/pages/index.html
@@ -8,7 +8,7 @@
   <link rel="preconnect" href="https://fonts.googleapis.com"/>
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin/>
   <link href="https://fonts.googleapis.com/css2?family=Geist:wght@300;400;500;600;700&family=Cormorant+Garamond:ital,wght@0,400;0,500;1,400;1,500&family=JetBrains+Mono:wght@400;500&display=swap" rel="stylesheet"/>
-  <link rel="stylesheet" href="styles.css?v=5"/>
+  <link rel="stylesheet" href="styles.css?v=6"/>
   <link rel="icon" type="image/svg+xml" href="favicon.svg"/>
 </head>
 <body>
@@ -1043,10 +1043,11 @@
       </div>
     </div>
     <div class="container footer-thanks">
-      <span class="ft-kicker">Acknowledgements</span>
+      <h3 class="ft-title"><em>The people behind it.</em></h3>
       <p class="ft-statement">
-        No tool ships alone. With thanks to the <em>AI specialists, researchers and engineers</em>
-        who tested, guided, broke things, and made ZO sharper.
+        No tool ships alone. With thanks to the specialists, researchers and
+        engineers who tested, broke things, pushed back when it counted, and
+        made ZO sharper.
       </p>
       <ul class="ft-names">
         <li><a href="https://www.linkedin.com/in/arjunagraw/" target="_blank" rel="noopener">Arjun Agrawal</a></li>

--- a/website/src/pages/index.html
+++ b/website/src/pages/index.html
@@ -8,7 +8,7 @@
   <link rel="preconnect" href="https://fonts.googleapis.com"/>
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin/>
   <link href="https://fonts.googleapis.com/css2?family=Geist:wght@300;400;500;600;700&family=Cormorant+Garamond:ital,wght@0,400;0,500;1,400;1,500&family=JetBrains+Mono:wght@400;500&display=swap" rel="stylesheet"/>
-  <link rel="stylesheet" href="styles.css?v=3"/>
+  <link rel="stylesheet" href="styles.css?v=4"/>
   <link rel="icon" type="image/svg+xml" href="favicon.svg"/>
 </head>
 <body>
@@ -21,7 +21,7 @@
         <span class="wordmark">Zero<em>Operators</em></span>
       </a>
       <div class="nav-right">
-        <a class="nav-link" href="#diagnosis">The diagnosis</a>
+        <a class="nav-link" href="#problem">Problem</a>
         <a class="nav-link" href="#idea">The idea</a>
         <a class="nav-link" href="#team">The team</a>
         <a class="nav-link" href="#how">How it works</a>
@@ -56,15 +56,15 @@
         </button>
       </div>
       <nav class="md-links">
-        <a href="#diagnosis" class="md-link" data-md-close><span class="md-num">02</span><span class="md-label">The diagnosis</span></a>
+        <a href="#problem" class="md-link" data-md-close><span class="md-num">02</span><span class="md-label">Problem</span></a>
         <a href="#unlock" class="md-link" data-md-close><span class="md-num">03</span><span class="md-label">The unlock</span></a>
-        <a href="#origin" class="md-link" data-md-close><span class="md-num">04</span><span class="md-label">Why I built it</span></a>
-        <a href="#idea" class="md-link" data-md-close><span class="md-num">05</span><span class="md-label">The idea</span></a>
-        <a href="#handoff" class="md-link" data-md-close><span class="md-num">06</span><span class="md-label">Handoff</span></a>
-        <a href="#team" class="md-link" data-md-close><span class="md-num">07</span><span class="md-label">The team</span></a>
-        <a href="#how" class="md-link" data-md-close><span class="md-num">08</span><span class="md-label">How it works</span></a>
-        <a href="#oracle" class="md-link" data-md-close><span class="md-num">09</span><span class="md-label">Oracle &amp; memory</span></a>
-        <a href="#different" class="md-link" data-md-close><span class="md-num">10</span><span class="md-label">Different</span></a>
+        <a href="#idea" class="md-link" data-md-close><span class="md-num">04</span><span class="md-label">The idea</span></a>
+        <a href="#handoff" class="md-link" data-md-close><span class="md-num">05</span><span class="md-label">Handoff</span></a>
+        <a href="#team" class="md-link" data-md-close><span class="md-num">06</span><span class="md-label">The team</span></a>
+        <a href="#how" class="md-link" data-md-close><span class="md-num">07</span><span class="md-label">How it works</span></a>
+        <a href="#oracle" class="md-link" data-md-close><span class="md-num">08</span><span class="md-label">Oracle &amp; memory</span></a>
+        <a href="#different" class="md-link" data-md-close><span class="md-num">09</span><span class="md-label">Different</span></a>
+        <a href="#origin" class="md-link" data-md-close><span class="md-num">10</span><span class="md-label">Why I built it</span></a>
         <a href="#start" class="md-link" data-md-close><span class="md-num">11</span><span class="md-label">Quick start</span></a>
       </nav>
       <div class="md-foot">
@@ -88,7 +88,7 @@
           You stay the <em>director.</em>
         </h1>
         <p class="lede reveal" data-delay="260">
-          Most of building a model <em>isn't the model</em>. Three weeks understanding the data,
+          Most of building an <em>AI model</em> isn't the model. Three weeks understanding the data,
           two weeks cleaning, one on infra — by the time you're modelling, the deadline is
           breathing down your neck. Zero Operators runs that pipeline as a <em>full production-grade
           AI research team</em>. You stay where you add value: reading results, choosing the next
@@ -132,14 +132,14 @@
   </header>
 
   <!-- =================================================================
-       §02 · THE DIAGNOSIS  (NEW)
+       §02 · PROBLEM  (NEW)
        ================================================================= -->
-  <section class="section" id="diagnosis">
+  <section class="section" id="problem">
     <div class="container">
       <div class="section-head reveal">
-        <span class="section-num">02<span class="section-kind">The diagnosis</span></span>
+        <span class="section-num">02<span class="section-kind">Problem</span></span>
         <h2 class="section-title">
-          Most of building a model <em>isn't the model.</em>
+          Most of building an <em>AI model</em> isn't the model.
         </h2>
         <p class="section-lede">
           Three weeks understanding the data. Two weeks cleaning it. One on
@@ -374,53 +374,12 @@
   </section>
 
   <!-- =================================================================
-       §04 · WHY I BUILT IT (founder origin)  (NEW)
-       ================================================================= -->
-  <section class="section" id="origin">
-    <div class="container">
-      <div class="section-head reveal" style="max-width: 720px; margin: 0 auto 56px;">
-        <span class="section-num">04<span class="section-kind">The proof</span></span>
-        <h2 class="section-title">Why I built it.</h2>
-      </div>
-
-      <div class="origin-frame reveal r-d1">
-        <span class="o-tag">Creator note</span>
-        <p>
-          I had an 8-week project: a high-stakes client needed a model to optimise
-          their power plant. <em>Eight weeks</em> to do all of it — data understanding,
-          cleaning, scaffolding, training, iteration, packaging — and a model
-          delivered to production. The math didn't work.
-        </p>
-        <p>
-          So I asked the obvious question: <em>what if I had a digital research
-          team at my fingertips,</em> doing all the manual work, while I acted
-          as the research director — validating, checking results, choosing
-          what to try next?
-        </p>
-        <p>
-          That's what ZO is. A full production-grade AI research team. Tied to
-          a fixed, repeatable, reproducible workflow. ZO tokens cost a
-          <em>fraction of one percent</em> of the project budget. Best ROI I've
-          ever made on a tool.
-        </p>
-        <div class="origin-attr">
-          <span class="o-name">Samyakh (Sam) Tukra</span>
-          <span class="o-sep">·</span>
-          <span>creator</span>
-          <span class="o-sep">·</span>
-          <a href="https://samtukra.com/" target="_blank" rel="noopener">samtukra.com ↗</a>
-        </div>
-      </div>
-    </div>
-  </section>
-
-  <!-- =================================================================
-       §05 · THE IDEA (was §02 — copy trimmed; diagram unchanged)
+       §04 · THE IDEA (was §02 — copy trimmed; diagram unchanged)
        ================================================================= -->
   <section class="section" id="idea">
     <div class="container">
       <div class="section-head reveal">
-        <span class="section-num">05<span class="section-kind">The idea</span></span>
+        <span class="section-num">04<span class="section-kind">The idea</span></span>
         <h2 class="section-title">
           Write one file. <em>Walk away.</em><br/>
           Come back to verified work.
@@ -503,12 +462,12 @@
   </section>
 
   <!-- =================================================================
-       §06 · HANDOFF (was §03)
+       §05 · HANDOFF (was §03)
        ================================================================= -->
   <section class="section section-handoff" id="handoff">
     <div class="container">
       <div class="section-head reveal">
-        <span class="section-num">06<span class="section-kind">The handoff</span></span>
+        <span class="section-num">05<span class="section-kind">The handoff</span></span>
         <h2 class="section-title">
           You bring two things. <em>You get four.</em>
         </h2>
@@ -573,12 +532,12 @@
   </section>
 
   <!-- =================================================================
-       §07 · DIGITAL RESEARCH TEAM (tmux) (was §04)
+       §06 · DIGITAL RESEARCH TEAM (tmux) (was §04)
        ================================================================= -->
   <section class="section section-team" id="team">
     <div class="container">
       <div class="section-head reveal">
-        <span class="section-num">07<span class="section-kind">A digital research team</span></span>
+        <span class="section-num">06<span class="section-kind">A digital research team</span></span>
         <h2 class="section-title">
           A <em>team</em>, not a single agent.
         </h2>
@@ -786,12 +745,12 @@
   </section>
 
   <!-- =================================================================
-       §08 · HOW IT WORKS (was §05)
+       §07 · HOW IT WORKS (was §05)
        ================================================================= -->
   <section class="section section-pipeline" id="how">
     <div class="container">
       <div class="section-head reveal">
-        <span class="section-num">08<span class="section-kind">How it works</span></span>
+        <span class="section-num">07<span class="section-kind">How it works</span></span>
         <h2 class="section-title">
           Six phases. <em>Gated at every transition.</em>
         </h2>
@@ -854,12 +813,12 @@
   </section>
 
   <!-- =================================================================
-       §09 · ORACLE & MEMORY (was §06)
+       §08 · ORACLE & MEMORY (was §06)
        ================================================================= -->
   <section class="section section-split" id="oracle">
     <div class="container">
       <div class="section-head reveal">
-        <span class="section-num">09<span class="section-kind">Oracle &amp; memory</span></span>
+        <span class="section-num">08<span class="section-kind">Oracle &amp; memory</span></span>
         <h2 class="section-title">
           <em>Every claim</em> verified. <em>Every failure</em> remembered.
         </h2>
@@ -923,12 +882,12 @@
   </section>
 
   <!-- =================================================================
-       §10 · WHAT MAKES IT DIFFERENT (was §07)
+       §09 · WHAT MAKES IT DIFFERENT (was §07)
        ================================================================= -->
   <section class="section" id="different">
     <div class="container">
       <div class="section-head reveal">
-        <span class="section-num">10<span class="section-kind">What makes it different</span></span>
+        <span class="section-num">09<span class="section-kind">What makes it different</span></span>
         <h2 class="section-title">
           Three tools. <em>Three units of work.</em><br/>
           Only one ships <em>a trained model.</em>
@@ -973,6 +932,47 @@
             <li><span>Memory</span><em>persistent · <span class="nobreak">self-evolving</span></em></li>
             <li><span>Delivery</span><em>checkpoint, recipe, audit log</em></li>
           </ul>
+        </div>
+      </div>
+    </div>
+  </section>
+
+  <!-- =================================================================
+       §10 · WHY I BUILT IT (founder origin)
+       ================================================================= -->
+  <section class="section" id="origin">
+    <div class="container">
+      <div class="section-head reveal" style="max-width: 720px; margin: 0 auto 56px;">
+        <span class="section-num">10<span class="section-kind">Origin</span></span>
+        <h2 class="section-title">Why I built it.</h2>
+      </div>
+
+      <div class="origin-frame reveal r-d1">
+        <span class="o-tag">Creator note</span>
+        <p>
+          I had an 8-week project: a high-stakes client needed a model to optimise
+          their power plant. <em>Eight weeks</em> to do all of it — data understanding,
+          cleaning, scaffolding, training, iteration, packaging — and a model
+          delivered to production. The math didn't work.
+        </p>
+        <p>
+          So I asked the obvious question: <em>what if I had a digital research
+          team at my fingertips,</em> doing all the manual work, while I acted
+          as the research director — validating, checking results, choosing
+          what to try next?
+        </p>
+        <p>
+          That's what ZO is. A full production-grade AI research team. Tied to
+          a fixed, repeatable, reproducible workflow. ZO tokens cost a
+          <em>fraction of one percent</em> of the project budget. Best ROI I've
+          ever made on a tool.
+        </p>
+        <div class="origin-attr">
+          <span class="o-name">Samyakh (Sam) Tukra</span>
+          <span class="o-sep">·</span>
+          <span>creator</span>
+          <span class="o-sep">·</span>
+          <a href="https://samtukra.com/" target="_blank" rel="noopener">samtukra.com ↗</a>
         </div>
       </div>
     </div>
@@ -1036,7 +1036,7 @@
         <div class="fm-row"><span>Source</span><a href="https://github.com/SamPlvs/zero-operators" target="_blank" rel="noopener">GitHub →</a></div>
       </div>
       <div class="footer-links">
-        <a href="#diagnosis">The diagnosis</a>
+        <a href="#problem">Problem</a>
         <a href="#idea">The idea</a>
         <a href="#how">How it works</a>
         <a href="#oracle">Oracle &amp; memory</a>

--- a/website/src/pages/index.html
+++ b/website/src/pages/index.html
@@ -8,7 +8,7 @@
   <link rel="preconnect" href="https://fonts.googleapis.com"/>
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin/>
   <link href="https://fonts.googleapis.com/css2?family=Geist:wght@300;400;500;600;700&family=Cormorant+Garamond:ital,wght@0,400;0,500;1,400;1,500&family=JetBrains+Mono:wght@400;500&display=swap" rel="stylesheet"/>
-  <link rel="stylesheet" href="styles.css?v=4"/>
+  <link rel="stylesheet" href="styles.css?v=5"/>
   <link rel="icon" type="image/svg+xml" href="favicon.svg"/>
 </head>
 <body>
@@ -278,17 +278,17 @@
       <div class="section-head reveal">
         <span class="section-num">03<span class="section-kind">The unlock</span></span>
         <h2 class="section-title">
-          Same six phases. <em>Now autonomous.</em>
+          Same six phases. <em>Now in days.</em>
         </h2>
         <p class="section-lede">
-          Data engineering, cleaning, scaffolding, training infra, eval scripts,
-          packaging — the work that used to consume your weeks runs autonomously.
-          You stay the researcher: <em>reading results, choosing the next experiment,
-          deciding when to pivot.</em>
+          Data engineering, cleaning, scaffolding, eval scripts, packaging —
+          done in days, <em>fully automated</em>. You act as research director:
+          defining the model, reading results, choosing the next experiment.
+          <em>ZO executes everything else.</em>
         </p>
       </div>
 
-      <div class="lanes-pretitle reveal">10 weeks · same axis as above</div>
+      <div class="lanes-pretitle reveal">5 working days · compressed from 10 weeks</div>
 
       <div class="lanes-frame">
         <div class="lanes-grid">
@@ -298,12 +298,10 @@
               <span class="lane-sub">runs the cycle</span>
             </span>
             <div class="zo-lane">
-              <div class="zo-seg" style="grid-column: span 1">data</div>
-              <div class="zo-seg" style="grid-column: span 1">clean</div>
-              <div class="zo-seg" style="grid-column: span 1">scaffold</div>
-              <div class="zo-seg is-active" style="grid-column: span 2">model exp.</div>
-              <div class="zo-seg" style="grid-column: span 2">iteration</div>
-              <div class="zo-seg" style="grid-column: span 3">package · test · deploy</div>
+              <div class="zo-seg" style="grid-column: span 1">data · clean · scaffold</div>
+              <div class="zo-seg is-active" style="grid-column: span 3">model exp. ↻ ZO iterates till benchmark</div>
+              <div class="zo-seg" style="grid-column: span 1">package · test · deploy</div>
+              <div class="zo-seg zo-seg-weekend" style="grid-column: span 2">weekend</div>
             </div>
           </div>
 
@@ -311,7 +309,7 @@
             <div class="between-spacer"></div>
             <div class="between-label">
               <em>continuous direction</em>
-              <span class="between-note">— reading results, choosing the next experiment, deciding when to pivot</span>
+              <span class="between-note">— ZO tracks every run, recommends the next step, retrains till the oracle clears</span>
             </div>
           </div>
 
@@ -328,17 +326,17 @@
                   <span class="pl-dur">~30 min</span>
                 </span>
                 <span class="pin-mark"></span>
-                <span class="pin-time">week 1</span>
+                <span class="pin-time">day 1</span>
               </div>
-              <div class="human-pin" style="--col: 3">
+              <div class="human-pin" style="--col: 2">
                 <span class="pin-label">
                   <span class="pl-name">gate 2 · features</span>
                   <span class="pl-dur">~30 min</span>
                 </span>
                 <span class="pin-mark"></span>
-                <span class="pin-time">week 3</span>
+                <span class="pin-time">day 2</span>
               </div>
-              <div class="human-pin" style="--col: 6">
+              <div class="human-pin" style="--col: 4">
                 <span class="pin-label">
                   <span class="pl-name">oracle plateau</span>
                   <span class="pl-dur">~15 min</span>
@@ -346,13 +344,13 @@
                 <span class="pin-mark is-optional"></span>
                 <span class="pin-time">if needed</span>
               </div>
-              <div class="human-pin pin-edge-r" style="--col: 9">
+              <div class="human-pin pin-edge-r" style="--col: 5">
                 <span class="pin-label">
                   <span class="pl-name">gate 4 · analysis</span>
                   <span class="pl-dur">~45 min</span>
                 </span>
                 <span class="pin-mark"></span>
-                <span class="pin-time">week 9</span>
+                <span class="pin-time">day 5</span>
               </div>
             </div>
           </div>
@@ -360,14 +358,14 @@
           <div class="lane-row">
             <span class="lane-label" style="visibility: hidden">.</span>
             <div class="lanes-ticks">
-              <span class="tl-tick">w1</span><span class="tl-tick">2</span><span class="tl-tick">3</span><span class="tl-tick">4</span><span class="tl-tick">5</span><span class="tl-tick">6</span><span class="tl-tick">7</span><span class="tl-tick">8</span><span class="tl-tick">9</span><span class="tl-tick">10</span>
+              <span class="tl-tick">d1</span><span class="tl-tick">d2</span><span class="tl-tick">d3</span><span class="tl-tick">d4</span><span class="tl-tick">d5</span><span class="tl-tick is-weekend">d6</span><span class="tl-tick is-weekend">d7</span>
             </div>
           </div>
         </div>
 
         <div class="lanes-cap">
-          <span>2 hours of human attention · across 10 weeks of work</span>
-          <span>full audit trail · oracle-gated · reproducible</span>
+          <span class="lanes-cap-headline"><em>Weeks of work, reduced to days.</em> Fully automated — you direct, ZO executes.</span>
+          <span>2 hours of human attention · 5 days of work · oracle-gated · reproducible · full audit trail</span>
         </div>
       </div>
     </div>


### PR DESCRIPTION
## Summary

The previous "ACKNOWLEDGEMENTS" mono kicker read as an academic-paper section label — bureaucratic, soft. The contributors actually *shaped the product* (tested, broke things, pushed back when it counted), so the heading should match the substance.

Promoted to a proper italic Cormorant display title — same treatment the site uses for hero/section emphasis — across all three surfaces where the names live:

| File | Before | After |
|---|---|---|
| `website/src/pages/index.html` | `<span class="ft-kicker">Acknowledgements</span>` (10px mono uppercase coral kicker with leader rule) | `<h3 class="ft-title"><em>The people behind it.</em></h3>` (italic Cormorant, ~38 px desktop / 26 px mobile, coral) |
| `docs/acknowledgements.mdx` | `title: "Acknowledgements"` | `title: "The people behind it"` (URL slug `/acknowledgements` unchanged so external links survive) |
| `README.md` | `## Acknowledgements` | `## The people behind it` |

## Statement update (all 3 surfaces)

Was:
> No tool ships alone. With thanks to the *AI specialists, researchers and engineers* who tested, guided, broke things, and made ZO sharper.

Now:
> No tool ships alone. With thanks to the *specialists, researchers and engineers* who tested, broke things, **pushed back when it counted**, and made ZO sharper.

- Drops "AI" — the audience is technical, "AI specialists" was redundant.
- Drops "guided" — vaguer than what these folks actually did.
- Adds "pushed back when it counted" — the substantive contribution that "Acknowledgements" buried.

## CSS

New `.ft-title` rule replacing `.ft-kicker`:
```css
.footer-thanks .ft-title {
  font-family: var(--italic); font-style: italic;
  font-size: clamp(28px, 3.6vw, 38px);
  font-weight: 400; color: var(--coral);
  letter-spacing: -0.005em; line-height: 1.1;
  margin: 0; text-wrap: balance;
}
```

Mobile (`<=720`) caps at 26 px.

## Branch base

Stacked on top of [#72](https://github.com/SamPlvs/zero-operators/pull/72) → [#71](https://github.com/SamPlvs/zero-operators/pull/71) → [#70](https://github.com/SamPlvs/zero-operators/pull/70). Merge order doesn't matter — GitHub auto-rebases.

Cache version bumped `styles.css?v=5` → `?v=6`.

## Test plan

- [x] `npm run build` clean (Astro 5 static, ~260 ms).
- [x] `validate-docs.sh` 10/10.
- [x] **Desktop 1280×900** — title renders as italic Cormorant coral display weight, all 7 names visible on one row.
- [x] **Mobile 375×812** — title at 26 px italic, statement readable, 7 names wrap to 3 rows naturally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)