### PR TITLE
chore(governance): CODEOWNERS + split CI for path filtering

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,18 @@
+# Zero Operators code ownership
+# Every PR touching these paths requires @SamPlvs review.
+# Order matters: later patterns override earlier ones.
+
+# Default owner for everything not otherwise specified.
+# Solo maintainer — formalises what's already true: Sam reviews every change.
+*                           @SamPlvs
+
+# Protected brand surface (explicit for clarity; catch-all also covers them)
+/website/                   @SamPlvs
+/docs/                      @SamPlvs
+/design/                    @SamPlvs
+
+# Governance and CI infrastructure — must not be modifiable by contributors
+/.github/                   @SamPlvs
+/scripts/validate-docs.sh   @SamPlvs
+/CONTRIBUTING.md            @SamPlvs
+/LICENSE                    @SamPlvs

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,8 +3,14 @@ name: CI
 on:
   push:
     branches: [main]
+    paths-ignore:
+      - 'website/**'
+      - 'design/**'
   pull_request:
     branches: [main]
+    paths-ignore:
+      - 'website/**'
+      - 'design/**'
 
 permissions:
   contents: read
@@ -42,12 +48,3 @@ jobs:
 
       - name: Run tests
         run: uv run pytest -q
-
-  validate-docs:
-    name: Validate documentation consistency
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v4
-
-      - name: Run validate-docs.sh
-        run: ./scripts/validate-docs.sh

--- a/.github/workflows/validate-docs.yml
+++ b/.github/workflows/validate-docs.yml
@@ -1,0 +1,24 @@
+name: Validate docs
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  validate-docs:
+    name: Validate documentation consistency
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Run validate-docs.sh
+        run: ./scripts/validate-docs.sh


### PR DESCRIPTION
## Summary
- Adds `.github/CODEOWNERS` so every PR touching `website/`, `docs/`, `design/`, `.github/`, `scripts/validate-docs.sh`, `CONTRIBUTING.md`, or `LICENSE` requires `@SamPlvs` review. Catch-all `* @SamPlvs` formalises that Sam reviews everything.
- Splits `.github/workflows/ci.yml` — the `test` job (pytest + ruff) now skips PRs that only touch `website/**` or `design/**`; the docs validator moves to its own `.github/workflows/validate-docs.yml` and runs **unconditionally** so Check 8 (client-name confidentiality scan) covers every changed `.md`/`.py`/`.yaml`/`.json`/`.sh` regardless of path.

## Why
Repo is public; `website/`, `docs/`, `design/` are de-facto brand surface. Today there is no `CODEOWNERS`, no branch protection on `main`, and CI runs the full pytest matrix on website-only PRs. This closes the gap without splitting the repo (rejected — would break `design/` references from OSS code per [CLAUDE.md](CLAUDE.md), and Sam doesn't need privacy, just change control).

## Follow-up after this merges
Apply branch protection via `gh api`:
- `require_code_owner_reviews: true`, `required_approving_review_count: 0`, `require_last_push_approval: false`
- `enforce_admins: false` (admin bypass kept for Sam)
- `required_linear_history: true`, `allow_force_pushes: false`, `allow_deletions: false`
- No required status checks yet (avoid the `paths-ignore` + required-check pending-forever gotcha)

## Test plan
- [ ] `gh api repos/SamPlvs/zero-operators/codeowners/errors` returns `{"errors": []}` once the file is on `main`.
- [ ] After branch protection lands, a fork PR touching `website/` shows "Review required from code owners" and merge is blocked.
- [ ] A PR touching only `src/` runs both `CI` and `Validate docs`.
- [ ] A PR touching only `website/` runs `Validate docs` but skips `CI`.
- [ ] A PR touching both runs both (path-ignore only fires when every changed file matches).

## Confidentiality
No client identifiers or project-specific paths added. `validate-docs.sh` passes locally (10/10, 1 pre-existing warning about missing local blocklist file — unrelated).

🤖 Generated with [Claude Code](https://claude.com/claude-code)