### PR TITLE
feat(website): surface Discord — header, mobile drawer, hero CTA

### DIFF
--- a/website/public/styles.css
+++ b/website/public/styles.css
@@ -1616,6 +1616,7 @@ em, .it {
   .nav-link { display: none; }
   .nav-github { display: none; }
   .nav-docs { display: none; }
+  .nav-discord { display: none; }
   .nav-burger { display: inline-flex; }
   .nav-right { gap: 10px; }
 

--- a/website/public/styles.css
+++ b/website/public/styles.css
@@ -271,8 +271,23 @@ em, .it {
 
 .ctas {
   display: flex; gap: 12px; align-items: center;
-  margin-bottom: 64px;
+  margin-bottom: 18px;
 }
+
+.hero-aside {
+  margin-bottom: 46px;
+  font-family: var(--mono);
+  font-size: 13px;
+  color: var(--dim);
+  letter-spacing: 0.04em;
+}
+.hero-aside a {
+  color: var(--coral);
+  text-decoration: none;
+  border-bottom: 1px solid currentColor;
+  transition: opacity 0.18s var(--ease);
+}
+.hero-aside a:hover { opacity: 0.7; }
 
 .hero-meta {
   display: grid;

--- a/website/src/pages/index.html
+++ b/website/src/pages/index.html
@@ -107,6 +107,9 @@
             View on GitHub
           </a>
         </div>
+        <p class="hero-aside reveal" data-delay="480">
+          Building or curious? <a href="https://discord.gg/keg73kMmEw" target="_blank" rel="noopener">Join the Discord →</a>
+        </p>
         <dl class="hero-meta reveal" data-delay="560">
           <div><dt>Agents</dt><dd>20</dd></div>
           <div><dt>Phases</dt><dd>6</dd></div>

--- a/website/src/pages/index.html
+++ b/website/src/pages/index.html
@@ -36,6 +36,9 @@
         <a class="btn btn-ghost-sm nav-github" href="https://github.com/SamPlvs/zero-operators" target="_blank" rel="noopener">
           GitHub →
         </a>
+        <a class="btn btn-ghost-sm nav-discord" href="https://discord.gg/keg73kMmEw" target="_blank" rel="noopener">
+          Discord →
+        </a>
         <button class="nav-burger" id="nav-burger" aria-label="Open menu" aria-expanded="false" aria-controls="mobile-drawer">
           <span class="burger-line"></span>
           <span class="burger-line"></span>
@@ -70,6 +73,7 @@
       <div class="md-foot">
         <a class="btn btn-ghost-sm md-docs" href="https://docs.zerooperators.com" target="_blank" rel="noopener">Docs →</a>
         <a class="btn btn-ghost-sm md-github" href="https://github.com/SamPlvs/zero-operators" target="_blank" rel="noopener">GitHub →</a>
+        <a class="btn btn-ghost-sm md-discord" href="https://discord.gg/keg73kMmEw" target="_blank" rel="noopener">Discord →</a>
         <span class="md-version">v1.0.2 · MIT</span>
       </div>
     </aside>


### PR DESCRIPTION
## Summary

Three Discord touchpoints on the marketing site, all pointing at the same never-expiring invite (`https://discord.gg/keg73kMmEw` → `#start-here`):

- **Top nav (desktop)** — `Discord →` button next to `Docs →` / `GitHub →` in [website/src/pages/index.html](website/src/pages/index.html), same ghost-button style as siblings.
- **Mobile drawer foot** — matching `Discord →` in the slide-out menu so mobile visitors don't lose the link.
- **Hero CTA (body)** — tertiary affordance below the primary `Get started` / `View on GitHub` buttons: `Building or curious? Join the Discord →` in mono / 13px / dim text with a coral link, so it's discoverable without competing with the primary action.

New CSS:
- `.nav-discord { display: none }` added to the responsive hide rule (matches existing `.nav-github` / `.nav-docs` so the button collapses behind the burger menu at small viewports).
- `.hero-aside` rule for the new tertiary line (mono 13px, dim brown text, coral link, hover opacity).
- `.ctas { margin-bottom: 18px }` (was 64px) to make room for the new aside line above the `.hero-meta` metadata strip.

The corresponding Discord server is set up separately (categories, channels, roles, pinned content, Onboarding pending Community enable).

## Test plan
- [x] Local Astro dev preview at 1400×1400: top nav shows `Docs / GitHub / Discord` in correct order, identical ghost-button styling
- [x] Hero CTA region: primary `Get started` button + secondary `View on GitHub` button + new tertiary `Building or curious? Join the Discord →` line — clear visual hierarchy, no competition for the primary action
- [x] DOM check: `.nav-discord` href, `.md-discord` (mobile drawer) href, `.hero-aside a` href all = `https://discord.gg/keg73kMmEw`
- [x] Computed styles match: aside font-family JetBrains Mono, size 13px, link color coral oklch(0.58 0.16 35)
- [x] Discord invite verified via API: `max_age=0`, `max_uses=0` (never expires, unlimited uses), points to `#start-here`
- [ ] Production deploy preview — confirm three-touchpoint layout on shipped CSS
- [ ] Mobile viewport (~375px) — burger menu opens, Discord button visible in drawer footer; hero aside reflows naturally

🤖 Generated with [Claude Code](https://claude.com/claude-code)