### PR TITLE
fix(website): match secondary byline font size to primary

### DIFF
--- a/website/public/styles.css
+++ b/website/public/styles.css
@@ -252,7 +252,6 @@ em, .it {
 .author-secondary {
   display: block;
   opacity: 0.55;
-  font-size: 0.9em;
   margin-top: 2px;
   transition: opacity 0.18s var(--ease);
 }


### PR DESCRIPTION
## Summary

Drops `font-size: 0.9em` from the `.author-secondary` CSS rule so "with Callum Adamson" renders at the same size and font family as "Samyakh (Sam) Tukra". The 0.55 opacity fade now carries the visual hierarchy alone — the prior 9px-vs-10px size differential read as off rather than subtle.

## Test plan
- [x] Local Astro dev preview at 1400×1400: both names render at 11.88px Cormorant Garamond (italic suppressed via existing `.author-link em { font-style: normal }` rule)
- [x] DOM check: `.author-secondary` no longer has `font-size: 0.9em`; computed style on the inner `<em>` matches primary byline exactly
- [x] Opacity 0.55 still applied to the secondary clause; hover lifts to 0.85
- [ ] Mintlify deploy preview confirmation
- [ ] Mobile viewport spot-check

🤖 Generated with [Claude Code](https://claude.com/claude-code)