### PR TITLE
fix(website): remove opacity fade from secondary byline

### DIFF
--- a/website/public/styles.css
+++ b/website/public/styles.css
@@ -251,11 +251,8 @@ em, .it {
 
 .author-secondary {
   display: block;
-  opacity: 0.55;
   margin-top: 2px;
-  transition: opacity 0.18s var(--ease);
 }
-.author-secondary:hover { opacity: 0.85; }
 
 .display {
   font-weight: 500;


### PR DESCRIPTION
## Summary

Drops `opacity: 0.55` (and its hover transition) from `.author-secondary` so "with Callum Adamson" now renders at the same intensity as "Samyakh (Sam) Tukra". Positional hierarchy alone (second line, "with" prefix) carries the relationship.

After this PR, both names are visually identical:
- Same font (Cormorant Garamond, 11.88px)
- Same colour (coral oklch(0.58 0.16 35))
- Same opacity (1.0)

## Test plan
- [x] Local Astro dev preview at desktop width: both names render at identical intensity and size
- [x] `getComputedStyle` snapshot — secondary opacity = 1, both font-size = 11.88px, both colour = coral oklch(0.58 0.16 35)
- [ ] Live deploy preview confirmation after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)