### PR TITLE
fix(website): bump styles.css cache-bust to force fresh fetch

### DIFF
--- a/website/src/pages/index.html
+++ b/website/src/pages/index.html
@@ -8,7 +8,7 @@
   <link rel="preconnect" href="https://fonts.googleapis.com"/>
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin/>
   <link href="https://fonts.googleapis.com/css2?family=Geist:wght@300;400;500;600;700&family=Cormorant+Garamond:ital,wght@0,400;0,500;1,400;1,500&family=JetBrains+Mono:wght@400;500&display=swap" rel="stylesheet"/>
-  <link rel="stylesheet" href="styles.css?v=6"/>
+  <link rel="stylesheet" href="styles.css?v=7"/>
   <link rel="icon" type="image/svg+xml" href="favicon.svg"/>
 </head>
 <body>


### PR DESCRIPTION
## Summary

PR #87 removed the opacity fade on the secondary byline. The CSS file on origin is correct — verified via `curl https://zerooperators.com/styles.css`:

\`\`\`
.author-secondary {
  display: block;
  margin-top: 2px;
}
\`\`\`

Problem: the HTML loads `styles.css?v=6`, the same URL it had **before** the PR #87 deploy. Browsers that visited the site before PR #87 went live cached `styles.css?v=6` and continue to serve the old CSS (with `opacity: 0.55`) until the cache expires or the URL changes.

This PR bumps the cache-bust string `v=6` → `v=7` so all clients fetch fresh CSS on next page load, picking up the opacity fix immediately.

## Test plan
- [x] Local Astro dev preview shows `<link rel="stylesheet" href="styles.css?v=7">` (verified via DOM query)
- [x] Origin CSS at `https://zerooperators.com/styles.css` already has the opacity removed (verified via cache-busted `curl`)
- [ ] After merge + deploy: hard-refresh `zerooperators.com` should now show "WITH CALLUM ADAMSON" at full intensity matching the primary byline

## Note on the underlying pattern

Whenever a `.css` file changes substantively, the `?v=` query string in `website/src/pages/index.html:11` should be bumped at the same time. Otherwise, returning visitors will keep seeing the old version. Worth a small mental note for future CSS PRs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)