### PR TITLE
copy(website): drop Callum Adamson from Contributors list (already in hero byline)

### DIFF
--- a/website/src/pages/index.html
+++ b/website/src/pages/index.html
@@ -1057,7 +1057,6 @@
         made ZO sharper.
       </p>
       <ul class="ft-names">
-        <li><a href="https://www.linkedin.com/in/callumadamson/" target="_blank" rel="noopener">Callum Adamson</a></li>
         <li><a href="https://www.linkedin.com/in/arjunagraw/" target="_blank" rel="noopener">Arjun Agrawal</a></li>
         <li><a href="https://www.linkedin.com/in/kchatfield/" target="_blank" rel="noopener">Ken Chatfield</a></li>
         <li><a href="https://www.linkedin.com/in/tianhong-dai-71b166117/" target="_blank" rel="noopener">Tianhong Dai</a></li>


### PR DESCRIPTION
## Summary

Removes the duplicate Callum Adamson entry from the footer Contributors list ([index.html:1060](website/src/pages/index.html#L1060)). He's already credited in the hero byline alongside Sam (since PR #84), so listing him again in the Contributors block reads as redundant.

Remaining list stays surname-alphabetical:
- Arjun Agrawal
- Ken Chatfield
- Tianhong Dai
- Harry Davies
- Nick Imrie
- Sergey Podatelev

## Test plan
- [x] Single line removal, no CSS or layout change
- [x] Surname-alphabetical ordering preserved (Arjun Agrawal now first)
- [ ] Deploy preview — confirm list reflows naturally with one fewer item

🤖 Generated with [Claude Code](https://claude.com/claude-code)