### PR TITLE
copy(website): replace 'with' framing with comma in hero byline

### DIFF
--- a/website/src/pages/index.html
+++ b/website/src/pages/index.html
@@ -85,7 +85,7 @@
       <div class="hero-copy">
         <div class="eyebrow reveal" data-delay="0">
           <span class="tick"></span>
-          <span>Zero Operators · v1.0.2 · by <a href="https://samtukra.com/" target="_blank" rel="noopener" class="author-link"><em>Samyakh (Sam) Tukra</em></a><span class="author-secondary">with <a href="https://www.linkedin.com/in/callumadamson/" target="_blank" rel="noopener" class="author-link"><em>Callum Adamson</em></a></span></span>
+          <span>Zero Operators · v1.0.2 · by <a href="https://samtukra.com/" target="_blank" rel="noopener" class="author-link"><em>Samyakh (Sam) Tukra</em></a>,<span class="author-secondary"><a href="https://www.linkedin.com/in/callumadamson/" target="_blank" rel="noopener" class="author-link"><em>Callum Adamson</em></a></span></span>
         </div>
         <h1 class="display reveal" data-delay="120">
           An autonomous AI <em>research team.</em><br/>


### PR DESCRIPTION
## Summary

Tweaks the hero byline from:

> Zero Operators · v1.0.2 · by **Samyakh (Sam) Tukra**
> **with Callum Adamson**

to:

> Zero Operators · v1.0.2 · by **Samyakh (Sam) Tukra,**
> **Callum Adamson**

Same two-line layout (`.author-secondary` still `display: block`); only the connecting text changes — comma now sits at the end of line 1, Callum's name reads as a co-credit on line 2 without the "with" prefix.

## Test plan
- [x] Single-line HTML change: comma added after `</a>` closing Sam's link; "with " removed from start of `.author-secondary` span
- [x] No CSS changes; existing `.author-secondary { display: block; margin-top: 2px }` continues to handle the line break
- [ ] Deploy preview confirmation

## Note

Stacks behind PR #89 (Contributors-list dedupe) — both touch the same file but different regions; should merge cleanly in either order.

🤖 Generated with [Claude Code](https://claude.com/claude-code)