### PR TITLE
chore(repo): gitignore .claude/settings.local.json

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -26,6 +26,7 @@ targets/*
 logs/
 .claude/agents/custom/*
 !.claude/agents/custom/README.md
+.claude/settings.local.json
 
 # Per-project memory (keep ZO platform memory, ignore everything else)
 memory/*


### PR DESCRIPTION
## Summary

Adds `.claude/settings.local.json` to `.gitignore`. It was untracked-but-not-ignored, so it kept surfacing in `git status` and risked accidental commit. Sometimes accumulates per-machine secrets in approved-command entries (Claude Code's auto-allowlist persists every "yes" the user clicks, occasionally including env vars embedded in approved Bash commands).

The rule sits next to the existing `.claude/agents/custom/*` exclusion.

## Test plan
- [x] `git check-ignore -v .claude/settings.local.json` now reports `.gitignore:29` as the matching rule
- [x] `git status` no longer surfaces the file
- [x] Nothing else affected — diff is one line

🤖 Generated with [Claude Code](https://claude.com/claude-code)