### PR TITLE
feat(core): extension points for workflow resolution, orchestrator class, and CLI plugins

### DIFF
--- a/src/zo/cli.py
+++ b/src/zo/cli.py
@@ -1039,7 +1039,9 @@ def build(
     # 6. Create Orchestrator
     gm = _gate_mode_from_str(effective_gate_mode)
     memory.write_gate_mode(gm.value)
-    orchestrator = Orchestrator(
+    from zo.extensions import get_orchestrator_class
+    orchestrator_cls = get_orchestrator_class() or Orchestrator
+    orchestrator = orchestrator_cls(
         plan=plan, target=target, memory=memory, comms=comms,
         semantic=semantic, zo_root=zo_root, gate_mode=gm,
         plan_path=plan_path,
@@ -3167,3 +3169,15 @@ TODO: Define constraints (compute, time, compliance).
 
 TODO: Define milestones.
 """
+
+
+# ---------------------------------------------------------------------------
+# Extension plugins (downstream builds add commands without editing core)
+# ---------------------------------------------------------------------------
+# Applied at import, after all core commands are defined, so a plugin may also
+# augment existing commands. No-op in the public build (nothing registered).
+# Discovers the "zo.commands" entry-point group; a broken plugin is logged and
+# skipped, never breaking the core CLI.
+from zo.extensions import load_cli_plugins as _load_cli_plugins  # noqa: E402
+
+_load_cli_plugins(cli)

--- a/src/zo/extensions.py
+++ b/src/zo/extensions.py
@@ -1,0 +1,108 @@
+"""Public extension points for Zero Operators.
+
+These hooks let a downstream build add capabilities WITHOUT editing ZO core
+files. The public build registers nothing here, so default behavior is
+unchanged. Two seams are exposed:
+
+1. **Orchestrator class** — register a custom :class:`~zo.orchestrator.Orchestrator`
+   subclass that the CLI instantiates instead of the default.
+2. **CLI command plugins** — contribute commands/options to the ``zo`` CLI,
+   discovered from the ``zo.commands`` entry-point group or registered in-process.
+
+A plugin is a callable ``register(cli_group)`` that may add commands/options to
+the group and/or call :func:`set_orchestrator_class`.
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from collections.abc import Callable
+
+    import click
+
+logger = logging.getLogger(__name__)
+
+CLI_ENTRYPOINT_GROUP = "zo.commands"
+
+
+# ---------------------------------------------------------------------------
+# Orchestrator class override
+# ---------------------------------------------------------------------------
+
+_orchestrator_class: type | None = None
+
+
+def set_orchestrator_class(cls: type | None) -> None:
+    """Register a custom Orchestrator subclass for the CLI to instantiate.
+
+    Passing ``None`` restores the default (the built-in Orchestrator).
+    """
+    global _orchestrator_class
+    _orchestrator_class = cls
+
+
+def get_orchestrator_class() -> type | None:
+    """Return the registered Orchestrator subclass, or ``None`` for the default."""
+    return _orchestrator_class
+
+
+# ---------------------------------------------------------------------------
+# CLI command plugins
+# ---------------------------------------------------------------------------
+
+_cli_plugins: list[Callable[[click.Group], None]] = []
+
+
+def register_cli_plugin(fn: Callable[[click.Group], None]) -> None:
+    """Register an in-process CLI plugin ``fn(cli_group)``.
+
+    Handy for tests and import-side-effect plugins. Most downstream builds will
+    instead expose a ``zo.commands`` entry point (discovered automatically).
+    """
+    _cli_plugins.append(fn)
+
+
+def load_cli_plugins(cli_group: click.Group) -> list[str]:
+    """Apply all in-process + entry-point CLI plugins to ``cli_group``.
+
+    Each plugin is a callable ``register(cli_group)``. Failures are logged and
+    skipped, so a broken plugin can never break the core CLI. Returns the names
+    of plugins that loaded successfully.
+    """
+    loaded: list[str] = []
+
+    for fn in list(_cli_plugins):
+        name = getattr(fn, "__name__", repr(fn))
+        try:
+            fn(cli_group)
+            loaded.append(name)
+        except Exception as exc:  # noqa: BLE001 - never let a plugin break the CLI
+            logger.warning("zo CLI plugin %r failed: %s", name, exc)
+
+    try:
+        from importlib.metadata import entry_points
+
+        eps = list(entry_points(group=CLI_ENTRYPOINT_GROUP))
+    except Exception as exc:  # noqa: BLE001 - discovery is best-effort
+        logger.warning("zo CLI plugin discovery failed: %s", exc)
+        eps = []
+
+    for ep in eps:
+        try:
+            register = ep.load()
+            register(cli_group)
+            loaded.append(ep.name)
+        except Exception as exc:  # noqa: BLE001 - skip a broken plugin
+            logger.warning("zo CLI plugin entry point %r failed: %s", ep.name, exc)
+
+    return loaded
+
+
+def _reset_for_tests() -> None:
+    """Reset all registered extensions. Test helper only."""
+    global _orchestrator_class
+    _orchestrator_class = None
+    _cli_plugins.clear()

--- a/src/zo/orchestrator.py
+++ b/src/zo/orchestrator.py
@@ -300,18 +300,29 @@ class Orchestrator:
 
     # -- Workflow decomposition -----------------------------------------------
 
-    def decompose_plan(self) -> WorkflowDecomposition:
-        """Decompose the plan into phases and agent contracts."""
-        self._ensure_custom_agents()
+    def _resolve_phases(self) -> tuple[WorkflowMode, list[PhaseDefinition]]:
+        """Resolve the workflow mode and its phase definitions for this plan.
 
+        Extension point: subclasses may override this to supply phases from an
+        alternative source (e.g. a custom workflow definition), falling back to
+        ``super()._resolve_phases()`` for the built-in ML modes. The default
+        returns the built-in phase factory for the plan's ``WorkflowMode``
+        (``classical_ml`` when unset) — identical to the previous inline logic.
+        """
+        from zo._orchestrator_phases import classical_ml_phases
         mode = (
             self._plan.workflow.mode
             if self._plan.workflow
             else WorkflowMode.CLASSICAL_ML
         )
-        from zo._orchestrator_phases import classical_ml_phases
         factory = MODE_PHASE_FACTORY.get(mode, classical_ml_phases)
-        phases = factory()
+        return mode, factory()
+
+    def decompose_plan(self) -> WorkflowDecomposition:
+        """Decompose the plan into phases and agent contracts."""
+        self._ensure_custom_agents()
+
+        mode, phases = self._resolve_phases()
 
         active = self._plan.agents.active_agents if self._plan.agents else []
         # Include custom agents from the plan in the active list

--- a/tests/unit/test_extensions.py
+++ b/tests/unit/test_extensions.py
@@ -1,0 +1,120 @@
+"""Tests for zo.extensions — the public extension seams.
+
+Covers the orchestrator-class override hook and the CLI plugin loader. These
+seams are no-ops in the public build (nothing registered), so default behavior
+is unchanged; the tests assert both the default no-op and the override paths.
+"""
+
+from __future__ import annotations
+
+import click
+import pytest
+
+from zo import extensions
+
+
+@pytest.fixture(autouse=True)
+def _reset(monkeypatch):
+    """Reset extension state and stub entry-point discovery to empty by default."""
+    extensions._reset_for_tests()
+    monkeypatch.setattr("importlib.metadata.entry_points", lambda *, group: [])
+    yield
+    extensions._reset_for_tests()
+
+
+def _fresh_group() -> click.Group:
+    @click.group()
+    def g() -> None:  # pragma: no cover - body never invoked
+        pass
+
+    return g
+
+
+class TestOrchestratorClassHook:
+    def test_default_is_none(self) -> None:
+        assert extensions.get_orchestrator_class() is None
+
+    def test_set_and_get(self) -> None:
+        class Custom:
+            pass
+
+        extensions.set_orchestrator_class(Custom)
+        assert extensions.get_orchestrator_class() is Custom
+
+    def test_reset_to_none(self) -> None:
+        class Custom:
+            pass
+
+        extensions.set_orchestrator_class(Custom)
+        extensions.set_orchestrator_class(None)
+        assert extensions.get_orchestrator_class() is None
+
+
+class TestCliPlugins:
+    def test_no_plugins_is_noop(self) -> None:
+        g = _fresh_group()
+        loaded = extensions.load_cli_plugins(g)
+        assert loaded == []
+        assert list(g.commands) == []
+
+    def test_in_process_plugin_adds_command(self) -> None:
+        def register(grp: click.Group) -> None:
+            @grp.command("hello")
+            def _hello() -> None:  # pragma: no cover
+                pass
+
+        extensions.register_cli_plugin(register)
+        g = _fresh_group()
+        loaded = extensions.load_cli_plugins(g)
+        assert "register" in loaded
+        assert "hello" in g.commands
+
+    def test_plugin_can_set_orchestrator_class(self) -> None:
+        class Custom:
+            pass
+
+        def register(grp: click.Group) -> None:
+            extensions.set_orchestrator_class(Custom)
+
+        extensions.register_cli_plugin(register)
+        extensions.load_cli_plugins(_fresh_group())
+        assert extensions.get_orchestrator_class() is Custom
+
+    def test_broken_plugin_is_skipped(self) -> None:
+        def bad(grp: click.Group) -> None:
+            raise RuntimeError("boom")
+
+        def good(grp: click.Group) -> None:
+            @grp.command("ok")
+            def _ok() -> None:  # pragma: no cover
+                pass
+
+        extensions.register_cli_plugin(bad)
+        extensions.register_cli_plugin(good)
+        g = _fresh_group()
+        loaded = extensions.load_cli_plugins(g)  # must not raise
+        assert "ok" in g.commands
+        assert "good" in loaded
+        assert "bad" not in loaded
+
+    def test_entry_point_discovery(self, monkeypatch) -> None:
+        class FakeEP:
+            name = "fake"
+
+            def load(self):
+                def register(grp: click.Group) -> None:
+                    @grp.command("frompoint")
+                    def _f() -> None:  # pragma: no cover
+                        pass
+
+                return register
+
+        def fake_entry_points(*, group: str):
+            assert group == extensions.CLI_ENTRYPOINT_GROUP
+            return [FakeEP()]
+
+        monkeypatch.setattr("importlib.metadata.entry_points", fake_entry_points)
+        g = _fresh_group()
+        loaded = extensions.load_cli_plugins(g)
+        assert "fake" in loaded
+        assert "frompoint" in g.commands


### PR DESCRIPTION
Three small, **behavior-preserving, generic** extension points so downstream builds can extend ZO without editing core files. The default build registers nothing, so behavior is unchanged.

## What changed
- **`Orchestrator._resolve_phases()`** — extracted the workflow-mode → phase-factory lookup out of `decompose_plan` into an overridable method (logic identical). Subclasses can return phases from an alternative source and fall back to `super()._resolve_phases()`.
- **`zo.extensions`** (new module) — the public extension surface:
  - `get/set_orchestrator_class()` — the CLI instantiates a registered `Orchestrator` subclass if set, else the default.
  - `register_cli_plugin()` + discovery of the `zo.commands` entry-point group — plugins are callables `register(cli_group)` that may add commands/options and/or set the orchestrator class. Broken plugins are logged and skipped, never breaking the core CLI.
- **`cli.py`** — `build()` resolves the orchestrator class via the hook; plugins load at import after all core commands are defined.

## Verified
- `zo --help`, the orchestrator, and `decompose_plan` are **identical** when nothing is registered.
- +8 unit tests cover the class hook, in-process + entry-point plugin loading, and graceful failure.
- Full local matrix (PR-039): `ruff check src/` clean; `pytest` **826 passed / 7 skipped** on Python 3.11 **and** 3.12; `validate-docs.sh` 10/0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
