### PR TITLE
feat: support ZO-scoped Claude settings at ~/.zo/settings.json

### DIFF
--- a/setup.sh
+++ b/setup.sh
@@ -60,19 +60,17 @@ else
     fixable "claude"
 fi
 
-# 4. Agent teams enabled
+# 4. Agent teams enabled — ZO-scoped file preferred, global settings accepted
 echo -e "${DIM}Checking agent teams...${RESET}"
 SETTINGS_FILE="$HOME/.claude/settings.json"
-if [[ -f "$SETTINGS_FILE" ]]; then
-    if grep -q "CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS" "$SETTINGS_FILE" 2>/dev/null; then
-        pass "Agent teams enabled in global settings"
-    else
-        fail "CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS not set in $SETTINGS_FILE"
-        fixable "agent-teams-env"
-    fi
+ZO_SETTINGS_FILE="${ZO_CLAUDE_SETTINGS:-$HOME/.zo/settings.json}"
+if grep -q "CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS" "$ZO_SETTINGS_FILE" 2>/dev/null; then
+    pass "Agent teams enabled in ZO settings ($ZO_SETTINGS_FILE)"
+elif grep -q "CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS" "$SETTINGS_FILE" 2>/dev/null; then
+    pass "Agent teams enabled in global settings"
 else
-    fail "Global settings not found at $SETTINGS_FILE"
-    fixable "global-settings"
+    fail "CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS not set in $ZO_SETTINGS_FILE or $SETTINGS_FILE"
+    fixable "agent-teams-env"
 fi
 
 # 5. Project settings.json
@@ -208,17 +206,34 @@ fix_item() {
             echo -e "  ${RED}✗${RESET} Claude CLI install failed — try manually: curl -fsSL https://claude.ai/install.sh | bash"
             return 1
             ;;
-        global-settings)
-            echo -e "  ${AMBER}→${RESET} Creating global settings at $SETTINGS_FILE..."
-            mkdir -p "$HOME/.claude"
-            cat > "$SETTINGS_FILE" << 'SETTINGS_EOF'
+        agent-teams-env)
+            echo -e "  ${AMBER}→${RESET} Enabling agent teams in $ZO_SETTINGS_FILE..."
+            mkdir -p "$(dirname "$ZO_SETTINGS_FILE")"
+            if [[ -f "$ZO_SETTINGS_FILE" ]]; then
+                # Merge into existing ZO settings without clobbering other keys
+                if python3 -c "
+import json
+with open('$ZO_SETTINGS_FILE') as f:
+    data = json.load(f)
+data.setdefault('env', {})['CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS'] = '1'
+with open('$ZO_SETTINGS_FILE', 'w') as f:
+    json.dump(data, f, indent=2)
+    f.write('\n')
+" 2>/dev/null; then
+                    echo -e "  ${GREEN}✓${RESET} Agent teams env merged into ZO settings"
+                    return 0
+                fi
+                echo -e "  ${RED}✗${RESET} Failed to update $ZO_SETTINGS_FILE — add manually"
+                return 1
+            fi
+            cat > "$ZO_SETTINGS_FILE" << 'SETTINGS_EOF'
 {
   "env": {
     "CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS": "1"
   }
 }
 SETTINGS_EOF
-            echo -e "  ${GREEN}✓${RESET} Global settings created with agent teams enabled"
+            echo -e "  ${GREEN}✓${RESET} ZO settings created with agent teams enabled"
             return 0
             ;;
         zo-cli)
@@ -246,25 +261,6 @@ SETTINGS_EOF
             fi
             echo -e "  ${RED}✗${RESET} zo symlink created but not working — check PATH includes ~/.local/bin"
             return 1
-            ;;
-        agent-teams-env)
-            echo -e "  ${AMBER}→${RESET} Adding agent teams env to $SETTINGS_FILE..."
-            # Use python to merge the env key into existing settings
-            if python3 -c "
-import json, sys
-with open('$SETTINGS_FILE') as f:
-    data = json.load(f)
-data.setdefault('env', {})['CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS'] = '1'
-with open('$SETTINGS_FILE', 'w') as f:
-    json.dump(data, f, indent=2)
-    f.write('\n')
-" 2>/dev/null; then
-                echo -e "  ${GREEN}✓${RESET} Agent teams env added to global settings"
-                return 0
-            else
-                echo -e "  ${RED}✗${RESET} Failed to update settings — add manually"
-                return 1
-            fi
             ;;
     esac
 }

--- a/src/zo/wrapper.py
+++ b/src/zo/wrapper.py
@@ -55,6 +55,20 @@ _RATE_LIMIT_PATTERNS: list[re.Pattern[str]] = [
     re.compile(r"too many requests", re.IGNORECASE),
 ]
 
+_ZO_USER_SETTINGS = Path.home() / ".zo" / "settings.json"
+
+
+def zo_user_settings_path() -> Path | None:
+    """Return the ZO-scoped Claude settings file, if present.
+
+    ``~/.zo/settings.json`` (override via ``ZO_CLAUDE_SETTINGS``) is passed
+    to every spawned Claude session via ``--settings``, so ZO-specific
+    config such as ``CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS`` never has to
+    live in the user's global ``~/.claude/settings.json``.
+    """
+    path = Path(os.environ.get("ZO_CLAUDE_SETTINGS") or _ZO_USER_SETTINGS)
+    return path if path.is_file() else None
+
 
 class LifecycleWrapper:
     """Manages the lifecycle of a Claude Code lead orchestrator session.
@@ -229,11 +243,16 @@ class LifecycleWrapper:
         env_prefix = ""
         for k, v in (extra_env or {}).items():
             env_prefix += f'{k}={shlex.quote(v)} '
+        settings_flag = ""
+        zo_settings = zo_user_settings_path()
+        if zo_settings:
+            settings_flag = f' --settings {shlex.quote(str(zo_settings))}'
         interactive_cmd = (
             f'{env_prefix}'
             f'{shlex.quote(claude_abs)}'
             f' --model {shlex.quote(model)}'
             f' --max-turns {max_turns}'
+            f'{settings_flag}'
             f'{add_dir_flags}'
         )
         subprocess.run(
@@ -439,6 +458,9 @@ class LifecycleWrapper:
             "--max-turns", str(max_turns),
             "--add-dir", cwd,
         ]
+        zo_settings = zo_user_settings_path()
+        if zo_settings:
+            cmd.extend(["--settings", str(zo_settings)])
         if bypass_permissions:
             from zo.permissions_overlay import ensure_bypass_disclaimer_accepted
             # --dangerously-skip-permissions / bypass mode refuses to start


### PR DESCRIPTION
## What

Removes the install-time requirement to edit the user's global `~/.claude/settings.json` to enable agent teams. ZO-specific Claude settings now live in a dedicated `~/.zo/settings.json`.

## How

- **`src/zo/wrapper.py`**: new `zo_user_settings_path()` helper resolves `~/.zo/settings.json` (path overridable via the `ZO_CLAUDE_SETTINGS` env var, returns `None` when the file is absent). Both launch paths — the tmux interactive command and the headless `--print` subprocess — pass it to the Claude CLI via `--settings <file>`, which loads it as additional settings on top of user/project settings.
- **`setup.sh`**: check 4 now passes if `CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS` is set in either `~/.zo/settings.json` or the global settings file. The auto-fixer creates (or merges into) the ZO-scoped file instead of modifying `~/.claude/settings.json`; the global-settings fixer arms are removed.

## Why

- Enabling an experimental flag globally affects every Claude Code session on the machine, not just ZO runs. Scoping it to the sessions ZO spawns is safer and self-contained.
- `--settings` also travels with the session regardless of cwd, so it covers sessions launched in delivery repos where the ZO project-level `.claude/settings.json` doesn't apply.
- Gives ZO a natural home for future session-scoped config (permissions, model pins) without touching user-global state.

## Testing

- Full suite: 854 passed, 7 skipped
- `ruff check src/zo/wrapper.py` clean
- `bash -n setup.sh` clean
- Manual: helper resolves the file when present, returns `None` for missing/override paths

🤖 Generated with [Claude Code](https://claude.com/claude-code)